### PR TITLE
feat: update selected rows type and add autoSelectOnBalanceLegalization

### DIFF
--- a/src/modules/clients/components/accounting-adjustments-table/accounting-adjustments-table.tsx
+++ b/src/modules/clients/components/accounting-adjustments-table/accounting-adjustments-table.tsx
@@ -6,6 +6,7 @@ import { useAppStore } from "@/lib/store/store";
 import { formatDate } from "@/utils/utils";
 
 import { FinancialDiscount } from "@/types/financialDiscounts/IFinancialDiscounts";
+import { ISelectedAccountingRows } from "../../containers/accounting-adjustments-tab/accounting-adjustments-tab";
 
 import "./accounting-adjustments-table.scss";
 
@@ -13,12 +14,12 @@ const { Text } = Typography;
 
 interface PropsInvoicesTable {
   dataAdjustmentsByStatus: FinancialDiscount[];
-  setSelectedRows: Dispatch<SetStateAction<FinancialDiscount[] | undefined>>;
+  setSelectedRows: Dispatch<SetStateAction<ISelectedAccountingRows[] | undefined>>;
   // eslint-disable-next-line no-unused-vars
   openAdjustmentDetail: (adjustment: FinancialDiscount) => void;
   financialStatusId: number;
   legalized?: boolean;
-  selectedRows?: FinancialDiscount[];
+  selectedRows?: ISelectedAccountingRows[];
 }
 
 const AccountingAdjustmentsTable = ({
@@ -32,6 +33,7 @@ const AccountingAdjustmentsTable = ({
   const formatMoney = useAppStore((state) => state.formatMoney);
 
   const [selectedRowKeys, setSelectedRowKeys] = useState<React.Key[]>([]);
+
   useEffect(() => {
     if (selectedRows) {
       const updatedKeys = selectedRowKeys.filter((key) =>
@@ -49,6 +51,11 @@ const AccountingAdjustmentsTable = ({
   };
 
   const onSelectChange = (newSelectedRowKeys: React.Key[], newSelectedRows: any) => {
+    if (newSelectedRowKeys.length === 0) {
+      setSelectedRowKeys([]);
+      setSelectedRows(undefined);
+    }
+
     setSelectedRowKeys(newSelectedRowKeys);
     if (newSelectedRowKeys.length >= 1) {
       // set the selected Rows but adding to the previous selected rows
@@ -61,10 +68,10 @@ const AccountingAdjustmentsTable = ({
           );
 
           //filters the unselected rows but only the ones that have the status_id equal to financialStatusId
+          // If we want to recover this we need in eachRow the label id
           const unCheckedRows = prevSelectedRows?.filter(
-            (prevSelectedRow) =>
-              !newSelectedRowKeys.includes(prevSelectedRow.id) &&
-              prevSelectedRow.financial_status_id === financialStatusId
+            (prevSelectedRow) => !newSelectedRowKeys.includes(prevSelectedRow.id)
+            // prevSelectedRow.label_status_id === financialStatusId
           );
 
           if (unCheckedRows.length > 0) {
@@ -176,6 +183,7 @@ const AccountingAdjustmentsTable = ({
   return (
     <>
       <Table
+        key={data?.length}
         className="adjustmentsTable customSticky"
         columns={columns}
         dataSource={data?.map((data) => ({ ...data, key: data.id }))}

--- a/src/modules/clients/containers/accounting-adjustments-tab/accounting-adjustments-tab.tsx
+++ b/src/modules/clients/containers/accounting-adjustments-tab/accounting-adjustments-tab.tsx
@@ -28,8 +28,12 @@ import {
 
 import "./accounting-adjustments-tab.scss";
 
+export interface ISelectedAccountingRows extends FinancialDiscount {
+  label_status_id: number;
+}
+
 const AccountingAdjustmentsTab = () => {
-  const [selectedRows, setSelectedRows] = useState<FinancialDiscount[] | undefined>();
+  const [selectedRows, setSelectedRows] = useState<ISelectedAccountingRows[] | undefined>();
   const [search, setSearch] = useState("");
   const [isModalOpen, setIsModalOpen] = useState({
     selected: 0
@@ -187,7 +191,10 @@ const AccountingAdjustmentsTab = () => {
                     openAdjustmentDetail={handleOpenAdjustmentDetail}
                     financialStatusId={financialState.status_id}
                     legalized={financialState.legalized}
-                    selectedRows={selectedRows}
+                    selectedRows={selectedRows?.map((item) => ({
+                      ...item,
+                      label_status_id: financialState.status_id
+                    }))}
                   />
                 </>
               )


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/e187461b-f8cf-4431-a1c3-929b713863c3)
This pull request introduces updates to the `AccountingAdjustmentsTable` and related components to enhance functionality and improve type safety. The key changes include modifying the structure of selected rows to include a new `label_status_id` property, refining row selection behavior, and improving the logic for matching adjustments in the `ModalBalanceLegalization` component.

### Updates to `AccountingAdjustmentsTable`:

* Updated the `PropsInvoicesTable` interface to replace `FinancialDiscount[]` with a new `ISelectedAccountingRows[]` type, which includes the `label_status_id` property. [[1]](diffhunk://#diff-b29f2b017a4dbf470b5e823a53b4908e8e89164faef062e2c27d761d33e77826R9-R22) [[2]](diffhunk://#diff-630ea3023eeabaf97263a144a91461c4235cbd3e49829c4b0b2166ce0177e384R31-R36)
* Enhanced the row selection logic by resetting selected rows and keys when no rows are selected.
* Adjusted the filtering logic for unselected rows, with a placeholder for recovering functionality related to `label_status_id`.
* Added a dynamic `key` property to the `Table` component to force re-rendering when data changes.

### Improvements to `ModalBalanceLegalization`:

* Implemented a matching algorithm to associate adjustments with the closest financial record, ensuring no record is reused by leveraging a `Set` to track used IDs.

### Changes to `AccountingAdjustmentsTab`:

* Updated the `selectedRows` state to use the new `ISelectedAccountingRows` type and added logic to map `label_status_id` when passing rows to the `AccountingAdjustmentsTable`. [[1]](diffhunk://#diff-630ea3023eeabaf97263a144a91461c4235cbd3e49829c4b0b2166ce0177e384R31-R36) [[2]](diffhunk://#diff-630ea3023eeabaf97263a144a91461c4235cbd3e49829c4b0b2166ce0177e384L190-R197)