### PR TITLE
Feat/mark payments as unidentified

### DIFF
--- a/src/components/molecules/modals/ModalActionPayment/ModalActionPayment.tsx
+++ b/src/components/molecules/modals/ModalActionPayment/ModalActionPayment.tsx
@@ -1,7 +1,11 @@
 import React, { Dispatch, SetStateAction } from "react";
-import { Modal } from "antd";
+import { message, Modal } from "antd";
+import { MagnifyingGlassPlus, HandTap, PushPin, QuestionMark } from "@phosphor-icons/react";
+
 import { ButtonGenerateAction } from "@/components/atoms/ButtonGenerateAction/ButtonGenerateAction";
-import { MagnifyingGlassPlus, HandTap, PushPin } from "@phosphor-icons/react";
+
+import { IClientPayment } from "@/types/clientPayments/IClientPayments";
+
 import "./modalActionPayment.scss";
 
 type ModalActionPaymentProps = {
@@ -16,6 +20,7 @@ type ModalActionPaymentProps = {
   >;
   setIsModalActionPaymentOpen: Dispatch<SetStateAction<boolean>>;
   addPaymentsToApplicationTable: () => void;
+  selectedPayments: IClientPayment[];
 };
 
 export const ModalActionPayment: React.FC<ModalActionPaymentProps> = ({
@@ -24,7 +29,8 @@ export const ModalActionPayment: React.FC<ModalActionPaymentProps> = ({
   onChangeTab,
   setIsSelectedActionModalOpen,
   setIsModalActionPaymentOpen,
-  addPaymentsToApplicationTable
+  addPaymentsToApplicationTable,
+  selectedPayments
 }) => {
   return (
     <Modal
@@ -52,6 +58,10 @@ export const ModalActionPayment: React.FC<ModalActionPaymentProps> = ({
           title="Aplicar pagos"
           onClick={() => {
             // onChangeTab("5");
+            if (selectedPayments.length === 0) {
+              message.info("No hay pagos seleccionados para aplicar.");
+              return;
+            }
             addPaymentsToApplicationTable();
           }}
         />
@@ -60,6 +70,20 @@ export const ModalActionPayment: React.FC<ModalActionPaymentProps> = ({
           title="Cambiar de estado"
           onClick={() => {
             console.log("Cambiar de estado clicked");
+          }}
+        />
+        <ButtonGenerateAction
+          icon={<QuestionMark size={20} />}
+          title="Marcar como no identificado"
+          onClick={() => {
+            if (selectedPayments.length === 0) {
+              message.info("No hay pagos seleccionados para marcar como no identificados.");
+              return;
+            }
+            setIsSelectedActionModalOpen({
+              selected: 2
+            });
+            setIsModalActionPaymentOpen((prev) => !prev);
           }}
         />
       </div>

--- a/src/components/molecules/modals/ModalActionPayment/ModalActionPayment.tsx
+++ b/src/components/molecules/modals/ModalActionPayment/ModalActionPayment.tsx
@@ -1,6 +1,6 @@
 import React, { Dispatch, SetStateAction } from "react";
 import { message, Modal } from "antd";
-import { MagnifyingGlassPlus, HandTap, PushPin, QuestionMark } from "@phosphor-icons/react";
+import { MagnifyingGlassPlus, HandTap, PushPin, ArrowDownLeft } from "@phosphor-icons/react";
 
 import { ButtonGenerateAction } from "@/components/atoms/ButtonGenerateAction/ButtonGenerateAction";
 
@@ -73,7 +73,7 @@ export const ModalActionPayment: React.FC<ModalActionPaymentProps> = ({
           }}
         />
         <ButtonGenerateAction
-          icon={<QuestionMark size={20} />}
+          icon={<ArrowDownLeft size={20} />}
           title="Marcar como no identificado"
           onClick={() => {
             if (selectedPayments.length === 0) {

--- a/src/components/molecules/modals/ModalActionPayment/ModalActionPayment.tsx
+++ b/src/components/molecules/modals/ModalActionPayment/ModalActionPayment.tsx
@@ -74,10 +74,10 @@ export const ModalActionPayment: React.FC<ModalActionPaymentProps> = ({
         />
         <ButtonGenerateAction
           icon={<ArrowDownLeft size={20} />}
-          title="Marcar como no identificado"
+          title="Pago no es del cliente"
           onClick={() => {
             if (selectedPayments.length === 0) {
-              message.info("No hay pagos seleccionados para marcar como no identificados.");
+              message.info("No hay pagos seleccionados para marcar como no identificados");
               return;
             }
             setIsSelectedActionModalOpen({

--- a/src/modules/banks/components/modal-actions-banks-payments/modal-actions-banks-payments.tsx
+++ b/src/modules/banks/components/modal-actions-banks-payments/modal-actions-banks-payments.tsx
@@ -6,7 +6,8 @@ import {
   CheckCircle,
   CirclesFour,
   FileArrowUp,
-  ArrowsClockwise
+  ArrowsClockwise,
+  ArrowDownLeft
 } from "@phosphor-icons/react";
 
 import { ButtonGenerateAction } from "@/components/atoms/ButtonGenerateAction/ButtonGenerateAction";
@@ -79,6 +80,13 @@ const ModalActionsBanksPayments = ({ isOpen, onClose, setSelectOpen }: Props) =>
           title="Cambiar de estado"
           onClick={() => {
             handleOpenModal(6);
+          }}
+        />
+        <ButtonGenerateAction
+          icon={<ArrowDownLeft size={20} />}
+          title="Marcar como sin identificar"
+          onClick={() => {
+            handleOpenModal(8);
           }}
         />
       </Flex>

--- a/src/modules/banks/containers/active-payments-tab/active-payments-tab.tsx
+++ b/src/modules/banks/containers/active-payments-tab/active-payments-tab.tsx
@@ -8,6 +8,7 @@ import { useMessageApi } from "@/context/MessageContext";
 import { useAppStore } from "@/lib/store/store";
 import { useBankPayments } from "@/hooks/useBankPayments";
 import { approvePayment } from "@/services/banksPayments/banksPayments";
+import { markPaymentsAsUnidentified } from "@/services/applyTabClients/applyTabClients";
 
 import PrincipalButton from "@/components/atoms/buttons/principalButton/PrincipalButton";
 import Collapse from "@/components/ui/collapse";
@@ -106,6 +107,21 @@ export const ActivePaymentsTab: FC = () => {
       showMessage("error", "Error al aprobar la asignación");
     }
     setLoadingApprove(false);
+  };
+
+  const handlePaymentUnidentified = async () => {
+    try {
+      await markPaymentsAsUnidentified(selectedRows?.map((payment) => payment.id) || []);
+      showMessage("success", "Pago(s) marcados como no identificados");
+      mutate();
+      setSelectedRows([]);
+    } catch (error) {
+      showMessage(
+        "error",
+        "Ha ocurrido un error al marcar los pagos seleccionados como no identificados"
+      );
+    }
+    setIsSelectOpen({ selected: 0 });
   };
 
   const handleSearch = (query: string) => {
@@ -261,6 +277,12 @@ export const ActivePaymentsTab: FC = () => {
             isOpen={isSelectOpen.selected === 7}
             onClose={() => setIsSelectOpen({ selected: 0 })}
             selectDates={handleFilterDates}
+          />
+          <ModalConfirmAction
+            title="¿Marcar pagos seleccionados como sin identificar?"
+            isOpen={isSelectOpen.selected === 8}
+            onClose={() => setIsSelectOpen({ selected: 0 })}
+            onOk={handlePaymentUnidentified}
           />
         </Flex>
       )}

--- a/src/modules/clients/containers/apply-tab/apply-tab.tsx
+++ b/src/modules/clients/containers/apply-tab/apply-tab.tsx
@@ -11,6 +11,7 @@ import { useAppStore } from "@/lib/store/store";
 import { extractSingleParam } from "@/utils/utils";
 import {
   addItemsToTable,
+  markPaymentsAsUnidentified,
   removeItemsFromTable,
   removeMultipleRows,
   saveApplication
@@ -159,6 +160,16 @@ const ApplyTab: React.FC = () => {
       row: row,
       editing_type
     });
+  };
+
+  const handlePaymentUnidentified = async (row: IApplyTabRecord) => {
+    try {
+      await markPaymentsAsUnidentified([row.payment_id]);
+      showMessage("success", "Pago marcado como no identificado");
+      mutate();
+    } catch (error) {
+      showMessage("error", "Ha ocurrido un error al marcar el pago como no identificado");
+    }
   };
 
   const handleSelectChange = useCallback(
@@ -471,6 +482,7 @@ const ApplyTab: React.FC = () => {
                       handleDeleteRow={handleRemoveRow}
                       handleEditRow={handleEditRow}
                       rowSelection={rowSelection("payments")}
+                      markPaymentAsUnidentified={handlePaymentUnidentified}
                     />
                   )}
                   {section.statusName === "ajustes" && (

--- a/src/modules/clients/containers/apply-tab/tables/PaymentsTable.tsx
+++ b/src/modules/clients/containers/apply-tab/tables/PaymentsTable.tsx
@@ -1,10 +1,13 @@
 import React, { ReactNode, useState } from "react";
 import { Button, Dropdown, Table, TableProps, Tooltip } from "antd";
 import { DotsThreeVertical, Eye, Trash } from "phosphor-react";
+import { QuestionMark } from "@phosphor-icons/react";
 
 import { useAppStore } from "@/lib/store/store";
 import { formatDate } from "@/utils/utils";
+
 import { ModalRemove } from "@/components/molecules/modals/ModalRemove/ModalRemove";
+import { ModalConfirmAction } from "@/components/molecules/modals/ModalConfirmAction/ModalConfirmAction";
 
 import { IApplyTabRecord } from "@/types/applyTabClients/IApplyTabClients";
 
@@ -19,18 +22,22 @@ interface PaymentsTableProps {
     // eslint-disable-next-line no-unused-vars
     onChange: (newSelectedRowKeys: React.Key[], selectedRows: any[]) => void;
   };
+  // eslint-disable-next-line no-unused-vars
+  markPaymentAsUnidentified?: (row: IApplyTabRecord) => void;
 }
 
 const PaymentsTable: React.FC<PaymentsTableProps> = ({
   data,
   handleDeleteRow,
   handleEditRow,
-  rowSelection
+  rowSelection,
+  markPaymentAsUnidentified
 }) => {
   const formatMoney = useAppStore((state) => state.formatMoney);
   const [activeRow, setActiveRow] = useState<IApplyTabRecord | null>(null);
 
   const [removeModal, setRemoveModal] = useState(false);
+  const [confirmModal, setConfirmModal] = useState(false);
 
   const columns: TableProps<IApplyTabRecord>["columns"] = [
     {
@@ -120,6 +127,21 @@ const PaymentsTable: React.FC<PaymentsTableProps> = ({
                 Eliminar
               </Button>
             )
+          },
+          {
+            key: "3",
+            label: (
+              <Button
+                icon={<QuestionMark size={20} />}
+                className="buttonNoBorder"
+                onClick={() => {
+                  setActiveRow(row);
+                  setConfirmModal(true);
+                }}
+              >
+                No identificado
+              </Button>
+            )
           }
         ];
 
@@ -167,6 +189,16 @@ const PaymentsTable: React.FC<PaymentsTableProps> = ({
           setActiveRow(null);
           setRemoveModal(false);
           handleDeleteRow && activeRow && handleDeleteRow(activeRow.id);
+        }}
+      />
+
+      <ModalConfirmAction
+        title="¿Marcar pago como no identificado?"
+        isOpen={confirmModal}
+        onClose={() => setConfirmModal(false)}
+        onOk={() => {
+          setConfirmModal(false);
+          markPaymentAsUnidentified && activeRow && markPaymentAsUnidentified(activeRow);
         }}
       />
     </>

--- a/src/modules/clients/containers/apply-tab/tables/PaymentsTable.tsx
+++ b/src/modules/clients/containers/apply-tab/tables/PaymentsTable.tsx
@@ -1,7 +1,6 @@
 import React, { ReactNode, useState } from "react";
 import { Button, Dropdown, Table, TableProps, Tooltip } from "antd";
-import { DotsThreeVertical, Eye, Trash } from "phosphor-react";
-import { QuestionMark } from "@phosphor-icons/react";
+import { ArrowDownLeft, DotsThreeVertical, Eye, Trash } from "@phosphor-icons/react";
 
 import { useAppStore } from "@/lib/store/store";
 import { formatDate } from "@/utils/utils";
@@ -132,7 +131,7 @@ const PaymentsTable: React.FC<PaymentsTableProps> = ({
             key: "3",
             label: (
               <Button
-                icon={<QuestionMark size={20} />}
+                icon={<ArrowDownLeft size={20} />}
                 className="buttonNoBorder"
                 onClick={() => {
                   setActiveRow(row);

--- a/src/modules/clients/containers/apply-tab/tables/PaymentsTable.tsx
+++ b/src/modules/clients/containers/apply-tab/tables/PaymentsTable.tsx
@@ -138,7 +138,7 @@ const PaymentsTable: React.FC<PaymentsTableProps> = ({
                   setConfirmModal(true);
                 }}
               >
-                No identificado
+                Pago no es del cliente
               </Button>
             )
           }
@@ -192,7 +192,7 @@ const PaymentsTable: React.FC<PaymentsTableProps> = ({
       />
 
       <ModalConfirmAction
-        title="¿Marcar pago como no identificado?"
+        title="Se marcará el pago como no identificado"
         isOpen={confirmModal}
         onClose={() => setConfirmModal(false)}
         onOk={() => {

--- a/src/modules/clients/containers/payments-tab/payments-tab.tsx
+++ b/src/modules/clients/containers/payments-tab/payments-tab.tsx
@@ -195,7 +195,7 @@ const PaymentsTab: React.FC<PaymentProd> = ({ onChangeTab }) => {
         onClose={handleCloseActionModal}
       />
       <ModalConfirmAction
-        title="¿Marcar pagos seleccionados como no identificados?"
+        title="Se marcarán los pagos seleccionados como no identificados"
         isOpen={isSelectedActionModalOpen.selected === 2}
         onClose={handleCloseActionModal}
         onOk={handlePaymentUnidentified}

--- a/src/modules/clients/containers/payments-tab/payments-tab.tsx
+++ b/src/modules/clients/containers/payments-tab/payments-tab.tsx
@@ -4,7 +4,10 @@ import { DotsThree, MagnifyingGlassPlus } from "phosphor-react";
 import { useParams } from "next/navigation";
 import { AxiosError } from "axios";
 
-import { addItemsToTable } from "@/services/applyTabClients/applyTabClients";
+import {
+  addItemsToTable,
+  markPaymentsAsUnidentified
+} from "@/services/applyTabClients/applyTabClients";
 import { extractSingleParam } from "@/utils/utils";
 import { useSelectedPayments } from "@/context/SelectedPaymentsContext";
 import { useClientsPayments } from "@/hooks/useClientsPayments";
@@ -19,6 +22,7 @@ import UiFilterDropdown from "@/components/ui/ui-filter-dropdown";
 import PaymentsTable from "@/modules/clients/components/payments-table";
 import { ModalActionPayment } from "@/components/molecules/modals/ModalActionPayment/ModalActionPayment";
 import ModalIdentifyPayment from "../../components/payments-tab/modal-identify-payment-action";
+import { ModalConfirmAction } from "@/components/molecules/modals/ModalConfirmAction/ModalConfirmAction";
 
 import { IClientPayment } from "@/types/clientPayments/IClientPayments";
 import { ISingleBank } from "@/types/banks/IBanks";
@@ -106,6 +110,22 @@ const PaymentsTab: React.FC<PaymentProd> = ({ onChangeTab }) => {
       }
     }
   };
+
+  const handlePaymentUnidentified = async () => {
+    try {
+      await markPaymentsAsUnidentified(selectedPayments.map((payment) => payment.id));
+      showMessage("success", "Pago(s) marcados como no identificados");
+      mutate();
+      setSelectedPayments([]);
+    } catch (error) {
+      showMessage(
+        "error",
+        "Ha ocurrido un error al marcar los pagos seleccionados como no identificados"
+      );
+    }
+    setIsSelectedActionModalOpen({ selected: 0 });
+  };
+
   return (
     <>
       <div className="paymentsTab">
@@ -168,10 +188,17 @@ const PaymentsTab: React.FC<PaymentProd> = ({ onChangeTab }) => {
         setIsSelectedActionModalOpen={setIsSelectedActionModalOpen}
         setIsModalActionPaymentOpen={setIsModalActionPaymentOpen}
         addPaymentsToApplicationTable={handleAddSelectedPaymentsToApplicationTable}
+        selectedPayments={selectedPayments}
       />
       <ModalIdentifyPayment
         isOpen={isSelectedActionModalOpen.selected === 1}
         onClose={handleCloseActionModal}
+      />
+      <ModalConfirmAction
+        title="¿Marcar pagos seleccionados como no identificados?"
+        isOpen={isSelectedActionModalOpen.selected === 2}
+        onClose={handleCloseActionModal}
+        onOk={handlePaymentUnidentified}
       />
     </>
   );

--- a/src/services/applyTabClients/applyTabClients.ts
+++ b/src/services/applyTabClients/applyTabClients.ts
@@ -251,3 +251,17 @@ export const applyWithCashportAI = async (
     throw error;
   }
 };
+
+export const markPaymentsAsUnidentified = async (paymentIds: number[]) => {
+  try {
+    const response: GenericResponse<any> = await API.post(
+      `${config.API_HOST}/paymentApplication/unlink-client`,
+      { payments: paymentIds }
+    );
+
+    return response;
+  } catch (error) {
+    console.error("Error in markAsUnidentified:", error);
+    throw error;
+  }
+};


### PR DESCRIPTION
This pull request introduces functionality to mark payments as "unidentified" across multiple components and modules in the application. The changes include adding a new API method, updating modals and tables to handle this functionality, and ensuring appropriate user feedback for the new action.

### New Feature: Mark Payments as Unidentified
* Added a new API method `markPaymentsAsUnidentified` in `src/services/applyTabClients/applyTabClients.ts` to handle the backend request for marking payments as unidentified.

### Updates to Modals and Actions
* Updated `ModalActionPayment` in `src/components/molecules/modals/ModalActionPayment/ModalActionPayment.tsx` to include a new button for marking selected payments as unidentified. This includes validation to ensure at least one payment is selected before proceeding. [[1]](diffhunk://#diff-481728bc279aefc1186a7f2e4435b0bf292763c402fc3f6e588ae3d7db80e2c4R23) [[2]](diffhunk://#diff-481728bc279aefc1186a7f2e4435b0bf292763c402fc3f6e588ae3d7db80e2c4R61-R64) [[3]](diffhunk://#diff-481728bc279aefc1186a7f2e4435b0bf292763c402fc3f6e588ae3d7db80e2c4R75-R88)
* Added a new `ModalConfirmAction` to confirm marking payments as unidentified in various components, including `ActivePaymentsTab`, `PaymentsTab`, and `PaymentsTable`. [[1]](diffhunk://#diff-0e4db53181eb260b9096dc2f7aeebffa1d70bbcb43f75f492a59cfc0a5324fbbR281-R286) [[2]](diffhunk://#diff-77369ac334ccf46d321b87ceca3968eeaca7af342136929ca88fdc12ab9b61a8R191-R202) [[3]](diffhunk://#diff-bad38a2f5d3b3c954634f0e695f2847d77980b1f64157565f6da6f592c74022eR193-R202)

### Integration with Tables
* Updated `PaymentsTable` in `src/modules/clients/containers/apply-tab/tables/PaymentsTable.tsx` to include a dropdown option for marking individual payments as unidentified, with a confirmation modal. [[1]](diffhunk://#diff-bad38a2f5d3b3c954634f0e695f2847d77980b1f64157565f6da6f592c74022eR129-R143) [[2]](diffhunk://#diff-bad38a2f5d3b3c954634f0e695f2847d77980b1f64157565f6da6f592c74022eR193-R202)

### Contextual Updates Across Modules
* Integrated the new "mark as unidentified" functionality into the `ActivePaymentsTab`, `ApplyTab`, and `PaymentsTab` components, including handlers for user actions and success/error messaging. [[1]](diffhunk://#diff-0e4db53181eb260b9096dc2f7aeebffa1d70bbcb43f75f492a59cfc0a5324fbbR112-R126) [[2]](diffhunk://#diff-783ab654e6b1029e83918ef67351ca29faaefef8709bda898a5ab3aee63eef72R165-R174) [[3]](diffhunk://#diff-77369ac334ccf46d321b87ceca3968eeaca7af342136929ca88fdc12ab9b61a8R113-R128)

### Icon and Styling Adjustments
* Imported the `ArrowDownLeft` icon from `@phosphor-icons/react` for use in the new action buttons across components. [[1]](diffhunk://#diff-481728bc279aefc1186a7f2e4435b0bf292763c402fc3f6e588ae3d7db80e2c4L2-R8) [[2]](diffhunk://#diff-0fb5324376b36079c542b11a0035eedbf9cc65f4632bee8d266ecd38dad51c6aL9-R10) [[3]](diffhunk://#diff-bad38a2f5d3b3c954634f0e695f2847d77980b1f64157565f6da6f592c74022eL3-R9)