### PR TITLE
Feat/add change cashport ai prompt apply tab

### DIFF
--- a/src/modules/clients/containers/apply-tab/Modals/ModalChangeAIPrompt/ModalChangeAIPrompt.tsx
+++ b/src/modules/clients/containers/apply-tab/Modals/ModalChangeAIPrompt/ModalChangeAIPrompt.tsx
@@ -1,0 +1,85 @@
+"use client";
+import { useState } from "react";
+import { Button, Flex, Modal, Typography } from "antd";
+import { Sparkle } from "@phosphor-icons/react";
+
+import "./modalChangeAIPrompt.scss";
+const { Title } = Typography;
+
+interface Props {
+  isOpen: boolean;
+  onClose: () => void;
+}
+
+export const ModalChangeAIPrompt = ({ isOpen, onClose }: Props) => {
+  const [isEditing, setIsEditing] = useState(false);
+  const [availableTags] = useState([
+    { id: "tag1", content: "IMPORTANTE" },
+    { id: "tag2", content: "URGENTE" },
+    { id: "tag3", content: "REVISAR" },
+    { id: "tag4", content: "NOTA" }
+  ]);
+  return (
+    <Modal
+      className="modalChangeAIPrompt"
+      open={isOpen}
+      centered
+      title={
+        <Title className="modalChangeAIPrompt__title" level={4}>
+          Promtp de cliente para{" "}
+          <span
+            className="cashportIATextGradient"
+            style={{
+              fontWeight: 500
+            }}
+          >
+            CashportAI
+          </span>
+        </Title>
+      }
+      footer={null}
+      onCancel={onClose}
+      width={660}
+    >
+      <Flex vertical gap={"24px"}>
+        <p className="modalChangeAIPrompt__description">
+          Si el cliente tiene condiciones especiales y CashportAI los tendré en cuenta en el proceso
+          para la extracción de data
+        </p>
+
+        <textarea name="" id=""></textarea>
+
+        <Flex gap={"12px"} align="center">
+          <p>Tags:</p>
+          <Flex gap={"5px"} wrap>
+            {availableTags.map((tag) => (
+              <span key={tag.id} className="modalChangeAIPrompt__tag">
+                {tag.content}
+              </span>
+            ))}
+          </Flex>
+        </Flex>
+
+        <div className="modalChangeAIPrompt__footer">
+          <Button className="cancelButton" onClick={() => setIsEditing(!isEditing)}>
+            Editar
+          </Button>
+          <Button className="iaButton">
+            <Sparkle size={14} color="#5b21b6" weight="fill" />
+            <span className="textNormal">
+              Guardar{" "}
+              <span
+                className="cashportIATextGradient"
+                style={{
+                  fontWeight: 500
+                }}
+              >
+                CashportAI
+              </span>
+            </span>
+          </Button>
+        </div>
+      </Flex>
+    </Modal>
+  );
+};

