### PR TITLE
Fixes/search adjustmentss apply tab and accounting adjustments rendering erp

### DIFF
--- a/src/modules/clients/components/accounting-adjustments-table/accounting-adjustments-table.tsx
+++ b/src/modules/clients/components/accounting-adjustments-table/accounting-adjustments-table.tsx
@@ -101,11 +101,11 @@ const AccountingAdjustmentsTable = ({
   const columns: TableProps<FinancialDiscount>["columns"] = [
     {
       title: "ID ERP",
-      dataIndex: "id",
-      key: "id",
-      render: (_, record) => (
+      dataIndex: "erp_id",
+      key: "erp_id",
+      render: (erp_id, record) => (
         <p onClick={() => handleOpenDetail(record)} className="adjustmentsTable__id">
-          {record.id}
+          {erp_id}
         </p>
       ),
       sorter: (a, b) => a.id - b.id,

--- a/src/modules/clients/containers/apply-tab/Modals/ModalListAdjustments/ModalListAdjustments.tsx
+++ b/src/modules/clients/containers/apply-tab/Modals/ModalListAdjustments/ModalListAdjustments.tsx
@@ -123,7 +123,15 @@ const ModalListAdjustments: React.FC<ModalListAdjustmentsProps> = ({
 
   const filteredData = useMemo(() => {
     if (!adjustments) return [];
-    return adjustments.filter((row) => row.id.toString().includes(searchQuery));
+    return adjustments.filter((row) => {
+      const query = searchQuery.toLowerCase();
+
+      const matchesErpId = row.erp_id?.toString().toLowerCase().includes(query);
+
+      const matchesComment = row.comments?.toLowerCase().includes(query);
+
+      return matchesErpId || matchesComment;
+    });
   }, [adjustments, searchQuery]);
 
   const paginatedRows = useMemo(() => {


### PR DESCRIPTION
This pull request includes changes to improve the handling of ERP IDs and search functionality in the accounting adjustments components. The most important changes include updating the column data index and key to use `erp_id` and enhancing the search functionality to include both ERP IDs and comments.

Improvements to ERP ID handling:

* [`src/modules/clients/components/accounting-adjustments-table/accounting-adjustments-table.tsx`](diffhunk://#diff-b29f2b017a4dbf470b5e823a53b4908e8e89164faef062e2c27d761d33e77826L104-R108): Updated the `dataIndex` and `key` for the ID column to use `erp_id` and modified the rendering logic to use `erp_id` instead of `record.id`.

Enhancements to search functionality:

* [`src/modules/clients/containers/apply-tab/Modals/ModalListAdjustments/ModalListAdjustments.tsx`](diffhunk://#diff-e98b7d0469816dd27289bcde870eb0e31caed8416fbaf58a5187467370ecf4e2L126-R134): Enhanced the search functionality to filter adjustments based on both ERP IDs and comments, making the search case-insensitive.