### PR TITLE
feat: adjust table scrolling height dynamically and remove unnecessar…

### DIFF
--- a/src/components/molecules/tables/ProjectsTable/ProjectsTable.tsx
+++ b/src/components/molecules/tables/ProjectsTable/ProjectsTable.tsx
@@ -11,6 +11,7 @@ import { countries } from "@/utils/countries";
 import { FilterProjects } from "@/components/atoms/Filters/FilterProjects/FilterProjects";
 import UiSearchInput from "@/components/ui/search-input";
 import { DotsDropdown } from "@/components/atoms/DotsDropdown/DotsDropdown";
+import useScreenHeight from "@/components/hooks/useScreenHeight";
 
 import { IProject } from "@/types/projects/IProjects";
 
@@ -31,6 +32,8 @@ export const ProjectTable = () => {
     countryId: selectFilters.country,
     searchQuery: search
   });
+
+  const height = useScreenHeight();
 
   const projects = useAppStore((state) => state.projects);
   const setProjects = useAppStore((state) => state.setProjects);
@@ -210,7 +213,7 @@ export const ProjectTable = () => {
       </Flex>
       <Table
         loading={loading}
-        scroll={{ y: "61dvh", x: undefined }}
+        scroll={{ y: height - 310 }}
         columns={columns as TableProps<any>["columns"]}
         pagination={{
           pageSize: 25,

--- a/src/components/molecules/tables/ProjectsTable/projectstable.scss
+++ b/src/components/molecules/tables/ProjectsTable/projectstable.scss
@@ -34,10 +34,6 @@
         transform: rotate(-90deg);
     }
 
-    .ant-table-pagination {
-        margin-top: 40px !important;
-    }
-
     .mainProjectsTable_header {
         margin: 1rem 0;
 


### PR DESCRIPTION
…y pagination margin
This pull request introduces improvements to the `ProjectsTable` component, focusing on dynamic height adjustments and cleanup of unused styles. The most significant changes include leveraging a custom hook to calculate screen height for better table scrolling behavior and removing redundant CSS rules.

### Enhancements to table height calculation:

* [`src/components/molecules/tables/ProjectsTable/ProjectsTable.tsx`](diffhunk://#diff-84b0637823de272fac7652fe3c0dee4e3337126cd15f364ec363a1cfb84c7909R14): Added the `useScreenHeight` hook to dynamically calculate screen height and updated the table's vertical scroll behavior to use `height - 310` instead of a hardcoded value. [[1]](diffhunk://#diff-84b0637823de272fac7652fe3c0dee4e3337126cd15f364ec363a1cfb84c7909R14) [[2]](diffhunk://#diff-84b0637823de272fac7652fe3c0dee4e3337126cd15f364ec363a1cfb84c7909R36-R37) [[3]](diffhunk://#diff-84b0637823de272fac7652fe3c0dee4e3337126cd15f364ec363a1cfb84c7909L213-R216)

### Cleanup of unused styles:

* [`src/components/molecules/tables/ProjectsTable/projectstable.scss`](diffhunk://#diff-28b51f521739364c9fbca9820660d66262dbf99eb93ece6bca506e773815f4adL37-L40): Removed the `.ant-table-pagination` style rules, which were no longer necessary.