### PR TITLE
fix: handle null case for event approval status in EventSection

### DIFF
--- a/src/components/organisms/proveedores/components/DrawerComponent/sections/EventSection.tsx
+++ b/src/components/organisms/proveedores/components/DrawerComponent/sections/EventSection.tsx
@@ -110,11 +110,13 @@ export const EventSection: React.FC<EventSectionProps> = ({
                   </Flex>
                   <p className="commentText">{event.comment}</p>
                 </div>
-                {event.is_approved ? (
-                  <CheckCircle size={24} color="#016630" />
-                ) : (
-                  <XCircle size={24} color="#EC003F" />
-                )}
+                {event.is_approved !== null ? (
+                  event.is_approved ? (
+                    <CheckCircle size={24} color="#016630" />
+                  ) : (
+                    <XCircle size={24} color="#EC003F" />
+                  )
+                ) : null}
               </Flex>
             }
             icon={


### PR DESCRIPTION
This pull request refines the conditional rendering logic in the `EventSection` component to handle cases where the `is_approved` property is `null`. This ensures the component displays the appropriate icon or nothing based on the value of `is_approved`.

**Key change:**

* Updated the conditional check for `event.is_approved` in `EventSection` to explicitly handle `null` values, ensuring no icon is rendered when `is_approved` is `null`. (`[src/components/organisms/proveedores/components/DrawerComponent/sections/EventSection.tsxL113-R119](diffhunk://#diff-010d5a048288ea8d9690d754dbac4b4e48463ceb3e9cdb9cb8ddea27c47a00f2L113-R119)`)