### PR TITLE
fix: update log download functionality to use fetch API and handle er…

### DIFF
--- a/src/modules/clients/containers/apply-tab/apply-tab.tsx
+++ b/src/modules/clients/containers/apply-tab/apply-tab.tsx
@@ -8,7 +8,7 @@ import LabelCollapse from "@/components/ui/label-collapse";
 import { useParams } from "next/navigation";
 
 import { useAppStore } from "@/lib/store/store";
-import { extractSingleParam, fetchFileFromUrl } from "@/utils/utils";
+import { extractSingleParam } from "@/utils/utils";
 import {
   addItemsToTable,
   removeItemsFromTable,
@@ -294,7 +294,23 @@ const ApplyTab: React.FC = () => {
   const handleDownloadLog = async () => {
     try {
       if (applicationData?.summary?.url_log) {
-        await fetchFileFromUrl(applicationData?.summary?.url_log);
+        const response = await fetch(applicationData.summary.url_log);
+
+        if (!response.ok) {
+          throw new Error(`HTTP error! Status: ${response.status}`);
+        }
+
+        const blob = await response.blob();
+        const fileName = applicationData.summary.url_log.split("/").pop() || "log.txt";
+
+        // Crear un enlace invisible y disparar el click
+        const link = document.createElement("a");
+        link.href = window.URL.createObjectURL(blob);
+        link.download = fileName;
+        document.body.appendChild(link);
+        link.click();
+        document.body.removeChild(link);
+
         showMessage("success", "Log descargado correctamente");
         setIsModalOpen({ selected: 0 });
       } else {


### PR DESCRIPTION
This pull request updates the `ApplyTab` component in `src/modules/clients/containers/apply-tab/apply-tab.tsx` by removing the dependency on the `fetchFileFromUrl` utility function and replacing it with inline logic for downloading files. Additionally, the import statement for `fetchFileFromUrl` was removed.

### Refactoring for file download logic:
* [`src/modules/clients/containers/apply-tab/apply-tab.tsx`](diffhunk://#diff-783ab654e6b1029e83918ef67351ca29faaefef8709bda898a5ab3aee63eef72L297-R313): Replaced the `fetchFileFromUrl` utility function with inline logic using the `fetch` API to download a file. The new implementation includes error handling, blob creation, and dynamically generating a download link for the log file.

### Cleanup of unused imports:
* [`src/modules/clients/containers/apply-tab/apply-tab.tsx`](diffhunk://#diff-783ab654e6b1029e83918ef67351ca29faaefef8709bda898a5ab3aee63eef72L11-R11): Removed the import of `fetchFileFromUrl` from `@/utils/utils`, as it is no longer used in the file.…rors