--- a/src/modules/clients/containers/apply-tab/Modals/ModalChangeAIPrompt/ModalChangeAIPrompt.tsx
+++ b/src/modules/clients/containers/apply-tab/Modals/ModalChangeAIPrompt/ModalChangeAIPrompt.tsx
@@ -38,7 +38,7 @@ export const ModalChangeAIPrompt = ({ isOpen, onClose }: Props) => {
         try {
           const response = await getPromptByClientAndAITask(projectId, clientId, 1);
 
-          if (response.status === 404) {
+          if (response.data === null) {
             setNotFound(true);
             message.info("No se encontró un prompt para este cliente, por favor crea uno.");
             return;

--- a/src/modules/clients/containers/apply-tab/Modals/ModalChangeAIPrompt/ModalChangeAIPrompt.tsx
+++ b/src/modules/clients/containers/apply-tab/Modals/ModalChangeAIPrompt/ModalChangeAIPrompt.tsx
@@ -1,7 +1,15 @@
 "use client";
-import { useState } from "react";
-import { Button, Flex, Modal, Typography } from "antd";
+import { useEffect, useState } from "react";
+import { useParams } from "next/navigation";
+import { Button, Flex, message, Modal, Typography } from "antd";
 import { Sparkle } from "@phosphor-icons/react";
+
+import {
+  createPrompt,
+  getPromptByClientAndAITask
+} from "@/services/applyTabClients/applyTabClients";
+import { useAppStore } from "@/lib/store/store";
+import { extractSingleParam } from "@/utils/utils";
 
 import "./modalChangeAIPrompt.scss";
 const { Title } = Typography;
@@ -13,12 +21,53 @@ interface Props {
 
 export const ModalChangeAIPrompt = ({ isOpen, onClose }: Props) => {
   const [isEditing, setIsEditing] = useState(false);
-  const [availableTags] = useState([
-    { id: "tag1", content: "IMPORTANTE" },
-    { id: "tag2", content: "URGENTE" },
-    { id: "tag3", content: "REVISAR" },
-    { id: "tag4", content: "NOTA" }
-  ]);
+  const [prompt, setPrompt] = useState("");
+  const [notFound, setNotFound] = useState(false);
+
+  const { ID: projectId } = useAppStore((state) => state.selectedProject);
+  const params = useParams();
+  const clientId = extractSingleParam(params.clientId) || "";
+
+  useEffect(() => {
+    if (isOpen) {
+      // 1 es aplicación de pagos
+      (async () => {
+        try {
+          const response = await getPromptByClientAndAITask(projectId, clientId, 1);
+
+          if (response.status === 404) {
+            setNotFound(true);
+            message.info("No se encontró un prompt para este cliente, por favor crea uno.");
+            return;
+          }
+          setPrompt(response?.data.prompt || "");
+        } catch (error) {
+          message.error("Error al obtener el prompt del cliente");
+        }
+      })();
+    }
+
+    return () => {
+      setIsEditing(false);
+      setPrompt("");
+      setNotFound(false);
+    };
+  }, [isOpen]);
+
+  const onSubmitPrompt = async () => {
+    // Si no existe el prompt entonces se crea
+    if (notFound) {
+      try {
+        await createPrompt(projectId, clientId, 1, prompt);
+        message.success("Prompt creado con éxito");
+      } catch (error) {
+        message.error("Error al crear el prompt");
+      }
+    } else {
+      // TO DO: Aca entonces lo editamos
+    }
+  };
+
   return (
     <Modal
       className="modalChangeAIPrompt"
@@ -40,31 +89,37 @@ export const ModalChangeAIPrompt = ({ isOpen, onClose }: Props) => {
       footer={null}
       onCancel={onClose}
       width={660}
+      destroyOnClose
     >
       <Flex vertical gap={"24px"}>
         <p className="modalChangeAIPrompt__description">
-          Si el cliente tiene condiciones especiales y CashportAI los tendré en cuenta en el proceso
-          para la extracción de data
+          Si el cliente tiene condiciones especiales{" "}
+          <span
+            className="cashportIATextGradient"
+            style={{
+              fontWeight: 500
+            }}
+          >
+            CashportAI
+          </span>{" "}
+          los tendrá en cuenta en el proceso para la extracción de data
         </p>
 
-        <textarea name="" id=""></textarea>
-
-        <Flex gap={"12px"} align="center">
-          <p>Tags:</p>
-          <Flex gap={"5px"} wrap>
-            {availableTags.map((tag) => (
-              <span key={tag.id} className="modalChangeAIPrompt__tag">
-                {tag.content}
-              </span>
-            ))}
-          </Flex>
+        <Flex vertical>
+          <p className="modalChangeAIPrompt__label">Prompt</p>
+          <textarea
+            defaultValue={prompt}
+            className="modalChangeAIPrompt__textArea"
+            onChange={(e) => setPrompt(e.target.value)}
+            disabled={!isEditing}
+          />
         </Flex>
 
         <div className="modalChangeAIPrompt__footer">
           <Button className="cancelButton" onClick={() => setIsEditing(!isEditing)}>
             Editar
           </Button>
-          <Button className="iaButton">
+          <Button className="iaButton" onClick={onSubmitPrompt}>
             <Sparkle size={14} color="#5b21b6" weight="fill" />
             <span className="textNormal">
               Guardar{" "}

--- a/src/modules/clients/containers/apply-tab/Modals/ModalChangeAIPrompt/ModalChangeAIPrompt.tsx
+++ b/src/modules/clients/containers/apply-tab/Modals/ModalChangeAIPrompt/ModalChangeAIPrompt.tsx
@@ -6,7 +6,9 @@ import { Sparkle } from "@phosphor-icons/react";
 
 import {
   createPrompt,
-  getPromptByClientAndAITask
+  getPromptByClientAndAITask,
+  IPrompt,
+  updatePrompt
 } from "@/services/applyTabClients/applyTabClients";
 import { useAppStore } from "@/lib/store/store";
 import { extractSingleParam } from "@/utils/utils";
@@ -22,6 +24,7 @@ interface Props {
 export const ModalChangeAIPrompt = ({ isOpen, onClose }: Props) => {
   const [isEditing, setIsEditing] = useState(false);
   const [prompt, setPrompt] = useState("");
+  const [promptData, setPromptData] = useState<IPrompt>();
   const [notFound, setNotFound] = useState(false);
 
   const { ID: projectId } = useAppStore((state) => state.selectedProject);
@@ -41,6 +44,7 @@ export const ModalChangeAIPrompt = ({ isOpen, onClose }: Props) => {
             return;
           }
           setPrompt(response?.data.prompt || "");
+          setPromptData(response?.data);
         } catch (error) {
           message.error("Error al obtener el prompt del cliente");
         }
@@ -65,6 +69,7 @@ export const ModalChangeAIPrompt = ({ isOpen, onClose }: Props) => {
       }
     } else {
       // TO DO: Aca entonces lo editamos
+      await updatePrompt(promptData?.id || 0, prompt, "USERTEST");
     }
   };
 

--- a/src/modules/clients/containers/apply-tab/Modals/ModalChangeAIPrompt/ModalChangeAIPrompt.tsx
+++ b/src/modules/clients/containers/apply-tab/Modals/ModalChangeAIPrompt/ModalChangeAIPrompt.tsx
@@ -3,6 +3,7 @@ import { useEffect, useState } from "react";
 import { useParams } from "next/navigation";
 import { Button, Flex, message, Modal, Skeleton, Typography } from "antd";
 import { Sparkle } from "@phosphor-icons/react";
+import { auth } from "../../../../../../../firebase";
 
 import {
   createPrompt,
@@ -78,7 +79,8 @@ export const ModalChangeAIPrompt = ({ isOpen, onClose }: Props) => {
       }
     } else {
       try {
-        await updatePrompt(promptData?.id || 0, prompt, "USERTEST");
+        const currentUserEmail = auth.currentUser?.email || "";
+        await updatePrompt(promptData?.id || 0, prompt, currentUserEmail);
         message.success("Prompt actualizado con éxito");
         onClose();
       } catch (error) {

--- a/src/modules/clients/containers/apply-tab/Modals/ModalChangeAIPrompt/modalChangeAIPrompt.scss
+++ b/src/modules/clients/containers/apply-tab/Modals/ModalChangeAIPrompt/modalChangeAIPrompt.scss
@@ -25,6 +25,24 @@
         font-weight: 300;
     }
 
+    &__label {
+        font-size: 0.75rem;
+        font-weight: 600;
+        color: $gray;
+        margin-top: -16px;
+    }
+
+    &__textArea {
+        background-color: $background;
+        border-radius: 8px;
+        padding: 1rem;
+        min-height: 100px;
+        resize: none;
+        font-family: inherit;
+        font-size: 0.875rem;
+        font-weight: 300;
+    }
+
     &__footer {
         display: flex;
         justify-content: flex-end;

--- a/src/modules/clients/containers/apply-tab/Modals/ModalChangeAIPrompt/modalChangeAIPrompt.scss
+++ b/src/modules/clients/containers/apply-tab/Modals/ModalChangeAIPrompt/modalChangeAIPrompt.scss
@@ -1,0 +1,73 @@
+@import "@/styles/variables.scss";
+
+.modalChangeAIPrompt {
+    max-height: 90%;
+    .ant-modal-content {
+        padding: 1.5rem !important;
+
+        .ant-modal-close {
+            margin: 0rem;
+        }
+    }
+
+    .ant-modal-body {
+        display: flex;
+        flex-direction: column;
+        gap: 1rem;
+    }
+
+    &__title {
+        font-size: 1.25rem;
+        font-weight: 600;
+    }
+
+    &__description {
+        font-weight: 300;
+    }
+
+    &__footer {
+        display: flex;
+        justify-content: flex-end;
+        gap: 1rem;
+
+        .iaButton {
+            border-radius: 42px;
+            height: 42px;
+            background-color: $light-blue;
+            border-color: #f0e7ff !important;
+            padding: 0 16px;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            gap: 8px;
+
+            &:hover {
+                background-color: $light-blue !important;
+                border-color: #af90e0 !important;
+            }
+
+            .textNormal {
+                font-size: 0.875rem;
+                font-weight: 400;
+                color: #5b21b6;
+                line-height: 16px;
+                pointer-events: none;
+            }
+        }
+
+        .cancelButton {
+            background-color: transparent;
+            color: $darker-gray;
+            height: 42px;
+            border: none;
+            box-shadow: none;
+            font-size: 1rem;
+            font-weight: 500;
+
+            &:hover {
+                background-color: transparent !important;
+                color: $black !important;
+            }
+        }
+    }
+}

--- a/src/modules/clients/containers/apply-tab/Modals/ModalChangeAIPrompt/modalChangeAIPrompt.scss
+++ b/src/modules/clients/containers/apply-tab/Modals/ModalChangeAIPrompt/modalChangeAIPrompt.scss
@@ -41,6 +41,7 @@
         font-family: inherit;
         font-size: 0.875rem;
         font-weight: 300;
+        scrollbar-width: thin;
     }
 
     &__footer {

--- a/src/modules/clients/containers/apply-tab/Modals/ModalGenerateActionApplyTab/ModalGenerateActionApplyTab.tsx
+++ b/src/modules/clients/containers/apply-tab/Modals/ModalGenerateActionApplyTab/ModalGenerateActionApplyTab.tsx
@@ -1,6 +1,6 @@
 "use client";
 import { Flex, message, Modal, Typography } from "antd";
-import { DownloadSimple, Pencil, Trash } from "@phosphor-icons/react";
+import { DownloadSimple, Pencil, Robot, Trash } from "@phosphor-icons/react";
 import { ButtonGenerateAction } from "@/components/atoms/ButtonGenerateAction/ButtonGenerateAction";
 import { IApplyTabRecord } from "@/types/applyTabClients/IApplyTabClients";
 
@@ -74,6 +74,13 @@ export const ModalGenerateActionApplyTab = ({
           }}
           icon={<Pencil size={20} />}
           title="Editar ajustes"
+        />
+        <ButtonGenerateAction
+          onClick={() => {
+            handleOpenModal(7);
+          }}
+          icon={<Robot size={20} />}
+          title="Cambiar Prompt CahsportAI"
         />
       </Flex>
     </Modal>

--- a/src/modules/clients/containers/apply-tab/apply-tab.tsx
+++ b/src/modules/clients/containers/apply-tab/apply-tab.tsx
@@ -35,6 +35,7 @@ import ModalApplyAI from "./Modals/ModalApplyAI/ModalApplyAI";
 import { ModalGenerateActionApplyTab } from "./Modals/ModalGenerateActionApplyTab/ModalGenerateActionApplyTab";
 import { ModalConfirmAction } from "@/components/molecules/modals/ModalConfirmAction/ModalConfirmAction";
 import ModalEditAdjustments from "../accounting-adjustments-tab/Modals/ModalEditAdjustments/ModalEditAdjustments";
+import { ModalChangeAIPrompt } from "./Modals/ModalChangeAIPrompt/ModalChangeAIPrompt";
 
 import { IApplyTabRecord } from "@/types/applyTabClients/IApplyTabClients";
 
@@ -688,6 +689,10 @@ const ApplyTab: React.FC = () => {
         title={`¿Está seguro de eliminar todo?`}
         okText="Eliminar"
         okLoading={loadingRequest}
+      />
+      <ModalChangeAIPrompt
+        isOpen={isModalOpen.selected === 7}
+        onClose={() => setIsModalOpen({ selected: 0 })}
       />
     </>
   );

--- a/src/services/applyTabClients/applyTabClients.ts
+++ b/src/services/applyTabClients/applyTabClients.ts
@@ -316,12 +316,15 @@ export const createPrompt = async (
   prompt: string
 ) => {
   try {
-    const response: GenericResponse<any> = await API.post(`${config.API_HOST}/prompt/create`, {
-      id_project: projectId,
-      clientUUID: clientUUID,
-      id_ai_type_task: aiTypeTaskId,
-      prompt: prompt
-    });
+    const response: GenericResponse<any> = await API.post(
+      `${config.API_HOST}/prompt/create-client-prompt`,
+      {
+        id_project: projectId,
+        clientUUID: clientUUID,
+        id_ai_type_task: aiTypeTaskId,
+        prompt: prompt
+      }
+    );
     return response.data;
   } catch (error) {
     console.error("error createPrompt", error);

--- a/src/services/applyTabClients/applyTabClients.ts
+++ b/src/services/applyTabClients/applyTabClients.ts
@@ -281,15 +281,15 @@ export const uploadPaymentAttachment = async (
 ) => {
   try {
     const formData = new FormData();
-    formData.append('project_id', String(projectId));
-    formData.append('client_id', clientId);
+    formData.append("project_id", String(projectId));
+    formData.append("client_id", clientId);
 
     files.forEach((file) => {
-      formData.append('files', file);
+      formData.append("files", file);
     });
 
     if (comment) {
-      formData.append('comments', comment);
+      formData.append("comments", comment);
     }
 
     const response: GenericResponse<any> = await API.post(
@@ -297,15 +297,65 @@ export const uploadPaymentAttachment = async (
       formData,
       {
         headers: {
-          'Content-Type': 'multipart/form-data',
-        },
+          "Content-Type": "multipart/form-data"
+        }
       }
     );
 
     return response;
   } catch (error) {
-    console.error('Error in uploadPaymentAttachment:', error);
+    console.error("Error in uploadPaymentAttachment:", error);
     throw error;
   }
 };
 
+export const createPrompt = async (
+  projectId: number,
+  clientUUID: string,
+  aiTypeTaskId: number,
+  prompt: string
+) => {
+  try {
+    const response: GenericResponse<any> = await API.post(`${config.API_HOST}/prompt/create`, {
+      id_project: projectId,
+      clientUUID: clientUUID,
+      id_ai_type_task: aiTypeTaskId,
+      prompt: prompt
+    });
+    return response.data;
+  } catch (error) {
+    console.error("error createPrompt", error);
+    throw error;
+  }
+};
+
+export interface IPrompt {
+  id: number;
+  id_project: number;
+  id_client: string;
+  id_ai_type_task: number;
+  prompt: string;
+  created_at: string;
+  updated_at: string;
+}
+
+export const getPromptByClientAndAITask = async (
+  projectId: number,
+  clientUUID: string,
+  aiTypeTaskId: number
+) => {
+  try {
+    const response: GenericResponse<IPrompt> = await API.post(
+      `${config.API_HOST}/prompt/get-by-criteria`,
+      {
+        id_project: projectId,
+        clientUUID: clientUUID,
+        id_ai_type_task: aiTypeTaskId
+      }
+    );
+    return response;
+  } catch (error) {
+    console.error("error getPromptByCriteria", error);
+    throw error;
+  }
+};

--- a/src/services/applyTabClients/applyTabClients.ts
+++ b/src/services/applyTabClients/applyTabClients.ts
@@ -359,3 +359,18 @@ export const getPromptByClientAndAITask = async (
     throw error;
   }
 };
+
+export const updatePrompt = async (id: number, prompt: string, updatedBy: string) => {
+  try {
+    const response: GenericResponse<any> = await API.put(`${config.API_HOST}/prompt/update-by-id`, {
+      id: id,
+      prompt: prompt,
+      updated_by: updatedBy
+    });
+
+    return response.data;
+  } catch (error) {
+    console.error("error updatePrompt", error);
+    throw error;
+  }
+};


### PR DESCRIPTION
<img width="870" height="630" alt="image" src="https://github.com/user-attachments/assets/0f39dbbd-c216-4a31-99f9-ce7717b0777d" />
<img width="870" height="630" alt="image" src="https://github.com/user-attachments/assets/52914f0d-e642-4011-904d-276b75ae5c93" />
This pull request introduces a new feature that allows users to view, create, and update custom AI prompts for clients within the Apply Tab. The changes include a new modal for managing prompts, integration of this modal into the Apply Tab workflow, and supporting backend service methods for prompt management. Additionally, UI improvements and minor code cleanups are included.

**Feature: Client AI Prompt Management**
* Added `ModalChangeAIPrompt` component, enabling users to view, edit, create, and update the AI prompt associated with a client for CashportAI. The modal includes loading states, error handling, and a user-friendly interface. (`src/modules/clients/containers/apply-tab/Modals/ModalChangeAIPrompt/ModalChangeAIPrompt.tsx`, [src/modules/clients/containers/apply-tab/Modals/ModalChangeAIPrompt/ModalChangeAIPrompt.tsxR1-R171](diffhunk://#diff-b05b796673a667d0bc4e59b9eababa1c3dab3dec5c770371528a81a58cc2ed8aR1-R171))
* Created a corresponding SCSS file for the modal, ensuring consistent styling and user experience. (`src/modules/clients/containers/apply-tab/Modals/ModalChangeAIPrompt/modalChangeAIPrompt.scss`, [src/modules/clients/containers/apply-tab/Modals/ModalChangeAIPrompt/modalChangeAIPrompt.scssR1-R92](diffhunk://#diff-63b2bcac78453cff7e3e90081d9c67f49dfc49db4e776bd9173aebc02788c033R1-R92))
* Integrated the modal into the Apply Tab by adding it to the main component and updating modal selection logic. (`src/modules/clients/containers/apply-tab/apply-tab.tsx`, [[1]](diffhunk://#diff-783ab654e6b1029e83918ef67351ca29faaefef8709bda898a5ab3aee63eef72R38) [[2]](diffhunk://#diff-783ab654e6b1029e83918ef67351ca29faaefef8709bda898a5ab3aee63eef72R693-R696)
* Added a new button to the "Generate Action" modal to access the AI prompt modal, improving discoverability for users. (`src/modules/clients/containers/apply-tab/Modals/ModalGenerateActionApplyTab/ModalGenerateActionApplyTab.tsx`, [[1]](diffhunk://#diff-d76a3f4fd6577f991d0d0ef6f70d9450a9499c9c0cc9a201bd911b2dc13f4632L3-R3) [[2]](diffhunk://#diff-d76a3f4fd6577f991d0d0ef6f70d9450a9499c9c0cc9a201bd911b2dc13f4632R78-R84)

**Backend Service Enhancements**
* Implemented new service methods: `createPrompt`, `getPromptByClientAndAITask`, and `updatePrompt` in `applyTabClients.ts`, with a new `IPrompt` interface for type safety. These methods handle API interactions for prompt CRUD operations. (`src/services/applyTabClients/applyTabClients.ts`, [src/services/applyTabClients/applyTabClients.tsL284-R379](diffhunk://#diff-ee704b790fa4d1bb68085df83ea60c0204116e3a9d1ede2fc061bce08455c41eL284-R379))

These changes collectively provide a robust workflow for managing client-specific AI prompts, improving customization and flexibility for users interacting with CashportAI.