### PR TITLE
feat: add mandatory status column to document table

### DIFF
--- a/src/components/organisms/proveedores/Form/columns.tsx
+++ b/src/components/organisms/proveedores/Form/columns.tsx
@@ -44,6 +44,13 @@ export const columns = ({
     width: "15%"
   },
   {
+    title: "Obligatorio",
+    dataIndex: "isMandatory",
+    key: "isMandatory",
+    render: (isMandatory: boolean) => <p>{isMandatory ? "Sí" : "No"}</p>,
+    width: "10%"
+  },
+  {
     title: "Estado",
     dataIndex: "statusId",
     key: "statusId",


### PR DESCRIPTION
This pull request adds a new column to the `columns` configuration in the `Form` component for displaying whether a field is mandatory. 

* [`src/components/organisms/proveedores/Form/columns.tsx`](diffhunk://#diff-28da2c2a9a669c20d1753138c6c6eb6fd1c67034807f6b0f3e8ad4fd5c9c7997R46-R52): Added a new column with the title "Obligatorio" to display the `isMandatory` property. It renders "Sí" if the value is `true` and "No" if `false`.