### PR TITLE
Fix column width for created_at in HistoryTable component

### DIFF
--- a/src/modules/clients/components/history-tab/history-tab-table/history-tab-table.tsx
+++ b/src/modules/clients/components/history-tab/history-tab-table/history-tab-table.tsx
@@ -47,7 +47,8 @@ const HistoryTable = ({
       key: "created_at",
       render: (created_at) => <Text className="cell">{formatDate(created_at)}</Text>,
       sorter: (a, b) => a.created_at.localeCompare(b.created_at),
-      showSorterTooltip: false
+      showSorterTooltip: false,
+      width: 120
     },
     {
       title: "Evento",


### PR DESCRIPTION
This pull request makes a minor adjustment to the `HistoryTable` component. The main change is setting a fixed width for the "created_at" column to improve the table's layout consistency.

- UI improvement:
  * Added a `width` property (120px) to the "created_at" column in `history-tab-table.tsx` for better column sizing.