### PR TITLE
Fix/86dwrrhm7 navigation providers module

### DIFF
--- a/src/components/organisms/proveedores/Form/index.tsx
+++ b/src/components/organisms/proveedores/Form/index.tsx
@@ -20,15 +20,7 @@ import ModalAuditRequirements from "../components/ModalAuditRequirements/ModalAu
 import { InputSelect } from "@/components/atoms/inputs/InputSelect/InputSelect";
 import { ModalAddRequirement } from "../../projects/RequirementsView/components/ModalAddRequirement/ModalAddRequirement";
 
-import {
-  Document,
-  FormField,
-  Props,
-  ApiResponse,
-  IOption,
-  OPTIONS_TYPE_CLIENTS,
-  UserType
-} from "./types";
+import { Document, FormField, Props, ApiResponse, IOption, UserType } from "./types";
 
 import "./form.scss";
 
@@ -185,9 +177,7 @@ const SupplierForm: React.FC<Props> = ({ userType, clientTypeId }) => {
         return (
           <Flex justify="space-between" align="center">
             <Button type="text" onClick={handleGoBack} icon={<CaretLeft size={"1.3rem"} />}>
-              <Text
-                strong
-              >{`Crear ${OPTIONS_TYPE_CLIENTS.find((option) => option.value === clientTypeId)?.label}`}</Text>
+              <Text strong>{`Ver Proveedores`}</Text>
             </Button>
             <GenerateActionButton onClick={() => handleOpenModal(1)} />
           </Flex>

--- a/src/components/organisms/proveedores/ThirdPartiesView/index.tsx
+++ b/src/components/organisms/proveedores/ThirdPartiesView/index.tsx
@@ -1,25 +1,26 @@
 "use client";
 import React, { useState, useCallback } from "react";
+import { useRouter } from "next/navigation";
+import useSWR from "swr";
 import { Tabs, Table, Space, Flex } from "antd";
 import type { ColumnsType } from "antd/es/table";
-import { IThirdPartiesData } from "../interfaces/ThirdPartiesData";
+import { Circle, DotsThreeVertical, Eye } from "@phosphor-icons/react";
+
+import { useAppStore } from "@/lib/store/store";
+import { TabsEnum } from "@/lib/slices/providersViewSlice";
+import { fetcher } from "@/utils/api/api";
+
 import Container from "@/components/atoms/Container/Container";
 import UiSearchInput from "@/components/ui/search-input";
 import { FilterClients } from "@/components/atoms/Filters/FilterClients/FilterClients";
 import { Tag } from "@/components/atoms/Tag/Tag";
-import { Circle, DotsThreeVertical, Eye } from "@phosphor-icons/react";
 import { GenerateActionButton } from "@/components/atoms/GenerateActionButton";
 import IconButton from "@/components/atoms/IconButton/IconButton";
 import { ModalGenerateAction } from "../components/ModalGenerateAction";
-import { useRouter } from "next/navigation";
-import useSWR from "swr";
-import { fetcher } from "@/utils/api/api";
+
+import { IThirdPartiesData } from "../interfaces/ThirdPartiesData";
 import { GenericResponsePage } from "@/types/global/IGlobal";
 
-enum TabsEnum {
-  Clients = "clients",
-  Providers = "providers"
-}
 const formatDate = (isoString: string): string => {
   const date = new Date(isoString);
   const day = String(date.getDate()).padStart(2, "0");
@@ -29,7 +30,8 @@ const formatDate = (isoString: string): string => {
 };
 
 const ThirdPartiesView: React.FC = () => {
-  const [activeTab, setActiveTab] = useState<TabsEnum>(TabsEnum.Clients);
+  // const { activeTab, setActiveTab } = useProviderViewContext();
+  const { activeTab, setActiveTab } = useAppStore();
   const [debouncedSearch, setDebouncedSearch] = useState<string>("");
   const [isModalOpen, setModalOpen] = useState(false);
   const [currentPage, setCurrentPage] = useState(1);
@@ -142,7 +144,7 @@ const ThirdPartiesView: React.FC = () => {
   return (
     <Container style={{ gap: "1.5rem", overflowY: "auto" }}>
       <Tabs
-        defaultActiveKey="clients"
+        defaultActiveKey={activeTab}
         onChange={(key: string) => handleTabChange(key as TabsEnum)}
         size="large"
         style={{

--- a/src/lib/slices/providersViewSlice.ts
+++ b/src/lib/slices/providersViewSlice.ts
@@ -1,0 +1,18 @@
+/* eslint-disable no-unused-vars */
+
+export enum TabsEnum {
+  Clients = "clients",
+  Providers = "providers"
+}
+
+export interface IProvidersViewStore {
+  activeTab: TabsEnum;
+  setActiveTab: (tab: TabsEnum) => void;
+}
+
+export const providersViewSlice = (set: any): IProvidersViewStore => {
+  return {
+    activeTab: TabsEnum.Clients,
+    setActiveTab: (tab: TabsEnum) => set((state: any) => ({ ...state, activeTab: tab }))
+  };
+};

--- a/src/lib/store/store.ts
+++ b/src/lib/store/store.ts
@@ -6,8 +6,15 @@ import { createJSONStorage, persist } from "zustand/middleware";
 import { formatMoneySlice, IFormatMoneyStore } from "@/lib/slices/formatMoneySlice";
 import { createHidrationSlice, Hidration } from "../slices/hidratationSlice";
 import { setProjectInApi } from "@/utils/api/api";
+import { IProvidersViewStore, providersViewSlice } from "../slices/providersViewSlice";
 
-interface AppStore extends ProjectSlice, IUserSlice, ICommerceSlice, IFormatMoneyStore, Hidration {
+interface AppStore
+  extends ProjectSlice,
+    IUserSlice,
+    ICommerceSlice,
+    IFormatMoneyStore,
+    Hidration,
+    IProvidersViewStore {
   resetStore: () => void;
 }
 
@@ -19,6 +26,7 @@ export const useAppStore = create<AppStore>()(
       ...createCommerceSlice(set),
       ...formatMoneySlice(set, get),
       ...createHidrationSlice(set),
+      ...providersViewSlice(set),
       resetStore: () => {
         // Clear the session storage
         localStorage.removeItem("project");
@@ -28,7 +36,8 @@ export const useAppStore = create<AppStore>()(
           ...createProjectSlice(set),
           ...createCommerceSlice(set),
           ...formatMoneySlice(set, get),
-          ...createHidrationSlice(set)
+          ...createHidrationSlice(set),
+          ...providersViewSlice(set)
         });
       }
     }),


### PR DESCRIPTION
This pull request introduces several changes to improve the handling of tabs in the "Third Parties View" component and simplify the codebase. The most significant updates include replacing a local `TabsEnum` definition with a centralized slice, integrating a global state management approach for tab handling, and updating UI text for clarity.

### Tab Management Improvements:
* Added a new `providersViewSlice` to manage the active tab state globally, including the `TabsEnum` definition and methods for setting the active tab (`src/lib/slices/providersViewSlice.ts`).
* Integrated `providersViewSlice` into the global store by extending the `AppStore` interface and applying the slice in the store creation (`src/lib/store/store.ts`). [[1]](diffhunk://#diff-1a2bf18d47c70262cea0ce2c236115b2e1f2cd5e49e27e713fb5595db47eb40dR9-R17) [[2]](diffhunk://#diff-1a2bf18d47c70262cea0ce2c236115b2e1f2cd5e49e27e713fb5595db47eb40dR29) [[3]](diffhunk://#diff-1a2bf18d47c70262cea0ce2c236115b2e1f2cd5e49e27e713fb5595db47eb40dL31-R40)
* Replaced the local `TabsEnum` and `useState` for `activeTab` in `ThirdPartiesView` with the global state from `useAppStore`, ensuring consistent tab state management across components (`src/components/organisms/proveedores/ThirdPartiesView/index.tsx`). [[1]](diffhunk://#diff-8fe0bb8448a623053d2ae25cbcb778807207374cdb2992dd607f0ee5dcd519e7L32-R34) [[2]](diffhunk://#diff-8fe0bb8448a623053d2ae25cbcb778807207374cdb2992dd607f0ee5dcd519e7L145-R147)

### UI Text Update:
* Updated the button text in the `SupplierForm` component from "Crear [ClientType]" to "Ver Proveedores" for improved clarity and alignment with the context (`src/components/organisms/proveedores/Form/index.tsx`).

### Code Simplification:
* Removed the unused `OPTIONS_TYPE_CLIENTS` import from the `SupplierForm` component, reducing unnecessary dependencies (`src/components/organisms/proveedores/Form/index.tsx`).