### PR TITLE
hotfix: update client link to use client_uuid instead of client_id

### DIFF
--- a/src/components/organisms/Customers/ClientsViewTable/ClientsViewTable.tsx
+++ b/src/components/organisms/Customers/ClientsViewTable/ClientsViewTable.tsx
@@ -252,7 +252,7 @@ export const ClientsViewTable = () => {
       width: 64,
       dataIndex: "",
       render: (_, row: IClientsPortfolio) => (
-        <Link href={`/clientes/detail/${row.client_id}/project/${row.project_id}`}>
+        <Link href={`/clientes/detail/${row.client_uuid}/project/${row.project_id}`}>
           <Button
             key={row.client_id}
             onClick={() => {


### PR DESCRIPTION
This pull request makes a small update to the `ClientsViewTable` component to ensure the correct client identifier is used in the client detail link. The change replaces the use of `client_id` with `client_uuid` in the URL path.