### PR TITLE
fix: mutateDat whetter or not ApplyAi was succesful

### DIFF
--- a/src/modules/clients/containers/apply-tab/Modals/ModalApplyAI/ModalApplyAI.tsx
+++ b/src/modules/clients/containers/apply-tab/Modals/ModalApplyAI/ModalApplyAI.tsx
@@ -7,7 +7,10 @@ import { File, Sparkle, Trash, Upload, X } from "phosphor-react";
 
 import { useAppStore } from "@/lib/store/store";
 import { extractSingleParam } from "@/utils/utils";
-import { applyWithCashportAI, uploadPaymentAttachment } from "@/services/applyTabClients/applyTabClients";
+import {
+  applyWithCashportAI,
+  uploadPaymentAttachment
+} from "@/services/applyTabClients/applyTabClients";
 
 import { FILE_EXTENSIONS } from "@/utils/constants/globalConstants";
 
@@ -53,11 +56,11 @@ const ModalApplyAI = ({ isOpen, onClose, mutate }: Props) => {
       await uploadPaymentAttachment(projectId, clientId, uploadedFiles, commentary);
       await applyWithCashportAI(projectId, clientId, uploadedFiles, commentary);
       message.success("Archivos analizados con CashportAI");
-      mutate();
       closeModal();
     } catch (error) {
       message.error("Error al aplicar con CashportAI");
     }
+    mutate();
     setLoading(false);
   };
 


### PR DESCRIPTION
This pull request makes minor updates to the `ModalApplyAI` component in `ModalApplyAI.tsx`. The changes primarily involve code formatting and the order of operations for the `mutate` function.

### Code formatting improvements:

* [`src/modules/clients/containers/apply-tab/Modals/ModalApplyAI/ModalApplyAI.tsx`](diffhunk://#diff-84a439a5f1f76aa2f781b4016c438d3408fb835d9ead50b83aa9d495d39d6f6cL10-R13): Reformatted the import statement for better readability by splitting long lines into multiple lines.

### Functional adjustments:

* [`src/modules/clients/containers/apply-tab/Modals/ModalApplyAI/ModalApplyAI.tsx`](diffhunk://#diff-84a439a5f1f76aa2f781b4016c438d3408fb835d9ead50b83aa9d495d39d6f6cL56-R63): Moved the `mutate` function call to occur after closing the modal, ensuring proper execution flow.