### PR TITLE
Fixes/86dxxc2ey/bugs marketplace

### DIFF
--- a/src/modules/commerce/components/create-order-cart-item/create-order-cart-item.tsx
+++ b/src/modules/commerce/components/create-order-cart-item/create-order-cart-item.tsx
@@ -43,8 +43,10 @@ const CreateOrderItem: FC<CreateOrderItemProps> = ({ product, categoryName, prod
 
       <h4 className={styles.name}>
         {product.name}{" "}
-        {product.shipment_unit > 1 && (
-          <span className={styles.name__uds}>({product.shipment_unit} und)</span>
+        {product.shipment_unit > 1 && (alreadySelectedProduct?.quantity ?? 0) > 0 && (
+          <span className={styles.name__uds}>
+            ({product.shipment_unit * (alreadySelectedProduct?.quantity ?? 0)} und)
+          </span>
         )}
         {!product.stock && (
           <SimpleTag

--- a/src/modules/commerce/components/create-order-cart/create-order-cart.tsx
+++ b/src/modules/commerce/components/create-order-cart/create-order-cart.tsx
@@ -23,6 +23,7 @@ const { Text } = Typography;
 
 const CreateOrderCart: FC = ({}) => {
   const { ID: projectId } = useAppStore((state) => state.selectedProject);
+  const formatMoney = useAppStore((state) => state.formatMoney);
   const [openDiscountsModal, setOpenDiscountsModal] = useState(false);
   const [insufficientStockProducts, setInsufficientStockProducts] = useState<string[]>([]);
   const [appliedDiscounts, setAppliedDiscounts] = useState<any>([]);
@@ -50,21 +51,26 @@ const CreateOrderCart: FC = ({}) => {
     setOpenDiscountsModal(true);
   };
 
+  const MINIMUM_ORDER_AMOUNT = 1600000;
   const isTotalLessThanMinimum = useMemo(
-    () => confirmOrderData?.total && confirmOrderData.total < 1500000,
+    () => confirmOrderData?.total && confirmOrderData.total < MINIMUM_ORDER_AMOUNT,
     [confirmOrderData]
   );
 
-  const hasNoCanulas = useMemo(() => {
+  const hasNoCanulasOrAgua = useMemo(() => {
     return !selectedCategories.some((category) =>
-      category.products.some((product) => product.name?.toLowerCase().includes("canula"))
+      category.products.some(
+        (product) =>
+          product.name?.toLowerCase().includes("canula") ||
+          product.name?.toLowerCase().includes("agua")
+      )
     );
   }, [selectedCategories]);
 
   const handleContinuePurchase = () => {
     if (isTotalLessThanMinimum) {
       setShowConfirmModal(true);
-    } else if (hasNoCanulas) {
+    } else if (hasNoCanulasOrAgua) {
       setShowCanulasModal(true);
     } else {
       setCheckingOut(true);
@@ -73,7 +79,7 @@ const CreateOrderCart: FC = ({}) => {
 
   const handleConfirmPurchase = () => {
     setShowConfirmModal(false);
-    if (hasNoCanulas) {
+    if (hasNoCanulasOrAgua) {
       setShowCanulasModal(true);
     } else {
       setCheckingOut(true);
@@ -285,9 +291,9 @@ const CreateOrderCart: FC = ({}) => {
         content={
           <Flex vertical className={styles.confirmationModalContent} gap="0.5rem">
             <p className={styles.confirmationModalContent__totalLabel}>
-              El pedido es inferior a $1.500.000
+              El pedido es inferior a {formatMoney(MINIMUM_ORDER_AMOUNT)}
             </p>
-            <p>¿Desea continuar?</p>
+            <p>Te sugerimos que incrementes la compra</p>
           </Flex>
         }
         okText="Confirmar"
@@ -302,9 +308,9 @@ const CreateOrderCart: FC = ({}) => {
         content={
           <Flex vertical className={styles.confirmationModalContent} gap="0.5rem">
             <p className={styles.confirmationModalContent__totalLabel}>
-              No has seleccionado Canulas
+              No has seleccionado Canulas y/o Agua estéril
             </p>
-            <p>¿Desea continuar?</p>
+            <p>Te recomendamos revisar la orden</p>
           </Flex>
         }
         okText="Confirmar"

--- a/src/modules/commerce/components/create-order-product/create-order-product.tsx
+++ b/src/modules/commerce/components/create-order-product/create-order-product.tsx
@@ -66,8 +66,10 @@ const CreateOrderProduct: FC<CreateOrderProductProps> = ({ product, categoryName
         ) : (
           <Flex gap={"0.5rem"} align="baseline">
             <h5 className={styles.price__amount}>{formatMoney(product.price)}</h5>
-            {product.shipment_unit > 1 && (
-              <span className={styles.units}>{product.shipment_unit} und</span>
+            {product.shipment_unit > 1 && (alreadySelectedProduct?.quantity ?? 0) > 0 && (
+              <span className={styles.units}>
+                {product.shipment_unit * (alreadySelectedProduct?.quantity ?? 0)} und
+              </span>
             )}
           </Flex>
         )}


### PR DESCRIPTION
This pull request updates the order cart and product display logic to improve messaging and validation around minimum order amounts and required product types. It also refines how product shipment units are shown based on the quantity selected.

**Order validation and messaging improvements:**

* Introduced a `MINIMUM_ORDER_AMOUNT` constant and updated the minimum order check to use this value instead of a hardcoded number. The confirmation modal now displays the minimum amount dynamically and provides a more helpful suggestion to increase the order, rather than just asking to continue. [[1]](diffhunk://#diff-f5ffce025964f652d85862ec7e82ebc762eb60a8ad6510ab281a796e7a64ffefR54-R73) [[2]](diffhunk://#diff-f5ffce025964f652d85862ec7e82ebc762eb60a8ad6510ab281a796e7a64ffefL288-R296)
* Expanded the logic to check for both "canula" and "agua" (sterile water) products in the cart, updating the related modal messaging to reflect the new requirement and provide a recommendation instead of a generic prompt. [[1]](diffhunk://#diff-f5ffce025964f652d85862ec7e82ebc762eb60a8ad6510ab281a796e7a64ffefR54-R73) [[2]](diffhunk://#diff-f5ffce025964f652d85862ec7e82ebc762eb60a8ad6510ab281a796e7a64ffefL76-R82) [[3]](diffhunk://#diff-f5ffce025964f652d85862ec7e82ebc762eb60a8ad6510ab281a796e7a64ffefL305-R313)

**Product display enhancements:**

* Updated the display of shipment units in both `create-order-cart-item` and `create-order-product` components to show the total number of units only when a product is selected and has a quantity greater than zero, providing a clearer and more accurate representation for users. [[1]](diffhunk://#diff-729dae3bf512a7b8460499acb3131ca5a732d484032f9cc0c71d0a618825bf35L46-R49) [[2]](diffhunk://#diff-47da40a8685f155b36c346c9f58ea323356bb84dda51ed6cf2579bbbd6d14558L69-R72)

**Code consistency and maintainability:**

* Added the `formatMoney` utility from the app store for consistent currency formatting throughout the cart component.