### PR TITLE
Switch from client_id to client_uuid in client views

### DIFF
--- a/src/components/organisms/Customers/ClientsViewTable/ClientsViewTable.tsx
+++ b/src/components/organisms/Customers/ClientsViewTable/ClientsViewTable.tsx
@@ -115,7 +115,7 @@ export const ClientsViewTable = () => {
       dataIndex: "client_name",
       key: "client_name",
       render: (_, row: IClientsPortfolio) => (
-        <Link href={`/clientes/detail/${row.client_id}/project/${row.project_id}`}>
+        <Link href={`/clientes/detail/${row.client_uuid}/project/${row.project_id}`}>
           <Text className="text">{row.client_name}</Text>
         </Link>
       ),

--- a/src/modules/clients/hooks/client-details/client-details.hook.tsx
+++ b/src/modules/clients/hooks/client-details/client-details.hook.tsx
@@ -12,7 +12,7 @@ export const useClientDetails = (filters: IClientPortfolioFilters) => {
   const params = useParams();
   const clientIdParam = extractSingleParam(params.clientId);
   const projectIdParam = extractSingleParam(params.projectId);
-  const clientId = clientIdParam;
+  const clientUUID = clientIdParam;
   const projectId = projectIdParam ? parseInt(projectIdParam) : undefined;
 
   const queryParams = [
@@ -26,7 +26,7 @@ export const useClientDetails = (filters: IClientPortfolioFilters) => {
     .filter(Boolean)
     .join("&");
 
-  const pathKey = `/portfolio/project/${projectId}/client/${clientId}?${queryParams}`;
+  const pathKey = `/portfolio/project/${projectId}/client/${clientUUID}?${queryParams}`;
 
   const {
     data: portfolioData,

--- a/src/types/clients/IViewClientsTable.ts
+++ b/src/types/clients/IViewClientsTable.ts
@@ -13,6 +13,7 @@ export interface IClientsPortfolio {
   total_balances: any;
   id: number;
   client_id: string;
+  client_uuid: string;
   client_name: string;
   project_id: number;
   past_due_ammount: number;


### PR DESCRIPTION
Updated components and hooks to use client_uuid instead of client_id for client detail links and API paths. Added client_uuid to the IClientsPortfolio type to support this change.