### PR TITLE
Feat/add new column orders

### DIFF
--- a/src/modules/commerce/components/orders-view-table/orders-view-table.tsx
+++ b/src/modules/commerce/components/orders-view-table/orders-view-table.tsx
@@ -5,7 +5,7 @@ import { Eye } from "phosphor-react";
 import { WarningDiamond } from "@phosphor-icons/react";
 
 import { useAppStore } from "@/lib/store/store";
-import { formatDateDMY } from "@/utils/utils";
+import { formatDateDMY, formatTimeAgo } from "@/utils/utils";
 
 import OrderTrackingModal from "@/components/molecules/modals/OrderTrackingModal";
 import { ChangeWarehouseModal } from "@/components/molecules/modals/ChangeWarehouseModal/ChangeWarehouseModal";
@@ -156,6 +156,20 @@ const OrdersViewTable = ({
       key: "contacto",
       dataIndex: "contacto",
       render: (text) => <Text className="cell">{text}</Text>
+    },
+    {
+      title: "Tiempo transcurrido",
+      key: "last_datestamp",
+      dataIndex: "last_datestamp",
+      render: (date: string | null) => (
+        <Text className="cell">{`${date ? formatTimeAgo(date) : ""}`}</Text>
+      ),
+      sorter: (a, b) => {
+        const dateA = a.last_datestamp ? new Date(a.last_datestamp).getTime() : 0;
+        const dateB = b.last_datestamp ? new Date(b.last_datestamp).getTime() : 0;
+        return dateA - dateB;
+      },
+      showSorterTooltip: false
     },
     // TO DO: Uncomment when the status column is needed
     // {

--- a/src/types/commerce/ICommerce.ts
+++ b/src/types/commerce/ICommerce.ts
@@ -207,6 +207,7 @@ export interface IOrder {
   client_name: string;
   warehousename: string;
   warehouseid: number;
+  last_datestamp: string | null;
 }
 
 export interface IDiscount {


### PR DESCRIPTION
This pull request adds a new "Tiempo transcurrido" (Elapsed Time) column to the orders table, allowing users to see how much time has passed since the last datestamp for each order. The implementation includes updating the order type definition and utility imports to support this new feature.

**Orders Table Enhancements:**

* Added a "Tiempo transcurrido" column to the `OrdersViewTable` component, which displays the elapsed time since `last_datestamp` using the new `formatTimeAgo` utility. The column also supports sorting by the datestamp.
* Updated the import in `orders-view-table.tsx` to include `formatTimeAgo` from the utilities.

**Type Definition Update:**

* Added a new `last_datestamp` field to the `IOrder` interface in `ICommerce.ts` to support the new column.