### PR TITLE
Refactor/reload on focus comercio banco paths

### DIFF
--- a/src/components/molecules/modals/ChangeWarehouseModal/ChangeWarehouseModal.tsx
+++ b/src/components/molecules/modals/ChangeWarehouseModal/ChangeWarehouseModal.tsx
@@ -128,8 +128,8 @@ export const ChangeWarehouseModal: React.FC<Props> = ({
   const columnsDetails: ColumnsType<WarehouseProductsStock> = [
     {
       title: "Producto",
-      dataIndex: "sku",
-      key: "sku"
+      dataIndex: "description",
+      key: "description"
     },
     {
       title: "Pedido",
@@ -164,6 +164,7 @@ export const ChangeWarehouseModal: React.FC<Props> = ({
     }
   };
 
+  console.log("warehouseProductsStock", warehouseProductsStock);
   const renderView = () => {
     const viewMap = {
       "change-warehouse": (

--- a/src/components/molecules/modals/ChangeWarehouseModal/ChangeWarehouseModal.tsx
+++ b/src/components/molecules/modals/ChangeWarehouseModal/ChangeWarehouseModal.tsx
@@ -164,7 +164,6 @@ export const ChangeWarehouseModal: React.FC<Props> = ({
     }
   };
 
-  console.log("warehouseProductsStock", warehouseProductsStock);
   const renderView = () => {
     const viewMap = {
       "change-warehouse": (

--- a/src/hooks/useBankPayments.ts
+++ b/src/hooks/useBankPayments.ts
@@ -28,7 +28,10 @@ export const useBankPayments = ({ like, selectedFilters }: Props) => {
 
   const pathKey = `/bank/get-payments?project_id=${projectId}${likeQuery}${startDateQuery}${endDateQuery}${statusQuery}`;
 
-  const { data, error, mutate } = useSWR<GenericResponse<IPaymentsByStatus[]>>(pathKey, fetcher);
+  const { data, error, mutate } = useSWR<GenericResponse<IPaymentsByStatus[]>>(pathKey, fetcher, {
+    revalidateOnFocus: true,
+    revalidateOnReconnect: false
+  });
 
   return {
     data: data?.data,

--- a/src/modules/commerce/hooks/orders-view/useOrders.ts
+++ b/src/modules/commerce/hooks/orders-view/useOrders.ts
@@ -22,7 +22,7 @@ export const useOrders = ({ selectedFilters }: UseOrdersProps) => {
   const pathKey = `/marketplace/projects/${projectId}/orders${sellersQuery}`;
 
   const { data, error, mutate } = useSWR<GenericResponse<IOrderData[]>>(pathKey, fetcher, {
-    revalidateOnFocus: false,
+    revalidateOnFocus: true,
     revalidateOnReconnect: false
   });
 


### PR DESCRIPTION
This pull request introduces a few targeted updates to improve data presentation in the UI, enhance debugging, and adjust data fetching strategies for better user experience. The most notable changes involve modifying table columns in the warehouse modal, tweaking SWR fetcher options in hooks, and adding a console log for debugging.

**UI Improvements:**
- Changed the "Producto" column in the `ChangeWarehouseModal` table to display the product `description` instead of the `sku`, making the product information more user-friendly.

**Data Fetching Behavior:**
- Updated the `useBankPayments` hook to enable `revalidateOnFocus` and disable `revalidateOnReconnect` in SWR, ensuring data is refreshed when the window regains focus but not on network reconnect.
- Modified the `useOrders` hook to enable `revalidateOnFocus` in SWR, so order data is refreshed when the window regains focus.