### PR TITLE
refactor: add responsive search input styling for orders view

### DIFF
--- a/src/modules/commerce/containers/orders-view/orders-view.module.scss
+++ b/src/modules/commerce/containers/orders-view/orders-view.module.scss
@@ -74,3 +74,11 @@
     align-items: center !important;
     height: 3rem !important;
 }
+
+@media (max-width: 900px) {
+    .ordersView {
+        .searchInput {
+            width: 130px;
+        }
+    }
+}

--- a/src/modules/commerce/containers/orders-view/orders-view.tsx
+++ b/src/modules/commerce/containers/orders-view/orders-view.tsx
@@ -100,6 +100,7 @@ export const OrdersView: FC = () => {
         <Flex className={styles.header}>
           <UiSearchInput
             placeholder="Buscar"
+            className={styles.searchInput}
             onChange={(event) => setSearchTerm(event.target.value)}
           />
           <Button


### PR DESCRIPTION
<img width="518" height="524" alt="image" src="https://github.com/user-attachments/assets/4fccb018-e474-41dc-b118-bf28b8e36954" />

This pull request makes small improvements to the `OrdersView` component by refining the search input's styling and responsiveness.

- UI/UX improvements:
  * Added a `searchInput` class to the `UiSearchInput` component in `orders-view.tsx` to allow for targeted styling.
  * Updated `orders-view.module.scss` to reduce the width of the search input to 130px on screens smaller than 900px, improving mobile responsiveness.