### PR TITLE
Add confirmation modal for purchases below $1,500,000 in CreateOrderCart

### DIFF
--- a/src/modules/commerce/components/create-order-cart/create-order-cart.tsx
+++ b/src/modules/commerce/components/create-order-cart/create-order-cart.tsx
@@ -10,6 +10,7 @@ import { OrderViewContext } from "../../containers/create-order/create-order";
 import CreateOrderItem from "../create-order-cart-item";
 import PrincipalButton from "@/components/atoms/buttons/principalButton/PrincipalButton";
 import CreateOrderDiscountsModal from "../create-order-discounts-modal";
+import { ModalConfirmAction } from "@/components/molecules/modals/ModalConfirmAction/ModalConfirmAction";
 
 import { ISelectType } from "@/types/clients/IClients";
 
@@ -23,6 +24,7 @@ const CreateOrderCart: FC = ({}) => {
   const [openDiscountsModal, setOpenDiscountsModal] = useState(false);
   const [insufficientStockProducts, setInsufficientStockProducts] = useState<string[]>([]);
   const [appliedDiscounts, setAppliedDiscounts] = useState<any>([]);
+  const [showConfirmModal, setShowConfirmModal] = useState(false);
 
   const {
     selectedCategories,
@@ -46,7 +48,20 @@ const CreateOrderCart: FC = ({}) => {
   };
 
   const handleContinuePurchase = () => {
+    if (confirmOrderData?.total && confirmOrderData.total < 1500000) {
+      setShowConfirmModal(true);
+    } else {
+      setCheckingOut(true);
+    }
+  };
+
+  const handleConfirmPurchase = () => {
+    setShowConfirmModal(false);
     setCheckingOut(true);
+  };
+
+  const handleCloseModal = () => {
+    setShowConfirmModal(false);
   };
 
   useEffect(() => {
@@ -208,6 +223,16 @@ const CreateOrderCart: FC = ({}) => {
       {openDiscountsModal && (
         <CreateOrderDiscountsModal setOpenDiscountsModal={setOpenDiscountsModal} />
       )}
+
+      <ModalConfirmAction
+        isOpen={showConfirmModal}
+        onClose={handleCloseModal}
+        onOk={handleConfirmPurchase}
+        title="¿Está seguro que desea continuar?"
+        content="El pedido es inferior a $1.500.000 ¿Está seguro que desea continuar?"
+        okText="Confirmar"
+        cancelText="Cancelar"
+      />
     </div>
   );
 };


### PR DESCRIPTION
<img width="1115" height="835" alt="image" src="https://github.com/user-attachments/assets/67e6c49a-d899-4576-b5b6-875a4944d55e" />

This pull request adds a confirmation modal to the order creation flow when the order total is below a certain threshold. The modal prompts users to confirm their decision before proceeding with a purchase under $1,500,000. The main changes are grouped into user experience improvements and state management updates.

**User Experience Improvements:**

* Introduced the `ModalConfirmAction` component to display a confirmation dialog when the order total is less than $1,500,000, prompting the user to confirm before continuing. [[1]](diffhunk://#diff-f5ffce025964f652d85862ec7e82ebc762eb60a8ad6510ab281a796e7a64ffefR13) [[2]](diffhunk://#diff-f5ffce025964f652d85862ec7e82ebc762eb60a8ad6510ab281a796e7a64ffefR226-R235)

**State Management Updates:**

* Added the `showConfirmModal` state and related handler functions (`handleContinuePurchase`, `handleConfirmPurchase`, and `handleCloseModal`) to control the display and behavior of the confirmation modal within the `CreateOrderCart` component. [[1]](diffhunk://#diff-f5ffce025964f652d85862ec7e82ebc762eb60a8ad6510ab281a796e7a64ffefR27) [[2]](diffhunk://#diff-f5ffce025964f652d85862ec7e82ebc762eb60a8ad6510ab281a796e7a64ffefR51-R66)