### PR TITLE
Refactor HistoryTable component for improved readability and maintain…

### DIFF
--- a/src/modules/clients/components/history-tab/history-tab-table/history-tab-table.tsx
+++ b/src/modules/clients/components/history-tab/history-tab-table/history-tab-table.tsx
@@ -2,7 +2,7 @@ import { Dispatch, SetStateAction, useState } from "react";
 import { Button, Flex, Table, TableProps, Typography } from "antd";
 import { Eye, Triangle } from "phosphor-react";
 
-import { formatTimeAgo } from "@/utils/utils";
+import { formatDate } from "@/utils/utils";
 
 import useScreenHeight from "@/components/hooks/useScreenHeight";
 
@@ -45,7 +45,7 @@ const HistoryTable = ({
       title: "Fecha",
       dataIndex: "created_at",
       key: "created_at",
-      render: (created_at) => <Text className="cell">{`Hace ${formatTimeAgo(created_at)}`}</Text>,
+      render: (created_at) => <Text className="cell">{formatDate(created_at)}</Text>,
       sorter: (a, b) => a.created_at.localeCompare(b.created_at),
       showSorterTooltip: false
     },


### PR DESCRIPTION
…ability
This pull request updates the date formatting in the `HistoryTable` component to display dates using a standard date format instead of a relative "time ago" format.

Date formatting update:

* Replaced the use of `formatTimeAgo` with `formatDate` for the "Fecha" column in `history-tab-table.tsx`, so dates are now shown in a standard format rather than as relative times (e.g., "Hace 2 días"). [[1]](diffhunk://#diff-e3c558e14086fd674cf5d72cf05aa17612ccd02dc5333c69a94aa2af553944adL5-R5) [[2]](diffhunk://#diff-e3c558e14086fd674cf5d72cf05aa17612ccd02dc5333c69a94aa2af553944adL48-R48)