### PR TITLE
fix: :adhesive_bandage: changeDate4Description

### DIFF
--- a/src/modules/clients/components/payments-tab/modal-identified-payments/modal-identified-payments.tsx
+++ b/src/modules/clients/components/payments-tab/modal-identified-payments/modal-identified-payments.tsx
@@ -97,9 +97,7 @@ const ModalIdentifiedPayment: FC<ModalIdentifiedPaymentProps> = ({
               <div className={styles.paymentContent__content}>
                 <div className={styles.paymentContent__content__left}>
                   <h3 className={styles.paymentContent__content__name}>Pago {payment.id}</h3>
-                  <p className={styles.paymentContent__content__date}>
-                    {formatDateDMY(payment.payment_date)}
-                  </p>
+                  <p className={styles.paymentContent__content__date}>{payment.description}</p>
                   <p className={styles.paymentContent__content__client}>{payment.CLIENT_NAME}</p>
                 </div>
                 <h2 className={styles.paymentContent__content__amount}>

--- a/src/modules/clients/containers/payments-tab/payments-tab.tsx
+++ b/src/modules/clients/containers/payments-tab/payments-tab.tsx
@@ -18,12 +18,10 @@ import Collapse from "@/components/ui/collapse";
 import UiFilterDropdown from "@/components/ui/ui-filter-dropdown";
 import PaymentsTable from "@/modules/clients/components/payments-table";
 import { ModalActionPayment } from "@/components/molecules/modals/ModalActionPayment/ModalActionPayment";
+import ModalIdentifyPayment from "../../components/payments-tab/modal-identify-payment-action";
 
 import { IClientPayment } from "@/types/clientPayments/IClientPayments";
 import { ISingleBank } from "@/types/banks/IBanks";
-
-import "./payments-tab.scss";
-import ModalIdentifyPayment from "../../components/payments-tab/modal-identify-payment-action";
 
 import "./payments-tab.scss";
 


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/5aad2eb8-0e48-481f-bce6-409a78fbafbd)
This pull request includes changes to the `payments-tab` module to update the display of payment details and correct import statements. The most important changes are:

### Updates to payment details display:

* [`src/modules/clients/components/payments-tab/modal-identified-payments/modal-identified-payments.tsx`](diffhunk://#diff-66ffdb9f9cbfef83b187d5625d59c37496438053efce6c0e250caa358fb70cb5L100-R100): Changed the displayed payment date to show the payment description instead.

### Corrections to import statements:

* [`src/modules/clients/containers/payments-tab/payments-tab.tsx`](diffhunk://#diff-77369ac334ccf46d321b87ceca3968eeaca7af342136929ca88fdc12ab9b61a8R21-L27): Corrected the import order and removed duplicate import statements.