### PR TITLE
Swap product and order discount labels in cart and order views

### DIFF
--- a/src/modules/commerce/components/create-order-cart/create-order-cart.tsx
+++ b/src/modules/commerce/components/create-order-cart/create-order-cart.tsx
@@ -204,11 +204,11 @@ const CreateOrderCart: FC = ({}) => {
             </Flex>
             <Flex justify="space-between" style={{ marginTop: "0.2rem" }}>
               <p className={styles.cartContainer__footer__discountExplanation}>
-                Descuentos de la orden
+                Descuentos de productos
               </p>
               {confirmOrderData.discounts ? (
                 <Text className={styles.cartContainer__footer__discountExplanation}>
-                  -${formatNumber(confirmOrderData.discounts?.totalOrderDiscount)}
+                  -${formatNumber(confirmOrderData.discounts?.totalProductDiscount)}
                 </Text>
               ) : (
                 <Text className={styles.cartContainer__footer__discountExplanation}>-$0</Text>
@@ -216,11 +216,11 @@ const CreateOrderCart: FC = ({}) => {
             </Flex>
             <Flex justify="space-between" style={{ marginTop: "0.2rem" }}>
               <p className={styles.cartContainer__footer__discountExplanation}>
-                Descuentos de productos
+                Descuentos de la orden (Crosseling)
               </p>
               {confirmOrderData.discounts ? (
                 <Text className={styles.cartContainer__footer__discountExplanation}>
-                  -${formatNumber(confirmOrderData.discounts?.totalProductDiscount)}
+                  -${formatNumber(confirmOrderData.discounts?.totalOrderDiscount)}
                 </Text>
               ) : (
                 <Text className={styles.cartContainer__footer__discountExplanation}>-$0</Text>

--- a/src/modules/commerce/containers/confirmed-order/confirmed-order.tsx
+++ b/src/modules/commerce/containers/confirmed-order/confirmed-order.tsx
@@ -159,18 +159,18 @@ export const ConfirmedOrderView: FC = () => {
                   </Flex>
                   <Flex justify="space-between">
                     <Text className={styles.footer__discountExplanation}>
-                      Descuentos de la orden
-                    </Text>
-                    <Text className={styles.footer__discountExplanation}>
-                      -${formatNumber(order?.detail?.discounts?.totalOrderDiscount ?? 0)}
-                    </Text>
-                  </Flex>
-                  <Flex justify="space-between">
-                    <Text className={styles.footer__discountExplanation}>
                       Descuentos de productos
                     </Text>
                     <Text className={styles.footer__discountExplanation}>
                       -${formatNumber(order?.detail?.discounts?.totalProductDiscount ?? 0)}
+                    </Text>
+                  </Flex>
+                  <Flex justify="space-between">
+                    <Text className={styles.footer__discountExplanation}>
+                      Descuentos de la orden (Crosseling)
+                    </Text>
+                    <Text className={styles.footer__discountExplanation}>
+                      -${formatNumber(order?.detail?.discounts?.totalOrderDiscount ?? 0)}
                     </Text>
                   </Flex>
                   <Flex justify="space-between" style={{ marginTop: "0.5rem" }}>


### PR DESCRIPTION
Corrects the labels and displayed values for product and order discounts in both the create order cart and confirmed order views. Now 'Descuentos de productos' shows product discounts and 'Descuentos de la orden (Crosseling)' shows order-level discounts, ensuring accurate information for users.