### PR TITLE
Feat/add download excel history tab

### DIFF
--- a/src/modules/clients/components/history-tab/history-tab-table/history-tab-table.scss
+++ b/src/modules/clients/components/history-tab/history-tab-table/history-tab-table.scss
@@ -54,6 +54,21 @@
     .prev {
         transform: rotate(-90deg);
     }
+
+    .dotsBtn {
+        background-color: $background;
+        border: 1px solid transparent;
+        width: 24px;
+        height: 24px;
+        padding: 0;
+        border-radius: 4px;
+        margin-left: 1rem;
+
+        &:hover {
+            border: 1px solid $black;
+            background-color: $background !important;
+        }
+    }
 }
 
 .tooltipHistoryOptions {

--- a/src/modules/clients/components/history-tab/history-tab-table/history-tab-table.tsx
+++ b/src/modules/clients/components/history-tab/history-tab-table/history-tab-table.tsx
@@ -17,7 +17,7 @@ interface PropsHistoryTable {
   dataAllRecords?: IHistoryRow[];
   setSelectedRows: Dispatch<SetStateAction<IHistoryRow[] | undefined>>;
   // eslint-disable-next-line no-unused-vars
-  handleOpenDetail: (row: IHistoryRow) => void;
+  handleOpenDetail: (row: IHistoryRow, url: string | null) => void;
 }
 
 const HistoryTable = ({
@@ -86,7 +86,7 @@ const HistoryTable = ({
                 icon={<FileXls size={20} />}
                 className="buttonNoBorder"
                 onClick={() => {
-                  handleOpenDetail(row);
+                  handleOpenDetail(row, row.payment_identification_excel_url);
                 }}
               >
                 Descargar plano
@@ -100,7 +100,7 @@ const HistoryTable = ({
                 icon={<FileText size={20} />}
                 className="buttonNoBorder"
                 onClick={() => {
-                  handleOpenDetail(row);
+                  handleOpenDetail(row, row.payment_identification_url);
                 }}
               >
                 Ver pdf

--- a/src/modules/clients/components/history-tab/history-tab-table/history-tab-table.tsx
+++ b/src/modules/clients/components/history-tab/history-tab-table/history-tab-table.tsx
@@ -1,5 +1,5 @@
-import { Dispatch, SetStateAction, useState } from "react";
-import { Button, Flex, Table, TableProps, Typography } from "antd";
+import { Dispatch, ReactNode, SetStateAction, useState } from "react";
+import { Button, Dropdown, Flex, Table, TableProps, Typography } from "antd";
 import { Eye, Triangle } from "phosphor-react";
 
 import { formatDate } from "@/utils/utils";
@@ -9,6 +9,7 @@ import useScreenHeight from "@/components/hooks/useScreenHeight";
 import { IHistoryRow } from "@/types/clientHistory/IClientHistory";
 
 import "./history-tab-table.scss";
+import { DotsThreeVertical, FileText, FileXls } from "@phosphor-icons/react";
 
 const { Text } = Typography;
 
@@ -75,17 +76,56 @@ const HistoryTable = ({
       showSorterTooltip: false
     },
     {
-      title: "",
-      render: (_, row) => (
-        <Flex gap="0.5rem">
-          <Button
-            className="eyeButton"
-            onClick={() => handleOpenDetail(row)}
-            icon={<Eye size={"1.2rem"} />}
-          />
-        </Flex>
-      ),
-      width: 65
+      width: 76,
+      render: (_, row) => {
+        const items = [
+          {
+            key: "1",
+            label: (
+              <Button
+                icon={<FileXls size={20} />}
+                className="buttonNoBorder"
+                onClick={() => {
+                  handleOpenDetail(row);
+                }}
+              >
+                Descargar plano
+              </Button>
+            )
+          },
+          {
+            key: "2",
+            label: (
+              <Button
+                icon={<FileText size={20} />}
+                className="buttonNoBorder"
+                onClick={() => {
+                  handleOpenDetail(row);
+                }}
+              >
+                Ver pdf
+              </Button>
+            )
+          }
+        ];
+
+        const customDropdown = (menu: ReactNode) => (
+          <div className="dropdownApplicationTable">{menu}</div>
+        );
+
+        return (
+          <Dropdown
+            dropdownRender={customDropdown}
+            menu={{ items }}
+            placement="bottomLeft"
+            trigger={["click"]}
+          >
+            <Button className="dotsBtn">
+              <DotsThreeVertical size={16} />
+            </Button>
+          </Dropdown>
+        );
+      }
     }
   ];
 

--- a/src/modules/clients/containers/history-tab/history-tab.tsx
+++ b/src/modules/clients/containers/history-tab/history-tab.tsx
@@ -35,12 +35,12 @@ const HistoryTab = () => {
     setOpenModal({ selected: 0 });
   };
 
-  const handleOpenDetail = (row: IHistoryRow) => {
-    if (row.payment_identification_url && row.payment_identification_url !== null) {
-      window.open(row.payment_identification_url, "_blank");
+  const handleOpenDetail = (row: IHistoryRow, url: string | null) => {
+    if (url && url !== null) {
+      window.open(url, "_blank");
       return;
     }
-    if (!row.id_mongo_log) return showMessage("info", "No hay detalle para esta comunicación");
+    if (!row.id_mongo_log) return showMessage("info", "No hay detalle de esta comunicación");
     setRowDetailID(row.id_mongo_log);
     setOpenModal({ selected: 3 });
   };

--- a/src/types/clientHistory/IClientHistory.ts
+++ b/src/types/clientHistory/IClientHistory.ts
@@ -11,6 +11,7 @@ export interface IHistoryRow {
   id_mongo_log: string | null;
   user_name: string;
   payment_identification_url: string | null;
+  payment_identification_excel_url: string | null;
 }
 
 export interface IHistoryCommunicationDetail {


### PR DESCRIPTION
<img width="1161" height="695" alt="image" src="https://github.com/user-attachments/assets/79ea8915-1bdd-4042-9061-85e6c9ea3187" />

This pull request updates the client history table to improve user experience and add new functionality for downloading Excel files and viewing PDFs directly from the table. The main changes include adding a dropdown menu with new action buttons for each row, updating the handler logic to support both Excel and PDF actions, and extending the data model to include the Excel URL.

**UI/UX Improvements:**
- Replaced the single "eye" button in the history table with a dropdown menu (`Dropdown` component) that presents two options: "Descargar plano" (download Excel) and "Ver pdf" (view PDF), each with a corresponding icon. The dropdown is triggered by a new three-dots button for better clarity and usability.
- Added new styles for the three-dots action button (`dotsBtn`) to match the application's look and feel.

**Functionality Enhancements:**
- Updated the `handleOpenDetail` function to accept both the row and a URL, allowing it to handle different actions (opening Excel or PDF links in a new tab). The function now also displays an info message if there is no detail available.
- Modified the `IHistoryRow` interface to include a new `payment_identification_excel_url` property, enabling the download of Excel files from the dropdown.

**Codebase Updates:**
- Updated imports to include new icons and Ant Design components required for the dropdown and action buttons. [[1]](diffhunk://#diff-e3c558e14086fd674cf5d72cf05aa17612ccd02dc5333c69a94aa2af553944adL1-R2) [[2]](diffhunk://#diff-e3c558e14086fd674cf5d72cf05aa17612ccd02dc5333c69a94aa2af553944adR12-R20)