### PR TITLE
Fix/historic dso showing according2 back info

### DIFF
--- a/src/modules/clients/components/dashboard-historic-dso/dashboard-historic-dso.tsx
+++ b/src/modules/clients/components/dashboard-historic-dso/dashboard-historic-dso.tsx
@@ -47,33 +47,20 @@ const DashboardHistoricDso: FC<DashboardHistoricDsoProps> = ({
   ];
 
   useEffect(() => {
-    // Initialize the data array with default values
-    const initialData: history_chart[] = [];
-    for (let i = 0; i < 12; i++) {
-      const monthIndex = (currentMonth + i) % 12;
-      initialData.push({
-        name: monthNames[monthIndex],
-        month: monthIndex + 1,
-        value: 0
-      });
+    if (!history_dso) {
+      setData([]);
+      return;
     }
-
-    // Assign actual DSO values from the dataset
-    if (history_dso) {
-      history_dso.forEach((item: historic_dso) => {
-        const itemDate = dayjs(item.date).utc();
-        const itemMonth = itemDate.month(); // Get month index from date string
-        const foundIndex = initialData.findIndex((data) => data.month === itemMonth + 1);
-        if (foundIndex !== -1) {
-          initialData[foundIndex].value = item.dso;
-        }
-      });
-    }
-
-    // delete the months six months before the current month
-    initialData.splice(0, 6);
-
-    setData(initialData);
+    const chartData = history_dso.map((item) => {
+      const date = dayjs(item.date);
+      const monthIdx = date.month(); // 0-11
+      return {
+        name: monthNames[monthIdx],
+        month: monthIdx + 1,
+        value: item.dso
+      };
+    });
+    setData(chartData);
   }, [history_dso]);
 
   return (

--- a/src/modules/clients/components/dashboard-historic-dso/dashboard-historic-dso.tsx
+++ b/src/modules/clients/components/dashboard-historic-dso/dashboard-historic-dso.tsx
@@ -28,9 +28,6 @@ const DashboardHistoricDso: FC<DashboardHistoricDsoProps> = ({
 }) => {
   const [data, setData] = useState([] as history_chart[]);
 
-  const currentDate = new Date();
-  const currentMonth = currentDate.getMonth();
-
   const monthNames = [
     "Ene",
     "Feb",


### PR DESCRIPTION
This pull request refactors the `DashboardHistoricDso` component in `dashboard-historic-dso.tsx` to simplify the initialization and processing of chart data. The most important changes include removing redundant code for generating default data and streamlining the mapping of `history_dso` data into chart data.

### Refactoring for data initialization and processing:

* Removed the logic for generating default data for the chart and the deletion of months prior to the current month. This simplifies the `useEffect` hook by directly mapping `history_dso` data into the required format. (`[src/modules/clients/components/dashboard-historic-dso/dashboard-historic-dso.tsxL50-R60](diffhunk://#diff-448305c5fa3b01dba1cf9e3ecc77b5632ae0d1c1b4cc42fa20a8aaf7ee7157b1L50-R60)`)
* Eliminated unused variables, such as `currentDate` and `currentMonth`, which were no longer needed after the refactoring. (`[src/modules/clients/components/dashboard-historic-dso/dashboard-historic-dso.tsxL31-L33](diffhunk://#diff-448305c5fa3b01dba1cf9e3ecc77b5632ae0d1c1b4cc42fa20a8aaf7ee7157b1L31-L33)`)