### PR TITLE
Fix/historic dso showing according2 back info

### DIFF
--- a/src/modules/clients/components/dashboard-historic-dso/dashboard-historic-dso.tsx
+++ b/src/modules/clients/components/dashboard-historic-dso/dashboard-historic-dso.tsx
@@ -47,33 +47,20 @@ const DashboardHistoricDso: FC<DashboardHistoricDsoProps> = ({
   ];
 
   useEffect(() => {
-    // Initialize the data array with default values
-    const initialData: history_chart[] = [];
-    for (let i = 0; i < 12; i++) {
-      const monthIndex = (currentMonth + i) % 12;
-      initialData.push({
-        name: monthNames[monthIndex],
-        month: monthIndex + 1,
-        value: 0
-      });
+    if (!history_dso) {
+      setData([]);
+      return;
     }
-
-    // Assign actual DSO values from the dataset
-    if (history_dso) {
-      history_dso.forEach((item: historic_dso) => {
-        const itemDate = dayjs(item.date).utc();
-        const itemMonth = itemDate.month(); // Get month index from date string
-        const foundIndex = initialData.findIndex((data) => data.month === itemMonth + 1);
-        if (foundIndex !== -1) {
-          initialData[foundIndex].value = item.dso;
-        }
-      });
-    }
-
-    // delete the months six months before the current month
-    initialData.splice(0, 6);
-
-    setData(initialData);
+    const chartData = history_dso.map((item) => {
+      const date = dayjs(item.date);
+      const monthIdx = date.month(); // 0-11
+      return {
+        name: monthNames[monthIdx],
+        month: monthIdx + 1,
+        value: item.dso
+      };
+    });
+    setData(chartData);
   }, [history_dso]);
 
   return (

--- a/src/modules/clients/components/dashboard-historic-dso/dashboard-historic-dso.tsx
+++ b/src/modules/clients/components/dashboard-historic-dso/dashboard-historic-dso.tsx
@@ -28,9 +28,6 @@ const DashboardHistoricDso: FC<DashboardHistoricDsoProps> = ({
 }) => {
   const [data, setData] = useState([] as history_chart[]);
 
-  const currentDate = new Date();
-  const currentMonth = currentDate.getMonth();
-
   const monthNames = [
     "Ene",
     "Feb",


### PR DESCRIPTION
This pull request simplifies the initialization and processing of chart data in the `DashboardHistoricDso` component. The most important change is the removal of manual data initialization and replacement with a streamlined mapping approach.

Data processing improvements:

* [`src/modules/clients/components/dashboard-historic-dso/dashboard-historic-dso.tsx`](diffhunk://#diff-448305c5fa3b01dba1cf9e3ecc77b5632ae0d1c1b4cc42fa20a8aaf7ee7157b1L50-R63): Replaced the manual initialization of `history_chart` data with a `map` operation on `history_dso`, simplifying the logic and reducing redundancy. Removed unnecessary handling of default values and slicing operations.