### PR TITLE
Fix/notification count in pop over user notification

### DIFF
--- a/src/components/molecules/modals/ModalProjectSelector/ModalProjectSelector.tsx
+++ b/src/components/molecules/modals/ModalProjectSelector/ModalProjectSelector.tsx
@@ -27,6 +27,8 @@ export const ModalProjectSelector = ({ isOpen, onClose }: Props) => {
       isSuperAdmin: project.isSuperAdmin
     };
     setSelectedProject(projectInfo);
+    // set session storage for selectedProjectId, used in the useNotificationStore
+    sessionStorage.setItem("projectId", project.ID.toString());
     if (path.startsWith("/proyectos/review")) {
       router.push(`/proyectos/review/${project.ID}/detail`);
     } else if (path.startsWith("/clientes/all")) {

--- a/src/context/CountNotification.tsx
+++ b/src/context/CountNotification.tsx
@@ -1,5 +1,6 @@
 import { create } from "zustand";
 import { API } from "@/utils/api/api";
+import { GenericResponse } from "@/types/global/IGlobal";
 
 interface NotificationStore {
   notificationCount: number;
@@ -7,14 +8,13 @@ interface NotificationStore {
 }
 
 const getSelectedProjectId = (): number | null => {
-  const projectData = sessionStorage.getItem("project");
-  if (projectData) {
-    try {
-      const parsedData = JSON.parse(projectData);
-      return parsedData.state.selectedProject.ID;
-    } catch (error) {
-      console.error("Error parsing project data from sessionStorage", error);
+  try {
+    const projectId = sessionStorage.getItem("projectId");
+    if (projectId) {
+      return parseInt(projectId, 10);
     }
+  } catch (error) {
+    console.error("Error getting project ID from sessionStorage", error);
   }
   return null;
 };
@@ -25,7 +25,9 @@ export const useNotificationStore = create<NotificationStore>((set) => ({
     const projectId = getSelectedProjectId();
     if (projectId !== null) {
       try {
-        const response = await API.get(`/notification/count/project/${projectId}/user`);
+        const response: GenericResponse<number> = await API.get(
+          `/notification/count/project/${projectId}/user`
+        );
         set({ notificationCount: response.data });
       } catch (error) {
         console.error("Error fetching notification count:", error);


### PR DESCRIPTION
This pull request introduces changes to improve session storage handling and type safety in notification-related functionality. The key updates include switching from storing complex project data to storing a simple project ID in session storage, refactoring related code, and enhancing type safety in API responses.

### Session storage handling improvements:

* [`src/components/molecules/modals/ModalProjectSelector/ModalProjectSelector.tsx`](diffhunk://#diff-10770c08ed20760b423fc75fbc82c117dd949a14e47dac8f4b0af3f7c19284a2R30-R31): Added logic to store the selected project ID (`project.ID`) in session storage instead of complex project data, simplifying data retrieval for other components.
* [`src/context/CountNotification.tsx`](diffhunk://#diff-45636509452459e1f9a50d847dc9278ea3b8c0d9095ae04afad38f6385391080R3-R17): Refactored the `getSelectedProjectId` function to retrieve the project ID directly from session storage, replacing the previous approach of parsing complex project data. Improved error handling for session storage access.

### Type safety enhancements:

* [`src/context/CountNotification.tsx`](diffhunk://#diff-45636509452459e1f9a50d847dc9278ea3b8c0d9095ae04afad38f6385391080L28-R30): Updated the `useNotificationStore` to use a strongly typed API response (`GenericResponse<number>`), ensuring type safety when fetching notification counts.