### PR TITLE
Fixes/86dx0up5p

### DIFF
--- a/src/components/atoms/inputs/InputSelect/InputSelect.tsx
+++ b/src/components/atoms/inputs/InputSelect/InputSelect.tsx
@@ -23,6 +23,10 @@ interface InputSelectProps {
   loading?: boolean;
   isError?: boolean;
   mode?: "multiple" | "tags";
+  popupMatchSelectWidth?: boolean;
+  showSearch?: boolean;
+  // eslint-disable-next-line no-unused-vars
+  filterOption?: (input: string, option?: Option | any) => boolean;
 }
 
 export const InputSelect = ({
@@ -38,7 +42,10 @@ export const InputSelect = ({
   className,
   loading = false,
   isError = false,
-  mode
+  mode,
+  popupMatchSelectWidth = true,
+  showSearch = false,
+  filterOption
 }: InputSelectProps) => {
   return (
     <Flex vertical className={`selectContainer ${className}`}>
@@ -65,6 +72,9 @@ export const InputSelect = ({
               onChange={(value) => field.onChange(value)}
               value={field.value}
               mode={mode}
+              popupMatchSelectWidth={popupMatchSelectWidth}
+              showSearch={showSearch}
+              filterOption={filterOption}
             >
               {options.map((option) => (
                 <Select.Option key={option.value} value={option.value}>

--- a/src/components/molecules/modals/MoldalNoveltyDetail/MoldalNoveltyDetail.tsx
+++ b/src/components/molecules/modals/MoldalNoveltyDetail/MoldalNoveltyDetail.tsx
@@ -19,9 +19,14 @@ interface MoldalNoveltyDetailProps {
   isOpen: boolean;
   onClose: () => void;
   noveltyId: number;
+  deselectInvoices?: () => void;
 }
 
-const MoldalNoveltyDetail: FC<MoldalNoveltyDetailProps> = ({ onClose, noveltyId }) => {
+const MoldalNoveltyDetail: FC<MoldalNoveltyDetailProps> = ({
+  onClose,
+  noveltyId,
+  deselectInvoices
+}) => {
   const { data, isLoading, mutate: mutateIncident } = useIncidentDetail({ incidentId: noveltyId }); // TODO CAMBIAR ESTO
   const { mutate: mutateWallet } = useInvoices({});
   const [incidentData, setIncidentData] = useState<IIncidentDetail | null>(null);
@@ -58,6 +63,7 @@ const MoldalNoveltyDetail: FC<MoldalNoveltyDetailProps> = ({ onClose, noveltyId 
       }
       setOpenResolveModal(false);
       mutateWallet();
+      deselectInvoices && deselectInvoices();
       mutateIncident();
       onClose(); // Cierra el modal principal después de resolver/rechazar
     } catch (error) {

--- a/src/components/molecules/modals/RegisterNews/RegisterNews.tsx
+++ b/src/components/molecules/modals/RegisterNews/RegisterNews.tsx
@@ -178,6 +178,7 @@ const RegisterNews = ({
             loading={isLoading}
             isError={isError}
             placeholder="Seleccionar motivo"
+            popupMatchSelectWidth={false}
           />
           <InputFormMoney
             titleInput="Monto novedad"

--- a/src/components/molecules/modals/RegisterNews/registerNews.scss
+++ b/src/components/molecules/modals/RegisterNews/registerNews.scss
@@ -37,7 +37,7 @@
 
     &__select {
         display: grid;
-        grid-template-columns: 1fr 1fr;
+        grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
         padding: 1rem 0;
     }
 

--- a/src/components/molecules/modals/RegisterNews/registerNews.scss
+++ b/src/components/molecules/modals/RegisterNews/registerNews.scss
@@ -143,3 +143,12 @@
         }
     }
 }
+
+.ant-select-item-option {
+    .ant-select-item-option-content {
+        max-width: 24vw !important;
+        white-space: normal !important;
+        word-break: break-word;
+        max-width: 400px;
+    }
+}

--- a/src/components/organisms/Customers/WalletTab/WalletTab.tsx
+++ b/src/components/organisms/Customers/WalletTab/WalletTab.tsx
@@ -117,7 +117,10 @@ export const WalletTab = () => {
       clientId: clientId,
       projectId: projectId,
       selectInvoice: invoice,
-      handleActionInDetail: handleActionInDetail
+      handleActionInDetail: handleActionInDetail,
+      deselectInvoices: () => {
+        setSelectedRows([]);
+      }
     });
   };
 

--- a/src/context/ModalContext.tsx
+++ b/src/context/ModalContext.tsx
@@ -31,10 +31,12 @@ interface InvoiceModalProps {
   handleActionInDetail?: (invoice: IInvoice) => void;
   selectInvoice?: IInvoice;
   projectId?: number;
+  deselectInvoices?: () => void;
 }
 
 interface NoveltyModalProps {
   noveltyId: number;
+  deselectInvoices?: () => void;
 }
 
 interface AdjustmentModalProps {

--- a/src/modules/clients/containers/apply-tab/Modals/ModalApplyAI/modalApplyAI.scss
+++ b/src/modules/clients/containers/apply-tab/Modals/ModalApplyAI/modalApplyAI.scss
@@ -99,6 +99,7 @@
     &__commentary {
         display: flex;
         flex-direction: column;
+        gap: 0.5rem;
 
         p {
             color: $gray;

--- a/src/modules/clients/containers/invoice-detail-modal/invoice-detail-modal.tsx
+++ b/src/modules/clients/containers/invoice-detail-modal/invoice-detail-modal.tsx
@@ -34,6 +34,7 @@ interface InvoiceDetailModalProps {
   handleActionInDetail?: (invoice: IInvoice) => void;
   selectInvoice?: IInvoice;
   projectId?: number;
+  deselectInvoices?: () => void;
 }
 
 const InvoiceDetailModal: FC<InvoiceDetailModalProps> = ({
@@ -45,7 +46,8 @@ const InvoiceDetailModal: FC<InvoiceDetailModalProps> = ({
   hiddenActions,
   projectId = 0,
   selectInvoice,
-  handleActionInDetail
+  handleActionInDetail,
+  deselectInvoices
 }) => {
   const formatMoney = useAppStore((state) => state.formatMoney);
 
@@ -127,7 +129,8 @@ const InvoiceDetailModal: FC<InvoiceDetailModalProps> = ({
     });
   };
   const handelOpenNoveltyDetail = (noveltyId: number) => {
-    openModal("novelty", { noveltyId: noveltyId });
+    // deselect invoices in wallet tab
+    openModal("novelty", { noveltyId: noveltyId, deselectInvoices });
   };
 
   return (


### PR DESCRIPTION
This pull request introduces enhancements to the `InputSelect` component, adds functionality for deselecting invoices in various modals, and updates styling across multiple components. These changes aim to improve usability, functionality, and consistency within the codebase.

### Enhancements to the `InputSelect` component:
* Added new props to `InputSelectProps`: `popupMatchSelectWidth`, `showSearch`, and `filterOption`. These provide more control over the dropdown's behavior and filtering logic. (`src/components/atoms/inputs/InputSelect/InputSelect.tsx`, [src/components/atoms/inputs/InputSelect/InputSelect.tsxR26-R29](diffhunk://#diff-0f96b7efa4d430c753f9d8db531bd3896594d8706d21e2917d8dd574a108991eR26-R29))
* Set default values for the new props (`popupMatchSelectWidth`, `showSearch`, and `filterOption`) in the `InputSelect` component and passed them to the `Select` element. (`src/components/atoms/inputs/InputSelect/InputSelect.tsx`, [[1]](diffhunk://#diff-0f96b7efa4d430c753f9d8db531bd3896594d8706d21e2917d8dd574a108991eL41-R48) [[2]](diffhunk://#diff-0f96b7efa4d430c753f9d8db531bd3896594d8706d21e2917d8dd574a108991eR75-R77)

### Functionality for deselecting invoices:
* Added a new optional `deselectInvoices` prop to multiple components and contexts (`MoldalNoveltyDetail`, `InvoiceDetailModal`, and `ModalContext`) to allow clearing selected invoices. (`src/components/molecules/modals/MoldalNoveltyDetail/MoldalNoveltyDetail.tsx`, [[1]](diffhunk://#diff-ed5ba5c4f92204ad9dca317acb3ad38d55f67a93a387e3f1c24529835dff3b40R22-R29) [[2]](diffhunk://#diff-ed5ba5c4f92204ad9dca317acb3ad38d55f67a93a387e3f1c24529835dff3b40R66); `src/modules/clients/containers/invoice-detail-modal/invoice-detail-modal.tsx`, [[3]](diffhunk://#diff-3d3af98a6e52d0db9d3cd91b836f0686ce17e559afd22ce5852d4138ee112248R37) [[4]](diffhunk://#diff-3d3af98a6e52d0db9d3cd91b836f0686ce17e559afd22ce5852d4138ee112248L48-R50) [[5]](diffhunk://#diff-3d3af98a6e52d0db9d3cd91b836f0686ce17e559afd22ce5852d4138ee112248L130-R133); `src/context/ModalContext.tsx`, [[6]](diffhunk://#diff-b7535e49dee67ca9182b50212b83377e3d2585b9c12ea019be6a485c45fed4e9R34-R39)
* Implemented the `deselectInvoices` functionality in `WalletTab` to clear selected rows when interacting with modals. (`src/components/organisms/Customers/WalletTab/WalletTab.tsx`, [src/components/organisms/Customers/WalletTab/WalletTab.tsxL120-R123](diffhunk://#diff-da5f45cf009cf70d50201ca3b24bfe534196942ffa7e616df71a5ad7dac1857bL120-R123))

### Styling updates:
* Adjusted the grid layout in `registerNews.scss` to use `minmax` for better responsiveness. (`src/components/molecules/modals/RegisterNews/registerNews.scss`, [src/components/molecules/modals/RegisterNews/registerNews.scssL40-R40](diffhunk://#diff-4aa1a8ae407cbec75a6ebdc679157ea151aa569a2f1c2b5df542c7e70b34caadL40-R40))
* Updated `ant-select-item-option` styles to improve text wrapping and readability within dropdowns. (`src/components/molecules/modals/RegisterNews/registerNews.scss`, [src/components/molecules/modals/RegisterNews/registerNews.scssR146-R154](diffhunk://#diff-4aa1a8ae407cbec75a6ebdc679157ea151aa569a2f1c2b5df542c7e70b34caadR146-R154))
* Added a `gap` property to `__commentary` in `modalApplyAI.scss` for better spacing between elements. (`src/modules/clients/containers/apply-tab/Modals/ModalApplyAI/modalApplyAI.scss`, [src/modules/clients/containers/apply-tab/Modals/ModalApplyAI/modalApplyAI.scssR102](diffhunk://#diff-098f89114f4a690230ad9abffbeb4f929aa66d1b4732d42c1dc7515b52b7fb89R102))