### PR TITLE
fix: update client ID reference to use clientUUID in ClientsViewTable

### DIFF
--- a/src/components/organisms/Customers/ClientsViewTable/ClientsViewTable.tsx
+++ b/src/components/organisms/Customers/ClientsViewTable/ClientsViewTable.tsx
@@ -121,11 +121,11 @@ export const ClientsViewTable = () => {
         <Flex gap="0.5rem" align="center">
           <Link
             className="linkName"
-            href={`/clientes/detail/${row.client_id}/project/${row.project_id}`}
+            href={`/clientes/detail/${row.client_uuid}/project/${row.project_id}`}
           >
             {row.client_name}
           </Link>
-          {row.events.length > 0 && (
+          {row?.events?.length > 0 && (
             <Tooltip
               color={"#f7f7f7"}
               className="tooltipHistoricEvents__icon"


### PR DESCRIPTION
This pull request updates the `ClientsViewTable` component to improve its robustness and ensure correct data usage. The most notable changes include replacing `client_id` with `client_uuid` in the link URL and adding optional chaining for safer access to the `events` property.

### Improvements to data handling:

* Updated the `href` property in the `Link` component to use `client_uuid` instead of `client_id`, ensuring the correct unique identifier is used for navigation. (`src/components/organisms/Customers/ClientsViewTable/ClientsViewTable.tsx`, [src/components/organisms/Customers/ClientsViewTable/ClientsViewTable.tsxL124-R128](diffhunk://#diff-1f62dddf2612672ceb6a04e463f16994b93cdeff6c997efc3d70449406906544L124-R128))
* Added optional chaining (`row?.events?.length`) to safely check the length of `events`, preventing potential runtime errors if `events` is undefined or null. (`src/components/organisms/Customers/ClientsViewTable/ClientsViewTable.tsx`, [src/components/organisms/Customers/ClientsViewTable/ClientsViewTable.tsxL124-R128](diffhunk://#diff-1f62dddf2612672ceb6a04e463f16994b93cdeff6c997efc3d70449406906544L124-R128))