### PR TITLE
merge staging into main

### DIFF
--- a/src/components/molecules/modals/ModalGenerateAction/ModalGenerateAction.tsx
+++ b/src/components/molecules/modals/ModalGenerateAction/ModalGenerateAction.tsx
@@ -15,7 +15,8 @@ import {
   Paperclip,
   Link,
   Invoice,
-  PencilLine
+  PencilLine,
+  FileMinus
 } from "@phosphor-icons/react";
 
 import { ButtonGenerateAction } from "@/components/atoms/ButtonGenerateAction/ButtonGenerateAction";
@@ -38,6 +39,7 @@ interface Props {
   setSelectOpen: Dispatch<SetStateAction<{ selected: number }>>;
   addInvoicesToApplicationTable: () => void;
   balanceLegalization?: () => void;
+  markAsBalance: () => void;
 }
 
 export const ModalGenerateAction = ({
@@ -48,7 +50,8 @@ export const ModalGenerateAction = ({
   setShowActionDetailModal,
   setSelectOpen,
   addInvoicesToApplicationTable,
-  balanceLegalization
+  balanceLegalization,
+  markAsBalance
 }: Props) => {
   const router = useRouter();
   const handleActionDetail = (type: number) => {
@@ -167,6 +170,15 @@ export const ModalGenerateAction = ({
           title="Ingresar gestión"
           onClick={() => {
             handleOpenModal(9);
+          }}
+        />
+        <ButtonGenerateAction
+          icon={<FileMinus size={16} />}
+          title="Marcar como saldo"
+          onClick={() => {
+            if (validateInvoiceIsSelected()) {
+              markAsBalance();
+            }
           }}
         />
       </Flex>

--- a/src/components/organisms/Customers/WalletTab/WalletTab.tsx
+++ b/src/components/organisms/Customers/WalletTab/WalletTab.tsx
@@ -6,6 +6,7 @@ import { AxiosError } from "axios";
 
 import { extractSingleParam } from "@/utils/utils";
 import { addItemsToTable } from "@/services/applyTabClients/applyTabClients";
+import { markInvoiceAsBalance } from "@/services/accountingAdjustment/accountingAdjustment";
 import { useApplicationTable } from "@/hooks/useApplicationTable";
 import { useInvoices } from "@/hooks/useInvoices";
 import { useDebounce } from "@/hooks/useDeabouce";
@@ -178,6 +179,21 @@ export const WalletTab = () => {
     }
   };
 
+  const handleMarkAsBalance = async () => {
+    try {
+      await markInvoiceAsBalance(
+        projectId,
+        clientId,
+        selectedRows?.map((invoice) => invoice.id) || []
+      );
+      messageShow.success("La(s) factura(s) se han marcado como saldo correctamente");
+    } catch (error) {
+      messageShow.error("Error al marcar la(s) factura(s) como saldo");
+    }
+    setisGenerateActionOpen(false);
+    closeAllModal();
+  };
+
   return (
     <>
       {contextHolder}
@@ -253,6 +269,7 @@ export const WalletTab = () => {
         validateInvoiceIsSelected={validateInvoiceIsSelected}
         addInvoicesToApplicationTable={handleAddSelectedInvoicesToApplicationTable}
         balanceLegalization={handleOpenBalanceLegalization}
+        markAsBalance={handleMarkAsBalance}
       />
       <PaymentAgreementModal
         invoiceSelected={selectedRows}

--- a/src/services/accountingAdjustment/accountingAdjustment.ts
+++ b/src/services/accountingAdjustment/accountingAdjustment.ts
@@ -373,3 +373,22 @@ export const addCommentHistoricAction = async (
     throw error;
   }
 };
+
+export const markInvoiceAsBalance = async (
+  projectId: number,
+  clientUUID: string,
+  invoices: number[]
+): Promise<GenericResponse> => {
+  const body = new FormData();
+  body.append("invoice_ids", JSON.stringify(invoices));
+  try {
+    const response: GenericResponse = await API.post(
+      `${config.API_HOST}/invoice/project/${projectId}/client/${clientUUID}/set_residue`,
+      body
+    );
+    return response;
+  } catch (error) {
+    console.error("Error marking invoice as balance", error);
+    throw error;
+  }
+};


### PR DESCRIPTION
This pull request adds a new feature allowing users to mark invoices as "balance" directly from the UI. The main changes include introducing a new button in the modal, implementing the backend call to perform the action, and wiring the new functionality through the relevant components.

**Feature: Mark Invoices as Balance**

* Added a new `markAsBalance` prop and handler to the `ModalGenerateAction` component, along with a button that triggers the action when clicked. (`src/components/molecules/modals/ModalGenerateAction.tsx`) [[1]](diffhunk://#diff-ca004d0fdaf557d04524af82ce518c596fd8141b72c05ab93adac74cc26b6847R42) [[2]](diffhunk://#diff-ca004d0fdaf557d04524af82ce518c596fd8141b72c05ab93adac74cc26b6847L51-R54) [[3]](diffhunk://#diff-ca004d0fdaf557d04524af82ce518c596fd8141b72c05ab93adac74cc26b6847R175-R183)
* Integrated the new `markAsBalance` handler into the `WalletTab` component, ensuring selected invoices can be marked as balance and providing user feedback on success or failure. (`src/components/organisms/Customers/WalletTab/WalletTab.tsx`) [[1]](diffhunk://#diff-da5f45cf009cf70d50201ca3b24bfe534196942ffa7e616df71a5ad7dac1857bR182-R196) [[2]](diffhunk://#diff-da5f45cf009cf70d50201ca3b24bfe534196942ffa7e616df71a5ad7dac1857bR272)

**Backend Integration**

* Implemented the `markInvoiceAsBalance` service function to perform the API call for marking invoices as balance. (`src/services/accountingAdjustment/accountingAdjustment.ts`)
* Imported the new service function into the relevant component to enable the backend operation. (`src/components/organisms/Customers/WalletTab/WalletTab.tsx`)

**UI Enhancement**

* Added the `FileMinus` icon to the modal action button to visually distinguish the new "Mark as Balance" feature. (`src/components/molecules/modals/ModalGenerateAction.tsx`)