### PR TITLE
Refactor select input styles and update class assignment in SelectCli…

### DIFF
--- a/src/modules/commerce/components/create-order-select-client/create-order-select-client.scss
+++ b/src/modules/commerce/components/create-order-select-client/create-order-select-client.scss
@@ -1,14 +1,10 @@
 @import "@/styles/variables.scss";
 
-@import "@styles/variables.scss";
-
-.selectInputClientCustom {
+// Base styles for select input client
+.selectInputClientBase {
     height: 3rem !important;
-    margin-bottom: 1rem;
     background-color: $background;
     border-radius: 0.25rem;
-    width: 100% !important;
-    max-width: 300px;
     font-size: 1rem !important;
 
     .ant-select-selector {
@@ -21,25 +17,23 @@
 
         .ant-select-selection-placeholder {
             color: $dark-gray;
-        }
-    }
-}
-.selectInputClientError {
-    width: 100%;
-    border: 1px dashed red;
-    height: 3rem !important;
-    margin-bottom: 0.2rem;
-    background-color: $background;
-    padding: 0.45rem;
-    border-radius: 0.25rem;
-    font-weight: 300;
-
-    .ant-select-selector {
-        .ant-select-selection-placeholder {
-            color: $dark-gray;
             font-size: 1rem;
         }
     }
+}
+
+.selectInputClientCustom {
+    @extend .selectInputClientBase;
+    margin-bottom: 1rem;
+    max-width: 450px;
+}
+
+.selectInputClientError {
+    @extend .selectInputClientBase;
+    border: 1px dashed red;
+    margin-bottom: 0.2rem;
+    padding: 0.45rem;
+    font-weight: 300;
 }
 
 .selectDrop {

--- a/src/modules/commerce/components/create-order-select-client/create-order-select-client.tsx
+++ b/src/modules/commerce/components/create-order-select-client/create-order-select-client.tsx
@@ -85,7 +85,7 @@ const SelectClientSimplified = ({ errors, field }: Props) => {
       showSearch
       optionFilterProp="label"
       placeholder="Seleccione un cliente"
-      className={errors ? "selectInputClientError" : "selectInputClientCustom"}
+      className={`selectInputClientBase ${errors ? "selectInputClientError" : "selectInputClientCustom"}`}
       loading={loading}
       variant="borderless"
       optionLabelProp="label"


### PR DESCRIPTION
<img width="1438" height="670" alt="image" src="https://github.com/user-attachments/assets/31c96e67-401f-42c2-b6ad-aad3e13941e0" />
This pull request refactors the styling of the client selection input in the commerce module to improve maintainability and consistency. The main changes involve introducing a base style class to reduce code duplication, adjusting the styling for error and custom states, and updating how styles are applied in the component.

**Styling refactor and improvements:**

* Introduced a new `.selectInputClientBase` class in `create-order-select-client.scss` to hold common styles for the select input, and refactored `.selectInputClientCustom` and `.selectInputClientError` to extend from this base class, reducing code duplication and improving maintainability. [[1]](diffhunk://#diff-eef99b8b19241e0bd49d9a8b69ac486041cf91dc455e083f3465b08d0ba4616aL3-L11) [[2]](diffhunk://#diff-eef99b8b19241e0bd49d9a8b69ac486041cf91dc455e083f3465b08d0ba4616aR20-L42)
* Increased the `max-width` of `.selectInputClientCustom` from 300px to 450px and moved `margin-bottom` to this class, providing a more spacious and visually appealing input.
* Updated the placeholder font size and ensured consistent styling for both normal and error states.

**Component update:**

* Modified the `SelectClientSimplified` component to always apply the base style class and conditionally add either the error or custom class, ensuring consistent application of shared styles.