### PR TITLE
Feat/add equivalence modal catalog material tab

### DIFF
--- a/src/modules/dataQuality/components/CatalogsTable/catalogs-table.tsx
+++ b/src/modules/dataQuality/components/CatalogsTable/catalogs-table.tsx
@@ -420,6 +420,7 @@ export function CatalogsTable() {
         <ModalMaterialEquivalences
           isOpen={historyOpen}
           onClose={() => setHistoryOpen(false)}
+          catalogMaterialId={selectedCatalog?.id}
           clientCode={selectedCatalog?.customer_product_cod}
           clientName={selectedCatalog?.customer_product_description}
         />

--- a/src/modules/dataQuality/components/CatalogsTable/catalogs-table.tsx
+++ b/src/modules/dataQuality/components/CatalogsTable/catalogs-table.tsx
@@ -2,7 +2,7 @@
 
 import { ReactNode, useState } from "react";
 import { useParams } from "next/navigation";
-import { Plus, Edit, Trash2 } from "lucide-react";
+import { Plus, Edit, Trash2, History } from "lucide-react";
 import { Button as AntButton, Dropdown, Pagination, Spin, message } from "antd";
 import { DotsThreeVertical, DropboxLogo } from "@phosphor-icons/react";
 import { Badge } from "@/modules/chat/ui/badge";
@@ -19,6 +19,7 @@ import {
 } from "@/modules/chat/ui/table";
 import { IGetCatalogs, ICreateCatalogRequest } from "@/types/dataQuality/IDataQuality";
 import ModalAddEditCatalog, { CatalogFormData } from "../ModalAddEditCatalog/ModalAddEditCatalog";
+import { ModalMaterialEquivalences } from "../ModalMaterialEquivalences/ModalMaterialEquivalences";
 import { ModalConfirmAction } from "@/components/molecules/modals/ModalConfirmAction/ModalConfirmAction";
 import {
   createCatalog,
@@ -76,6 +77,7 @@ export function CatalogsTable() {
   const [isLoadingAction, setIsLoadingAction] = useState(false);
   const [isDownloadCatalogLoading, setIsDownloadCatalogLoading] = useState(false);
   const [isUploadLoading, setIsUploadLoading] = useState(false);
+  const [historyOpen, setHistoryOpen] = useState(false);
 
   const itemsPerPage = 25;
 
@@ -249,7 +251,7 @@ export function CatalogsTable() {
             <TableRow style={{ borderColor: "#DDDDDD" }}>
               <TableHead style={{ color: "#141414" }}>Código Cliente</TableHead>
               <TableHead style={{ color: "#141414" }}>Producto Cliente</TableHead>
-              <TableHead style={{ color: "#141414" }}>SKU</TableHead>
+              <TableHead style={{ color: "#141414" }}>GMN</TableHead>
               <TableHead style={{ color: "#141414" }}>Nombre Producto</TableHead>
               <TableHead style={{ color: "#141414" }}>Factor</TableHead>
               <TableHead style={{ color: "#141414" }}>Estado</TableHead>
@@ -330,6 +332,21 @@ export function CatalogsTable() {
                             Marcar como pack
                           </AntButton>
                         )
+                      },
+                      {
+                        key: "4",
+                        label: (
+                          <AntButton
+                            icon={<History className="w-4 h-4" />}
+                            className="buttonNoBorder"
+                            onClick={() => {
+                              setSelectedCatalog(item);
+                              setHistoryOpen(true);
+                            }}
+                          >
+                            Ver histórico
+                          </AntButton>
+                        )
                       }
                     ];
                     const customDropdown = (menu: ReactNode) => (
@@ -398,6 +415,13 @@ export function CatalogsTable() {
           onDownloadCatalog={handleDownloadCatalog}
           isDownloadCatalogLoading={isDownloadCatalogLoading}
           onUploadMaterialsAuxiliary={() => setWhichModalOpen({ selected: 4 })}
+        />
+
+        <ModalMaterialEquivalences
+          isOpen={historyOpen}
+          onClose={() => setHistoryOpen(false)}
+          clientCode={selectedCatalog?.customer_product_cod}
+          clientName={selectedCatalog?.customer_product_description}
         />
 
         <ModalUploadFile

--- a/src/modules/dataQuality/components/CatalogsTable/catalogs-table.tsx
+++ b/src/modules/dataQuality/components/CatalogsTable/catalogs-table.tsx
@@ -423,6 +423,7 @@ export function CatalogsTable() {
           catalogMaterialId={selectedCatalog?.id}
           clientCode={selectedCatalog?.customer_product_cod}
           clientName={selectedCatalog?.customer_product_description}
+          onReopenParent={() => setHistoryOpen(true)}
         />
 
         <ModalUploadFile

--- a/src/modules/dataQuality/components/CatalogsTable/catalogs-table.tsx
+++ b/src/modules/dataQuality/components/CatalogsTable/catalogs-table.tsx
@@ -424,6 +424,7 @@ export function CatalogsTable() {
           clientCode={selectedCatalog?.customer_product_cod}
           clientName={selectedCatalog?.customer_product_description}
           onReopenParent={() => setHistoryOpen(true)}
+          mutateMaterials={() => mutate()}
         />
 
         <ModalUploadFile

--- a/src/modules/dataQuality/components/ModalAddMaterialEquivalences/ModalAddMaterialEquivalences.tsx
+++ b/src/modules/dataQuality/components/ModalAddMaterialEquivalences/ModalAddMaterialEquivalences.tsx
@@ -1,0 +1,331 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import * as yup from "yup";
+import { Modal, Spin, message } from "antd";
+import { useForm, Controller } from "react-hook-form";
+import { yupResolver } from "@hookform/resolvers/yup";
+import { Save } from "lucide-react";
+
+import { Button } from "@/modules/chat/ui/button";
+import { Input } from "@/modules/chat/ui/input";
+import { Label } from "@/modules/chat/ui/label";
+import { Checkbox } from "@/modules/chat/ui/checkbox";
+import { createCatalogMaterialEquivalence } from "@/services/dataQuality/dataQuality";
+import { IPostCatalogMaterialEquivalence } from "@/types/dataQuality/IDataQuality";
+
+const equivalenceSchema = yup.object().shape({
+  internal_sku: yup.string().required("El SKU es requerido"),
+  internal_name: yup.string().required("El nombre del producto es requerido"),
+  conversion_factor: yup
+    .number()
+    .typeError("El factor debe ser un número")
+    .required("El factor es requerido")
+    .positive("El factor debe ser positivo"),
+  valid_from: yup.string().required("La fecha 'Desde' es requerida"),
+  is_active: yup.number().oneOf([0, 1]).required(),
+  valid_to: yup
+    .string()
+    .nullable()
+    .when("is_active", {
+      is: 0,
+      then: (schema) => schema.required("La fecha 'Hasta' es requerida"),
+      otherwise: (schema) => schema.nullable()
+    })
+});
+
+type EquivalenceFormData = {
+  internal_sku: string;
+  internal_name: string;
+  conversion_factor: number;
+  valid_from: string;
+  valid_to?: string | null;
+  is_active: 0 | 1;
+};
+
+const INITIAL_VALUES: EquivalenceFormData = {
+  internal_sku: "",
+  internal_name: "",
+  conversion_factor: 1,
+  valid_from: "",
+  valid_to: "",
+  is_active: 1
+};
+
+interface ModalAddMaterialEquivalencesProps {
+  isOpen: boolean;
+  onClose: () => void;
+  catalogMaterialId: number;
+  onCreated?: () => void;
+}
+
+export function ModalAddMaterialEquivalences({
+  isOpen,
+  onClose,
+  catalogMaterialId,
+  onCreated
+}: ModalAddMaterialEquivalencesProps) {
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  const {
+    control,
+    handleSubmit,
+    watch,
+    reset,
+    formState: { errors, isValid }
+  } = useForm<EquivalenceFormData>({
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    resolver: yupResolver(equivalenceSchema) as any,
+    defaultValues: INITIAL_VALUES,
+    mode: "onChange"
+  });
+
+  const isActive = watch("is_active");
+
+  useEffect(() => {
+    if (!isOpen) reset(INITIAL_VALUES);
+  }, [isOpen, reset]);
+
+  const handleClose = () => {
+    reset(INITIAL_VALUES);
+    onClose();
+  };
+
+  const onSubmit = async (data: EquivalenceFormData) => {
+    try {
+      setIsSubmitting(true);
+      const body: IPostCatalogMaterialEquivalence = {
+        internal_sku: data.internal_sku,
+        internal_name: data.internal_name,
+        conversion_factor: data.conversion_factor,
+        valid_from: data.valid_from,
+        valid_to: data.is_active === 1 ? null : data.valid_to ?? null,
+        is_active: data.is_active
+      };
+      await createCatalogMaterialEquivalence(catalogMaterialId, body);
+      message.success("Equivalencia creada correctamente");
+      onCreated?.();
+      handleClose();
+    } catch (error) {
+      console.error(error);
+      message.error("Error al crear la equivalencia");
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  return (
+    <Modal
+      open={isOpen}
+      onCancel={handleClose}
+      footer={null}
+      closable={false}
+      width={820}
+      centered
+      destroyOnClose
+      styles={{ body: { padding: 0, backgroundColor: "#FFFFFF" } }}
+    >
+      {/* Header */}
+      <div className="flex items-center gap-3 pb-5 border-b" style={{ borderColor: "#EEEEEE" }}>
+        <h2 className="text-base font-semibold flex-1" style={{ color: "#141414" }}>
+          Nueva equivalencia
+        </h2>
+      </div>
+
+      <form onSubmit={handleSubmit(onSubmit)}>
+        {/* Body */}
+        <div className="py-6">
+          {/* Row 1: SKU + Nombre producto */}
+          <div className="grid gap-4 mb-4" style={{ gridTemplateColumns: "1fr 2fr" }}>
+            <div className="flex flex-col gap-1.5">
+              <Label className="text-sm font-medium" style={{ color: "#141414" }}>
+                SKU
+              </Label>
+              <Controller
+                name="internal_sku"
+                control={control}
+                render={({ field }) => (
+                  <Input
+                    {...field}
+                    placeholder="Ej: SKU-CEN-PERF-V3"
+                    style={{ borderColor: errors.internal_sku ? "#ff4d4f" : "#DDDDDD" }}
+                  />
+                )}
+              />
+              {errors.internal_sku && (
+                <span style={{ color: "#ff4d4f", fontSize: "12px" }}>
+                  {errors.internal_sku.message}
+                </span>
+              )}
+            </div>
+            <div className="flex flex-col gap-1.5">
+              <Label className="text-sm font-medium" style={{ color: "#141414" }}>
+                Nombre del producto
+              </Label>
+              <Controller
+                name="internal_name"
+                control={control}
+                render={({ field }) => (
+                  <Input
+                    {...field}
+                    placeholder="Ej: Centrum Performance Ultra 60 Tabs"
+                    style={{ borderColor: errors.internal_name ? "#ff4d4f" : "#DDDDDD" }}
+                  />
+                )}
+              />
+              {errors.internal_name && (
+                <span style={{ color: "#ff4d4f", fontSize: "12px" }}>
+                  {errors.internal_name.message}
+                </span>
+              )}
+            </div>
+          </div>
+
+          {/* Row 2: Factor + Desde + Hasta + checkbox Activo */}
+          <div className="grid gap-4 items-end" style={{ gridTemplateColumns: "80px 1fr 1fr auto" }}>
+            <div className="flex flex-col gap-1.5">
+              <Label className="text-sm font-medium" style={{ color: "#141414" }}>
+                Factor
+              </Label>
+              <Controller
+                name="conversion_factor"
+                control={control}
+                render={({ field }) => (
+                  <Input
+                    type="number"
+                    step="0.01"
+                    min="0"
+                    value={field.value ?? ""}
+                    onChange={(e) => {
+                      const val = e.target.value;
+                      field.onChange(val === "" ? undefined : Number(val));
+                    }}
+                    style={{ borderColor: errors.conversion_factor ? "#ff4d4f" : "#DDDDDD" }}
+                  />
+                )}
+              />
+              {errors.conversion_factor && (
+                <span style={{ color: "#ff4d4f", fontSize: "12px" }}>
+                  {errors.conversion_factor.message}
+                </span>
+              )}
+            </div>
+
+            <div className="flex flex-col gap-1.5">
+              <Label className="text-sm font-medium" style={{ color: "#141414" }}>
+                Desde
+              </Label>
+              <Controller
+                name="valid_from"
+                control={control}
+                render={({ field }) => (
+                  <Input
+                    type="date"
+                    {...field}
+                    style={{ borderColor: errors.valid_from ? "#ff4d4f" : "#DDDDDD" }}
+                  />
+                )}
+              />
+              {errors.valid_from && (
+                <span style={{ color: "#ff4d4f", fontSize: "12px" }}>
+                  {errors.valid_from.message}
+                </span>
+              )}
+            </div>
+
+            <div className="flex flex-col gap-1.5">
+              <Label
+                className="text-sm font-medium"
+                style={{ color: isActive === 1 ? "#BBBBBB" : "#141414" }}
+              >
+                Hasta
+                {isActive === 1 && (
+                  <span className="ml-1 text-xs font-normal" style={{ color: "#BBBBBB" }}>
+                    (bloqueado — vigente)
+                  </span>
+                )}
+              </Label>
+              <Controller
+                name="valid_to"
+                control={control}
+                render={({ field }) => (
+                  <Input
+                    type="date"
+                    value={isActive === 1 ? "" : field.value ?? ""}
+                    onChange={field.onChange}
+                    disabled={isActive === 1}
+                    style={{
+                      borderColor: errors.valid_to ? "#ff4d4f" : "#DDDDDD",
+                      opacity: isActive === 1 ? 0.4 : 1
+                    }}
+                  />
+                )}
+              />
+              {errors.valid_to && (
+                <span style={{ color: "#ff4d4f", fontSize: "12px" }}>
+                  {errors.valid_to.message}
+                </span>
+              )}
+            </div>
+
+            <div className="flex items-center gap-2 pb-[9px]">
+              <Controller
+                name="is_active"
+                control={control}
+                render={({ field }) => (
+                  <Checkbox
+                    id="equivalence-active"
+                    checked={field.value === 1}
+                    onCheckedChange={(checked) => field.onChange(checked ? 1 : 0)}
+                    style={
+                      field.value === 1
+                        ? { backgroundColor: "#CBE71E", borderColor: "#CBE71E" }
+                        : {}
+                    }
+                  />
+                )}
+              />
+              <Label
+                htmlFor="equivalence-active"
+                className="text-sm font-medium cursor-pointer"
+                style={{ color: "#141414" }}
+              >
+                Activo
+              </Label>
+            </div>
+          </div>
+        </div>
+
+        {/* Footer */}
+        <div
+          className="pt-4 border-t flex items-center justify-end gap-2"
+          style={{ borderColor: "#EEEEEE" }}
+        >
+          <Button variant="outline" type="button" onClick={handleClose} className="bg-transparent">
+            Cancelar
+          </Button>
+          <Button
+            type="submit"
+            disabled={!isValid || isSubmitting}
+            style={{
+              backgroundColor: !isValid || isSubmitting ? "#d9d9d9" : "#CBE71E",
+              color: "#141414",
+              border: "none",
+              cursor: !isValid || isSubmitting ? "not-allowed" : "pointer"
+            }}
+          >
+            {isSubmitting ? (
+              <Spin size="small" />
+            ) : (
+              <>
+                <Save className="w-4 h-4 mr-2" /> Guardar
+              </>
+            )}
+          </Button>
+        </div>
+      </form>
+    </Modal>
+  );
+}
+
+export default ModalAddMaterialEquivalences;

--- a/src/modules/dataQuality/components/ModalAddMaterialEquivalences/ModalAddMaterialEquivalences.tsx
+++ b/src/modules/dataQuality/components/ModalAddMaterialEquivalences/ModalAddMaterialEquivalences.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEffect, useState } from "react";
+import { useParams } from "next/navigation";
 import * as yup from "yup";
 import { Modal, Spin, message } from "antd";
 import { useForm, Controller } from "react-hook-form";
@@ -11,12 +12,18 @@ import { Button } from "@/modules/chat/ui/button";
 import { Input } from "@/modules/chat/ui/input";
 import { Label } from "@/modules/chat/ui/label";
 import { Checkbox } from "@/modules/chat/ui/checkbox";
-import { createCatalogMaterialEquivalence } from "@/services/dataQuality/dataQuality";
-import { IPostCatalogMaterialEquivalence } from "@/types/dataQuality/IDataQuality";
+import Select from "@/modules/dataQuality/components/atoms/select/Select";
+import {
+  createCatalogMaterialEquivalence,
+  getCatalogMaterialsForSelect
+} from "@/services/dataQuality/dataQuality";
+import {
+  ICatalogMaterial,
+  IPostCatalogMaterialEquivalence
+} from "@/types/dataQuality/IDataQuality";
 
 const equivalenceSchema = yup.object().shape({
-  internal_sku: yup.string().required("El SKU es requerido"),
-  internal_name: yup.string().required("El nombre del producto es requerido"),
+  material_code: yup.string().required("El material es requerido"),
   conversion_factor: yup
     .number()
     .typeError("El factor debe ser un número")
@@ -35,8 +42,7 @@ const equivalenceSchema = yup.object().shape({
 });
 
 type EquivalenceFormData = {
-  internal_sku: string;
-  internal_name: string;
+  material_code: string;
   conversion_factor: number;
   valid_from: string;
   valid_to?: string | null;
@@ -44,8 +50,7 @@ type EquivalenceFormData = {
 };
 
 const INITIAL_VALUES: EquivalenceFormData = {
-  internal_sku: "",
-  internal_name: "",
+  material_code: "",
   conversion_factor: 1,
   valid_from: "",
   valid_to: "",
@@ -65,7 +70,11 @@ export function ModalAddMaterialEquivalences({
   catalogMaterialId,
   onCreated
 }: ModalAddMaterialEquivalencesProps) {
+  const params = useParams();
+  const countryId = Number(params.countryId) || 0;
+
   const [isSubmitting, setIsSubmitting] = useState(false);
+  const [materials, setMaterials] = useState<ICatalogMaterial[]>([]);
 
   const {
     control,
@@ -86,6 +95,18 @@ export function ModalAddMaterialEquivalences({
     if (!isOpen) reset(INITIAL_VALUES);
   }, [isOpen, reset]);
 
+  useEffect(() => {
+    const fetchMaterials = async () => {
+      try {
+        const data = await getCatalogMaterialsForSelect(countryId);
+        setMaterials(data);
+      } catch (error) {
+        console.error("Error fetching materials:", error);
+      }
+    };
+    fetchMaterials();
+  }, []);
+
   const handleClose = () => {
     reset(INITIAL_VALUES);
     onClose();
@@ -95,8 +116,7 @@ export function ModalAddMaterialEquivalences({
     try {
       setIsSubmitting(true);
       const body: IPostCatalogMaterialEquivalence = {
-        internal_sku: data.internal_sku,
-        internal_name: data.internal_name,
+        material_code: Number(data.material_code),
         conversion_factor: data.conversion_factor,
         valid_from: data.valid_from,
         valid_to: data.is_active === 1 ? null : data.valid_to ?? null,
@@ -107,8 +127,9 @@ export function ModalAddMaterialEquivalences({
       onCreated?.();
       handleClose();
     } catch (error) {
-      console.error(error);
-      message.error("Error al crear la equivalencia");
+      const errorMessage =
+        error instanceof Error ? error.message : "Error al crear la equivalencia";
+      message.error(errorMessage);
     } finally {
       setIsSubmitting(false);
     }
@@ -135,54 +156,40 @@ export function ModalAddMaterialEquivalences({
       <form onSubmit={handleSubmit(onSubmit)}>
         {/* Body */}
         <div className="py-6">
-          {/* Row 1: SKU + Nombre producto */}
-          <div className="grid gap-4 mb-4" style={{ gridTemplateColumns: "1fr 2fr" }}>
-            <div className="flex flex-col gap-1.5">
-              <Label className="text-sm font-medium" style={{ color: "#141414" }}>
-                SKU
-              </Label>
-              <Controller
-                name="internal_sku"
-                control={control}
-                render={({ field }) => (
-                  <Input
-                    {...field}
-                    placeholder="Ej: SKU-CEN-PERF-V3"
-                    style={{ borderColor: errors.internal_sku ? "#ff4d4f" : "#DDDDDD" }}
-                  />
-                )}
-              />
-              {errors.internal_sku && (
-                <span style={{ color: "#ff4d4f", fontSize: "12px" }}>
-                  {errors.internal_sku.message}
-                </span>
+          {/* Row 1: Material */}
+          <div className="flex flex-col gap-1.5 mb-4">
+            <Label className="text-sm font-medium" style={{ color: "#141414" }}>
+              Material
+            </Label>
+            <Controller
+              name="material_code"
+              control={control}
+              render={({ field }) => (
+                <Select
+                  showSearch
+                  value={field.value}
+                  onChange={field.onChange}
+                  placeholder="Seleccionar material"
+                  hasError={!!errors.material_code}
+                  options={materials.map((material) => ({
+                    value: String(material.id),
+                    label: `${material.material_code} - ${material.material_name}`
+                  }))}
+                />
               )}
-            </div>
-            <div className="flex flex-col gap-1.5">
-              <Label className="text-sm font-medium" style={{ color: "#141414" }}>
-                Nombre del producto
-              </Label>
-              <Controller
-                name="internal_name"
-                control={control}
-                render={({ field }) => (
-                  <Input
-                    {...field}
-                    placeholder="Ej: Centrum Performance Ultra 60 Tabs"
-                    style={{ borderColor: errors.internal_name ? "#ff4d4f" : "#DDDDDD" }}
-                  />
-                )}
-              />
-              {errors.internal_name && (
-                <span style={{ color: "#ff4d4f", fontSize: "12px" }}>
-                  {errors.internal_name.message}
-                </span>
-              )}
-            </div>
+            />
+            {errors.material_code && (
+              <span style={{ color: "#ff4d4f", fontSize: "12px" }}>
+                {errors.material_code.message}
+              </span>
+            )}
           </div>
 
           {/* Row 2: Factor + Desde + Hasta + checkbox Activo */}
-          <div className="grid gap-4 items-end" style={{ gridTemplateColumns: "80px 1fr 1fr auto" }}>
+          <div
+            className="grid gap-4 items-end"
+            style={{ gridTemplateColumns: "80px 1fr 1fr auto" }}
+          >
             <div className="flex flex-col gap-1.5">
               <Label className="text-sm font-medium" style={{ color: "#141414" }}>
                 Factor

--- a/src/modules/dataQuality/components/ModalMaterialEquivalences/ModalMaterialEquivalences.tsx
+++ b/src/modules/dataQuality/components/ModalMaterialEquivalences/ModalMaterialEquivalences.tsx
@@ -13,6 +13,7 @@ interface ModalMaterialEquivalencesProps {
   clientCode?: string;
   clientName?: string;
   onReopenParent?: () => void;
+  mutateMaterials: () => void;
 }
 
 const formatDate = (iso: string | null) => {
@@ -26,7 +27,8 @@ export function ModalMaterialEquivalences({
   catalogMaterialId,
   clientCode,
   clientName,
-  onReopenParent
+  onReopenParent,
+  mutateMaterials
 }: ModalMaterialEquivalencesProps) {
   const {
     data: equivalences,
@@ -47,241 +49,244 @@ export function ModalMaterialEquivalences({
 
   const handleCreated = () => {
     mutate();
+    mutateMaterials();
   };
 
   const customDropdown = (menu: ReactNode) => <div>{menu}</div>;
 
   return (
     <>
-    <Modal
-      open={isOpen}
-      onCancel={onClose}
-      footer={null}
-      closable={false}
-      width={820}
-      centered
-      styles={{ body: { padding: 0, backgroundColor: "#FFFFFF" } }}
-    >
-      {/* Header */}
-      <div className="flex items-center gap-3 pb-5 border-b" style={{ borderColor: "#EEEEEE" }}>
-        <div
-          className="w-9 h-9 rounded-lg flex items-center justify-center shrink-0"
-          style={{ backgroundColor: "rgba(203,231,30,0.15)" }}
-        >
-          <History className="w-4 h-4" style={{ color: "#8BAF00" }} />
-        </div>
-        <h2 className="text-base font-semibold flex-1" style={{ color: "#141414" }}>
-          Historial de equivalencias
-        </h2>
-      </div>
-
-      {/* Subtitle */}
-      <div className=" pt-4 pb-2 flex flex-col gap-1.5">
-        <div className="flex items-center gap-2">
-          <span
-            className="text-[11px] font-medium px-1.5 py-0.5 rounded"
-            style={{ backgroundColor: "#F3F3F3", color: "#888" }}
-          >
-            Cod. cliente
-          </span>
-          <span className="text-sm font-medium" style={{ color: "#333" }}>
-            {clientCode}
-          </span>
-        </div>
-        <div className="flex items-center gap-2">
-          <span
-            className="text-[11px] font-medium px-1.5 py-0.5 rounded"
-            style={{ backgroundColor: "#F3F3F3", color: "#888" }}
-          >
-            Producto cliente
-          </span>
-          <span className="text-sm" style={{ color: "#555" }}>
-            {clientName}
-          </span>
-        </div>
-      </div>
-
-      {/* Table */}
-      <div className=" pb-1">
-        <table className="w-full text-sm">
-          <thead>
-            <tr style={{ borderBottom: "1px solid #EEEEEE" }}>
-              <th
-                className="text-left py-2.5 font-semibold text-sm"
-                style={{ color: "#141414", minWidth: "320px" }}
-              >
-                Nombre producto
-              </th>
-              <th
-                className="text-left py-2.5 font-semibold text-sm"
-                style={{ color: "#141414", width: "160px" }}
-              >
-                SKU
-              </th>
-              <th
-                className="text-left py-2.5 font-semibold text-sm"
-                style={{ color: "#141414", width: "60px" }}
-              >
-                Factor
-              </th>
-              <th
-                className="text-left py-2.5 font-semibold text-sm"
-                style={{ color: "#141414", width: "100px" }}
-              >
-                Desde
-              </th>
-              <th
-                className="text-left py-2.5 font-semibold text-sm"
-                style={{ color: "#141414", width: "100px" }}
-              >
-                Hasta
-              </th>
-              <th style={{ width: "48px" }} />
-            </tr>
-          </thead>
-          <tbody>
-            {isLoading && (
-              <tr>
-                <td colSpan={6} className="text-center py-8">
-                  <Spin />
-                </td>
-              </tr>
-            )}
-            {!isLoading && equivalences.length === 0 && (
-              <tr>
-                <td colSpan={6} className="text-center py-8 text-sm" style={{ color: "#888" }}>
-                  No hay periodos registrados.
-                </td>
-              </tr>
-            )}
-            {!isLoading &&
-              equivalences.map((equivalence) => {
-                const isActive = equivalence.is_active === 1;
-                const rowColor = isActive ? "#1a6600" : "#BBBBBB";
-                const rowBg = isActive ? "rgba(203,231,30,0.10)" : "transparent";
-                return (
-                  <tr
-                    key={equivalence.id}
-                    style={{ borderBottom: "1px solid #F3F3F3", backgroundColor: rowBg }}
-                  >
-                    <td className="py-3 pr-4 rounded-l">
-                      <span className="font-medium" style={{ color: rowColor }}>
-                        {equivalence.internal_name}
-                      </span>
-                    </td>
-                    <td className="py-3 pr-4" style={{ color: rowColor }}>
-                      {equivalence.internal_sku}
-                    </td>
-                    <td className="py-3" style={{ color: rowColor }}>
-                      {equivalence.conversion_factor}
-                    </td>
-                    <td className="py-3" style={{ color: rowColor }}>
-                      {formatDate(equivalence.valid_from) || "–"}
-                    </td>
-                    <td className="py-3">
-                      {isActive ? (
-                        <span
-                          className="text-[11px] font-semibold px-2 py-0.5 rounded-full"
-                          style={{ backgroundColor: "#CBE71E", color: "#141414" }}
-                        >
-                          Vigente
-                        </span>
-                      ) : equivalence.valid_to ? (
-                        <span style={{ color: rowColor }}>{formatDate(equivalence.valid_to)}</span>
-                      ) : (
-                        <span style={{ color: rowColor }}>–</span>
-                      )}
-                    </td>
-                    <td className="py-3 text-right">
-                      <Dropdown
-                        dropdownRender={customDropdown}
-                        placement="bottomRight"
-                        trigger={["click"]}
-                        menu={{
-                          items: [
-                            {
-                              key: "edit",
-                              label: (
-                                <AntButton
-                                  className="buttonNoBorder"
-                                  icon={<Edit className="w-3.5 h-3.5" />}
-                                  onClick={() => {}}
-                                >
-                                  Editar
-                                </AntButton>
-                              )
-                            },
-                            {
-                              key: "delete",
-                              label: (
-                                <AntButton
-                                  className="buttonNoBorder"
-                                  icon={<Trash2 className="w-3.5 h-3.5" />}
-                                  onClick={() => {}}
-                                >
-                                  Eliminar
-                                </AntButton>
-                              )
-                            }
-                          ]
-                        }}
-                      >
-                        <button
-                          className="w-7 h-7 rounded flex items-center justify-center hover:bg-gray-100 transition-colors"
-                          style={{ color: "#888" }}
-                        >
-                          <MoreHorizontal className="w-4 h-4" />
-                        </button>
-                      </Dropdown>
-                    </td>
-                  </tr>
-                );
-              })}
-          </tbody>
-        </table>
-      </div>
-
-      {/* Add link */}
-      <div className=" pt-2 pb-4">
-        <button
-          type="button"
-          onClick={handleOpenAdd}
-          className="text-sm font-medium flex items-center gap-1 hover:opacity-70 transition-opacity"
-          style={{ color: "#141414" }}
-        >
-          <Plus className="w-3.5 h-3.5" /> Agregar equivalencia
-        </button>
-      </div>
-
-      {/* Footer */}
-      <div
-        className="pt-3 border-t flex items-center justify-end"
-        style={{ borderColor: "#EEEEEE" }}
+      <Modal
+        open={isOpen}
+        onCancel={onClose}
+        footer={null}
+        closable={false}
+        width={820}
+        centered
+        styles={{ body: { padding: 0, backgroundColor: "#FFFFFF" } }}
       >
-        <AntButton
-          onClick={onClose}
-          className="text-sm font-medium"
-          style={{
-            height: 32,
-            padding: "0 16px",
-            borderRadius: 6,
-            border: "1px solid #E5E7EB",
-            color: "#141414",
-            backgroundColor: "#FFFFFF"
-          }}
+        {/* Header */}
+        <div className="flex items-center gap-3 pb-5 border-b" style={{ borderColor: "#EEEEEE" }}>
+          <div
+            className="w-9 h-9 rounded-lg flex items-center justify-center shrink-0"
+            style={{ backgroundColor: "rgba(203,231,30,0.15)" }}
+          >
+            <History className="w-4 h-4" style={{ color: "#8BAF00" }} />
+          </div>
+          <h2 className="text-base font-semibold flex-1" style={{ color: "#141414" }}>
+            Historial de equivalencias
+          </h2>
+        </div>
+
+        {/* Subtitle */}
+        <div className=" pt-4 pb-2 flex flex-col gap-1.5">
+          <div className="flex items-center gap-2">
+            <span
+              className="text-[11px] font-medium px-1.5 py-0.5 rounded"
+              style={{ backgroundColor: "#F3F3F3", color: "#888" }}
+            >
+              Cod. cliente
+            </span>
+            <span className="text-sm font-medium" style={{ color: "#333" }}>
+              {clientCode}
+            </span>
+          </div>
+          <div className="flex items-center gap-2">
+            <span
+              className="text-[11px] font-medium px-1.5 py-0.5 rounded"
+              style={{ backgroundColor: "#F3F3F3", color: "#888" }}
+            >
+              Producto cliente
+            </span>
+            <span className="text-sm" style={{ color: "#555" }}>
+              {clientName}
+            </span>
+          </div>
+        </div>
+
+        {/* Table */}
+        <div className=" pb-1">
+          <table className="w-full text-sm">
+            <thead>
+              <tr style={{ borderBottom: "1px solid #EEEEEE" }}>
+                <th
+                  className="text-left py-2.5 font-semibold text-sm"
+                  style={{ color: "#141414", minWidth: "320px" }}
+                >
+                  Nombre producto
+                </th>
+                <th
+                  className="text-left py-2.5 font-semibold text-sm"
+                  style={{ color: "#141414", width: "160px" }}
+                >
+                  SKU
+                </th>
+                <th
+                  className="text-left py-2.5 font-semibold text-sm"
+                  style={{ color: "#141414", width: "60px" }}
+                >
+                  Factor
+                </th>
+                <th
+                  className="text-left py-2.5 font-semibold text-sm"
+                  style={{ color: "#141414", width: "100px" }}
+                >
+                  Desde
+                </th>
+                <th
+                  className="text-left py-2.5 font-semibold text-sm"
+                  style={{ color: "#141414", width: "100px" }}
+                >
+                  Hasta
+                </th>
+                <th style={{ width: "48px" }} />
+              </tr>
+            </thead>
+            <tbody>
+              {isLoading && (
+                <tr>
+                  <td colSpan={6} className="text-center py-8">
+                    <Spin />
+                  </td>
+                </tr>
+              )}
+              {!isLoading && equivalences.length === 0 && (
+                <tr>
+                  <td colSpan={6} className="text-center py-8 text-sm" style={{ color: "#888" }}>
+                    No hay periodos registrados.
+                  </td>
+                </tr>
+              )}
+              {!isLoading &&
+                equivalences.map((equivalence) => {
+                  const isActive = equivalence.is_active === 1;
+                  const rowColor = isActive ? "#1a6600" : "#BBBBBB";
+                  const rowBg = isActive ? "rgba(203,231,30,0.10)" : "transparent";
+                  return (
+                    <tr
+                      key={equivalence.id}
+                      style={{ borderBottom: "1px solid #F3F3F3", backgroundColor: rowBg }}
+                    >
+                      <td className="py-3 pr-4 rounded-l">
+                        <span className="font-medium" style={{ color: rowColor }}>
+                          {equivalence.internal_name}
+                        </span>
+                      </td>
+                      <td className="py-3 pr-4" style={{ color: rowColor }}>
+                        {equivalence.internal_sku}
+                      </td>
+                      <td className="py-3" style={{ color: rowColor }}>
+                        {equivalence.conversion_factor}
+                      </td>
+                      <td className="py-3" style={{ color: rowColor }}>
+                        {formatDate(equivalence.valid_from) || "–"}
+                      </td>
+                      <td className="py-3">
+                        {isActive ? (
+                          <span
+                            className="text-[11px] font-semibold px-2 py-0.5 rounded-full"
+                            style={{ backgroundColor: "#CBE71E", color: "#141414" }}
+                          >
+                            Vigente
+                          </span>
+                        ) : equivalence.valid_to ? (
+                          <span style={{ color: rowColor }}>
+                            {formatDate(equivalence.valid_to)}
+                          </span>
+                        ) : (
+                          <span style={{ color: rowColor }}>–</span>
+                        )}
+                      </td>
+                      <td className="py-3 text-right">
+                        <Dropdown
+                          dropdownRender={customDropdown}
+                          placement="bottomRight"
+                          trigger={["click"]}
+                          menu={{
+                            items: [
+                              {
+                                key: "edit",
+                                label: (
+                                  <AntButton
+                                    className="buttonNoBorder"
+                                    icon={<Edit className="w-3.5 h-3.5" />}
+                                    onClick={() => {}}
+                                  >
+                                    Editar
+                                  </AntButton>
+                                )
+                              },
+                              {
+                                key: "delete",
+                                label: (
+                                  <AntButton
+                                    className="buttonNoBorder"
+                                    icon={<Trash2 className="w-3.5 h-3.5" />}
+                                    onClick={() => {}}
+                                  >
+                                    Eliminar
+                                  </AntButton>
+                                )
+                              }
+                            ]
+                          }}
+                        >
+                          <button
+                            className="w-7 h-7 rounded flex items-center justify-center hover:bg-gray-100 transition-colors"
+                            style={{ color: "#888" }}
+                          >
+                            <MoreHorizontal className="w-4 h-4" />
+                          </button>
+                        </Dropdown>
+                      </td>
+                    </tr>
+                  );
+                })}
+            </tbody>
+          </table>
+        </div>
+
+        {/* Add link */}
+        <div className=" pt-2 pb-4">
+          <button
+            type="button"
+            onClick={handleOpenAdd}
+            className="text-sm font-medium flex items-center gap-1 hover:opacity-70 transition-opacity"
+            style={{ color: "#141414" }}
+          >
+            <Plus className="w-3.5 h-3.5" /> Agregar equivalencia
+          </button>
+        </div>
+
+        {/* Footer */}
+        <div
+          className="pt-3 border-t flex items-center justify-end"
+          style={{ borderColor: "#EEEEEE" }}
         >
-          Cerrar
-        </AntButton>
-      </div>
-    </Modal>
-    {catalogMaterialId !== undefined && (
-      <ModalAddMaterialEquivalences
-        isOpen={addOpen}
-        onClose={handleCloseAdd}
-        catalogMaterialId={catalogMaterialId}
-        onCreated={handleCreated}
-      />
-    )}
+          <AntButton
+            onClick={onClose}
+            className="text-sm font-medium"
+            style={{
+              height: 32,
+              padding: "0 16px",
+              borderRadius: 6,
+              border: "1px solid #E5E7EB",
+              color: "#141414",
+              backgroundColor: "#FFFFFF"
+            }}
+          >
+            Cerrar
+          </AntButton>
+        </div>
+      </Modal>
+      {catalogMaterialId !== undefined && (
+        <ModalAddMaterialEquivalences
+          isOpen={addOpen}
+          onClose={handleCloseAdd}
+          catalogMaterialId={catalogMaterialId}
+          onCreated={handleCreated}
+        />
+      )}
     </>
   );
 }

--- a/src/modules/dataQuality/components/ModalMaterialEquivalences/ModalMaterialEquivalences.tsx
+++ b/src/modules/dataQuality/components/ModalMaterialEquivalences/ModalMaterialEquivalences.tsx
@@ -1,9 +1,10 @@
 "use client";
 
-import { ReactNode } from "react";
+import { ReactNode, useState } from "react";
 import { Modal, Button as AntButton, Dropdown, Spin } from "antd";
 import { History, MoreHorizontal, Plus, Edit, Trash2 } from "lucide-react";
 import { useCatalogMaterialEquivalences } from "../../hooks/useCatalogMaterialEquivalences";
+import { ModalAddMaterialEquivalences } from "../ModalAddMaterialEquivalences/ModalAddMaterialEquivalences";
 
 interface ModalMaterialEquivalencesProps {
   isOpen: boolean;
@@ -11,6 +12,7 @@ interface ModalMaterialEquivalencesProps {
   catalogMaterialId?: number;
   clientCode?: string;
   clientName?: string;
+  onReopenParent?: () => void;
 }
 
 const formatDate = (iso: string | null) => {
@@ -23,13 +25,34 @@ export function ModalMaterialEquivalences({
   onClose,
   catalogMaterialId,
   clientCode,
-  clientName
+  clientName,
+  onReopenParent
 }: ModalMaterialEquivalencesProps) {
-  const { data: equivalences, isLoading } = useCatalogMaterialEquivalences(catalogMaterialId);
+  const {
+    data: equivalences,
+    isLoading,
+    mutate
+  } = useCatalogMaterialEquivalences(catalogMaterialId);
+  const [addOpen, setAddOpen] = useState(false);
+
+  const handleOpenAdd = () => {
+    setAddOpen(true);
+    onClose();
+  };
+
+  const handleCloseAdd = () => {
+    setAddOpen(false);
+    onReopenParent?.();
+  };
+
+  const handleCreated = () => {
+    mutate();
+  };
 
   const customDropdown = (menu: ReactNode) => <div>{menu}</div>;
 
   return (
+    <>
     <Modal
       open={isOpen}
       onCancel={onClose}
@@ -221,6 +244,8 @@ export function ModalMaterialEquivalences({
       {/* Add link */}
       <div className=" pt-2 pb-4">
         <button
+          type="button"
+          onClick={handleOpenAdd}
           className="text-sm font-medium flex items-center gap-1 hover:opacity-70 transition-opacity"
           style={{ color: "#141414" }}
         >
@@ -249,6 +274,15 @@ export function ModalMaterialEquivalences({
         </AntButton>
       </div>
     </Modal>
+    {catalogMaterialId !== undefined && (
+      <ModalAddMaterialEquivalences
+        isOpen={addOpen}
+        onClose={handleCloseAdd}
+        catalogMaterialId={catalogMaterialId}
+        onCreated={handleCreated}
+      />
+    )}
+    </>
   );
 }
 

--- a/src/modules/dataQuality/components/ModalMaterialEquivalences/ModalMaterialEquivalences.tsx
+++ b/src/modules/dataQuality/components/ModalMaterialEquivalences/ModalMaterialEquivalences.tsx
@@ -1,49 +1,17 @@
 "use client";
 
 import { ReactNode } from "react";
-import { Modal, Button as AntButton, Dropdown } from "antd";
+import { Modal, Button as AntButton, Dropdown, Spin } from "antd";
 import { History, MoreHorizontal, Plus, Edit, Trash2 } from "lucide-react";
+import { useCatalogMaterialEquivalences } from "../../hooks/useCatalogMaterialEquivalences";
 
 interface ModalMaterialEquivalencesProps {
   isOpen: boolean;
   onClose: () => void;
+  catalogMaterialId?: number;
   clientCode?: string;
   clientName?: string;
 }
-
-interface MaterialEquivalence {
-  id: number;
-  catalog_material_id: number;
-  internal_sku: string;
-  internal_name: string;
-  conversion_factor: number;
-  valid_from: string;
-  valid_to: string | null;
-  is_active: number;
-}
-
-const MOCK_EQUIVALENCES: MaterialEquivalence[] = [
-  {
-    id: 3,
-    catalog_material_id: 145358,
-    internal_sku: "FAKE-SKU-145358",
-    internal_name: "Material fake 145358",
-    conversion_factor: 1.25,
-    valid_from: "2001-11-12T00:00:00.000Z",
-    valid_to: "2002-11-12T00:00:00.000Z",
-    is_active: 0
-  },
-  {
-    id: 2,
-    catalog_material_id: 145358,
-    internal_sku: "FAKE-SKU-145358",
-    internal_name: "Material fake 145358",
-    conversion_factor: 1.25,
-    valid_from: "2003-01-01T00:00:00.000Z",
-    valid_to: null,
-    is_active: 1
-  }
-];
 
 const formatDate = (iso: string | null) => {
   if (!iso) return null;
@@ -53,18 +21,11 @@ const formatDate = (iso: string | null) => {
 export function ModalMaterialEquivalences({
   isOpen,
   onClose,
+  catalogMaterialId,
   clientCode,
   clientName
 }: ModalMaterialEquivalencesProps) {
-  const skus = MOCK_EQUIVALENCES.map((m) => ({
-    id: m.id,
-    productName: m.internal_name,
-    sku: m.internal_sku,
-    factor: m.conversion_factor,
-    desde: formatDate(m.valid_from),
-    hasta: formatDate(m.valid_to),
-    isVigente: m.is_active === 1
-  }));
+  const { data: equivalences, isLoading } = useCatalogMaterialEquivalences(catalogMaterialId);
 
   const customDropdown = (menu: ReactNode) => <div>{menu}</div>;
 
@@ -156,92 +117,103 @@ export function ModalMaterialEquivalences({
             </tr>
           </thead>
           <tbody>
-            {skus.length === 0 && (
+            {isLoading && (
+              <tr>
+                <td colSpan={6} className="text-center py-8">
+                  <Spin />
+                </td>
+              </tr>
+            )}
+            {!isLoading && equivalences.length === 0 && (
               <tr>
                 <td colSpan={6} className="text-center py-8 text-sm" style={{ color: "#888" }}>
                   No hay periodos registrados.
                 </td>
               </tr>
             )}
-            {skus.map((sku) => {
-              const rowColor = sku.isVigente ? "#1a6600" : "#BBBBBB";
-              const rowBg = sku.isVigente ? "rgba(203,231,30,0.10)" : "transparent";
-              return (
-                <tr
-                  key={sku.id}
-                  style={{ borderBottom: "1px solid #F3F3F3", backgroundColor: rowBg }}
-                >
-                  <td className="py-3 pr-4 rounded-l">
-                    <span className="font-medium" style={{ color: rowColor }}>
-                      {sku.productName}
-                    </span>
-                  </td>
-                  <td className="py-3 pr-4" style={{ color: rowColor }}>
-                    {sku.sku}
-                  </td>
-                  <td className="py-3" style={{ color: rowColor }}>
-                    {sku.factor}
-                  </td>
-                  <td className="py-3" style={{ color: rowColor }}>
-                    {sku.desde || "–"}
-                  </td>
-                  <td className="py-3">
-                    {sku.hasta ? (
-                      <span style={{ color: rowColor }}>{sku.hasta}</span>
-                    ) : (
-                      <span
-                        className="text-[11px] font-semibold px-2 py-0.5 rounded-full"
-                        style={{ backgroundColor: "#CBE71E", color: "#141414" }}
-                      >
-                        Vigente
+            {!isLoading &&
+              equivalences.map((equivalence) => {
+                const isActive = equivalence.is_active === 1;
+                const rowColor = isActive ? "#1a6600" : "#BBBBBB";
+                const rowBg = isActive ? "rgba(203,231,30,0.10)" : "transparent";
+                return (
+                  <tr
+                    key={equivalence.id}
+                    style={{ borderBottom: "1px solid #F3F3F3", backgroundColor: rowBg }}
+                  >
+                    <td className="py-3 pr-4 rounded-l">
+                      <span className="font-medium" style={{ color: rowColor }}>
+                        {equivalence.internal_name}
                       </span>
-                    )}
-                  </td>
-                  <td className="py-3 text-right">
-                    <Dropdown
-                      dropdownRender={customDropdown}
-                      placement="bottomRight"
-                      trigger={["click"]}
-                      menu={{
-                        items: [
-                          {
-                            key: "edit",
-                            label: (
-                              <AntButton
-                                className="buttonNoBorder"
-                                icon={<Edit className="w-3.5 h-3.5" />}
-                                onClick={() => {}}
-                              >
-                                Editar
-                              </AntButton>
-                            )
-                          },
-                          {
-                            key: "delete",
-                            label: (
-                              <AntButton
-                                className="buttonNoBorder"
-                                icon={<Trash2 className="w-3.5 h-3.5" />}
-                                onClick={() => {}}
-                              >
-                                Eliminar
-                              </AntButton>
-                            )
-                          }
-                        ]
-                      }}
-                    >
-                      <button
-                        className="w-7 h-7 rounded flex items-center justify-center hover:bg-gray-100 transition-colors"
-                        style={{ color: "#888" }}
+                    </td>
+                    <td className="py-3 pr-4" style={{ color: rowColor }}>
+                      {equivalence.internal_sku}
+                    </td>
+                    <td className="py-3" style={{ color: rowColor }}>
+                      {equivalence.conversion_factor}
+                    </td>
+                    <td className="py-3" style={{ color: rowColor }}>
+                      {formatDate(equivalence.valid_from) || "–"}
+                    </td>
+                    <td className="py-3">
+                      {isActive ? (
+                        <span
+                          className="text-[11px] font-semibold px-2 py-0.5 rounded-full"
+                          style={{ backgroundColor: "#CBE71E", color: "#141414" }}
+                        >
+                          Vigente
+                        </span>
+                      ) : equivalence.valid_to ? (
+                        <span style={{ color: rowColor }}>{formatDate(equivalence.valid_to)}</span>
+                      ) : (
+                        <span style={{ color: rowColor }}>–</span>
+                      )}
+                    </td>
+                    <td className="py-3 text-right">
+                      <Dropdown
+                        dropdownRender={customDropdown}
+                        placement="bottomRight"
+                        trigger={["click"]}
+                        menu={{
+                          items: [
+                            {
+                              key: "edit",
+                              label: (
+                                <AntButton
+                                  className="buttonNoBorder"
+                                  icon={<Edit className="w-3.5 h-3.5" />}
+                                  onClick={() => {}}
+                                >
+                                  Editar
+                                </AntButton>
+                              )
+                            },
+                            {
+                              key: "delete",
+                              label: (
+                                <AntButton
+                                  className="buttonNoBorder"
+                                  icon={<Trash2 className="w-3.5 h-3.5" />}
+                                  onClick={() => {}}
+                                >
+                                  Eliminar
+                                </AntButton>
+                              )
+                            }
+                          ]
+                        }}
                       >
-                        <MoreHorizontal className="w-4 h-4" />
-                      </button>
-                    </Dropdown>
-                  </td>
-                </tr>
-              );
-            })}
+                        <button
+                          className="w-7 h-7 rounded flex items-center justify-center hover:bg-gray-100 transition-colors"
+                          style={{ color: "#888" }}
+                        >
+                          <MoreHorizontal className="w-4 h-4" />
+                        </button>
+                      </Dropdown>
+                    </td>
+                  </tr>
+                );
+              })}
           </tbody>
         </table>
       </div>

--- a/src/modules/dataQuality/components/ModalMaterialEquivalences/ModalMaterialEquivalences.tsx
+++ b/src/modules/dataQuality/components/ModalMaterialEquivalences/ModalMaterialEquivalences.tsx
@@ -1,0 +1,283 @@
+"use client";
+
+import { ReactNode } from "react";
+import { Modal, Button as AntButton, Dropdown } from "antd";
+import { History, MoreHorizontal, Plus, Edit, Trash2 } from "lucide-react";
+
+interface ModalMaterialEquivalencesProps {
+  isOpen: boolean;
+  onClose: () => void;
+  clientCode?: string;
+  clientName?: string;
+}
+
+interface MaterialEquivalence {
+  id: number;
+  catalog_material_id: number;
+  internal_sku: string;
+  internal_name: string;
+  conversion_factor: number;
+  valid_from: string;
+  valid_to: string | null;
+  is_active: number;
+}
+
+const MOCK_EQUIVALENCES: MaterialEquivalence[] = [
+  {
+    id: 3,
+    catalog_material_id: 145358,
+    internal_sku: "FAKE-SKU-145358",
+    internal_name: "Material fake 145358",
+    conversion_factor: 1.25,
+    valid_from: "2001-11-12T00:00:00.000Z",
+    valid_to: "2002-11-12T00:00:00.000Z",
+    is_active: 0
+  },
+  {
+    id: 2,
+    catalog_material_id: 145358,
+    internal_sku: "FAKE-SKU-145358",
+    internal_name: "Material fake 145358",
+    conversion_factor: 1.25,
+    valid_from: "2003-01-01T00:00:00.000Z",
+    valid_to: null,
+    is_active: 1
+  }
+];
+
+const formatDate = (iso: string | null) => {
+  if (!iso) return null;
+  return iso.slice(0, 10);
+};
+
+export function ModalMaterialEquivalences({
+  isOpen,
+  onClose,
+  clientCode,
+  clientName
+}: ModalMaterialEquivalencesProps) {
+  const skus = MOCK_EQUIVALENCES.map((m) => ({
+    id: m.id,
+    productName: m.internal_name,
+    sku: m.internal_sku,
+    factor: m.conversion_factor,
+    desde: formatDate(m.valid_from),
+    hasta: formatDate(m.valid_to),
+    isVigente: m.is_active === 1
+  }));
+
+  const customDropdown = (menu: ReactNode) => <div>{menu}</div>;
+
+  return (
+    <Modal
+      open={isOpen}
+      onCancel={onClose}
+      footer={null}
+      closable={false}
+      width={820}
+      centered
+      styles={{ body: { padding: 0, backgroundColor: "#FFFFFF" } }}
+    >
+      {/* Header */}
+      <div className="flex items-center gap-3 pb-5 border-b" style={{ borderColor: "#EEEEEE" }}>
+        <div
+          className="w-9 h-9 rounded-lg flex items-center justify-center shrink-0"
+          style={{ backgroundColor: "rgba(203,231,30,0.15)" }}
+        >
+          <History className="w-4 h-4" style={{ color: "#8BAF00" }} />
+        </div>
+        <h2 className="text-base font-semibold flex-1" style={{ color: "#141414" }}>
+          Historial de equivalencias
+        </h2>
+      </div>
+
+      {/* Subtitle */}
+      <div className=" pt-4 pb-2 flex flex-col gap-1.5">
+        <div className="flex items-center gap-2">
+          <span
+            className="text-[11px] font-medium px-1.5 py-0.5 rounded"
+            style={{ backgroundColor: "#F3F3F3", color: "#888" }}
+          >
+            Cod. cliente
+          </span>
+          <span className="text-sm font-medium" style={{ color: "#333" }}>
+            {clientCode}
+          </span>
+        </div>
+        <div className="flex items-center gap-2">
+          <span
+            className="text-[11px] font-medium px-1.5 py-0.5 rounded"
+            style={{ backgroundColor: "#F3F3F3", color: "#888" }}
+          >
+            Producto cliente
+          </span>
+          <span className="text-sm" style={{ color: "#555" }}>
+            {clientName}
+          </span>
+        </div>
+      </div>
+
+      {/* Table */}
+      <div className=" pb-1">
+        <table className="w-full text-sm">
+          <thead>
+            <tr style={{ borderBottom: "1px solid #EEEEEE" }}>
+              <th
+                className="text-left py-2.5 font-semibold text-sm"
+                style={{ color: "#141414", minWidth: "320px" }}
+              >
+                Nombre producto
+              </th>
+              <th
+                className="text-left py-2.5 font-semibold text-sm"
+                style={{ color: "#141414", width: "160px" }}
+              >
+                SKU
+              </th>
+              <th
+                className="text-left py-2.5 font-semibold text-sm"
+                style={{ color: "#141414", width: "60px" }}
+              >
+                Factor
+              </th>
+              <th
+                className="text-left py-2.5 font-semibold text-sm"
+                style={{ color: "#141414", width: "100px" }}
+              >
+                Desde
+              </th>
+              <th
+                className="text-left py-2.5 font-semibold text-sm"
+                style={{ color: "#141414", width: "100px" }}
+              >
+                Hasta
+              </th>
+              <th style={{ width: "48px" }} />
+            </tr>
+          </thead>
+          <tbody>
+            {skus.length === 0 && (
+              <tr>
+                <td colSpan={6} className="text-center py-8 text-sm" style={{ color: "#888" }}>
+                  No hay periodos registrados.
+                </td>
+              </tr>
+            )}
+            {skus.map((sku) => {
+              const rowColor = sku.isVigente ? "#1a6600" : "#BBBBBB";
+              const rowBg = sku.isVigente ? "rgba(203,231,30,0.10)" : "transparent";
+              return (
+                <tr
+                  key={sku.id}
+                  style={{ borderBottom: "1px solid #F3F3F3", backgroundColor: rowBg }}
+                >
+                  <td className="py-3 pr-4 rounded-l">
+                    <span className="font-medium" style={{ color: rowColor }}>
+                      {sku.productName}
+                    </span>
+                  </td>
+                  <td className="py-3 pr-4" style={{ color: rowColor }}>
+                    {sku.sku}
+                  </td>
+                  <td className="py-3" style={{ color: rowColor }}>
+                    {sku.factor}
+                  </td>
+                  <td className="py-3" style={{ color: rowColor }}>
+                    {sku.desde || "–"}
+                  </td>
+                  <td className="py-3">
+                    {sku.hasta ? (
+                      <span style={{ color: rowColor }}>{sku.hasta}</span>
+                    ) : (
+                      <span
+                        className="text-[11px] font-semibold px-2 py-0.5 rounded-full"
+                        style={{ backgroundColor: "#CBE71E", color: "#141414" }}
+                      >
+                        Vigente
+                      </span>
+                    )}
+                  </td>
+                  <td className="py-3 text-right">
+                    <Dropdown
+                      dropdownRender={customDropdown}
+                      placement="bottomRight"
+                      trigger={["click"]}
+                      menu={{
+                        items: [
+                          {
+                            key: "edit",
+                            label: (
+                              <AntButton
+                                className="buttonNoBorder"
+                                icon={<Edit className="w-3.5 h-3.5" />}
+                                onClick={() => {}}
+                              >
+                                Editar
+                              </AntButton>
+                            )
+                          },
+                          {
+                            key: "delete",
+                            label: (
+                              <AntButton
+                                className="buttonNoBorder"
+                                icon={<Trash2 className="w-3.5 h-3.5" />}
+                                onClick={() => {}}
+                              >
+                                Eliminar
+                              </AntButton>
+                            )
+                          }
+                        ]
+                      }}
+                    >
+                      <button
+                        className="w-7 h-7 rounded flex items-center justify-center hover:bg-gray-100 transition-colors"
+                        style={{ color: "#888" }}
+                      >
+                        <MoreHorizontal className="w-4 h-4" />
+                      </button>
+                    </Dropdown>
+                  </td>
+                </tr>
+              );
+            })}
+          </tbody>
+        </table>
+      </div>
+
+      {/* Add link */}
+      <div className=" pt-2 pb-4">
+        <button
+          className="text-sm font-medium flex items-center gap-1 hover:opacity-70 transition-opacity"
+          style={{ color: "#141414" }}
+        >
+          <Plus className="w-3.5 h-3.5" /> Agregar equivalencia
+        </button>
+      </div>
+
+      {/* Footer */}
+      <div
+        className="pt-3 border-t flex items-center justify-end"
+        style={{ borderColor: "#EEEEEE" }}
+      >
+        <AntButton
+          onClick={onClose}
+          className="text-sm font-medium"
+          style={{
+            height: 32,
+            padding: "0 16px",
+            borderRadius: 6,
+            border: "1px solid #E5E7EB",
+            color: "#141414",
+            backgroundColor: "#FFFFFF"
+          }}
+        >
+          Cerrar
+        </AntButton>
+      </div>
+    </Modal>
+  );
+}
+
+export default ModalMaterialEquivalences;

--- a/src/modules/dataQuality/components/ModalMaterialEquivalences/ModalMaterialEquivalences.tsx
+++ b/src/modules/dataQuality/components/ModalMaterialEquivalences/ModalMaterialEquivalences.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { ReactNode, useState } from "react";
+import { ReactNode, useEffect, useState } from "react";
 import { Modal, Button as AntButton, Dropdown, Spin } from "antd";
 import { History, MoreHorizontal, Plus, Edit, Trash2 } from "lucide-react";
 import { useCatalogMaterialEquivalences } from "../../hooks/useCatalogMaterialEquivalences";
@@ -36,6 +36,12 @@ export function ModalMaterialEquivalences({
     mutate
   } = useCatalogMaterialEquivalences(catalogMaterialId);
   const [addOpen, setAddOpen] = useState(false);
+
+  useEffect(() => {
+    if (isOpen) {
+      mutate();
+    }
+  }, [isOpen]);
 
   const handleOpenAdd = () => {
     setAddOpen(true);

--- a/src/modules/dataQuality/hooks/useCatalogMaterialEquivalences.ts
+++ b/src/modules/dataQuality/hooks/useCatalogMaterialEquivalences.ts
@@ -1,0 +1,25 @@
+import useSWR from "swr";
+import { fetcher } from "@/utils/api/api";
+import { IGetCatalogMaterialEquivalence } from "@/types/dataQuality/IDataQuality";
+import { GenericResponse } from "@/types/global/IGlobal";
+
+export const useCatalogMaterialEquivalences = (catalogMaterialId?: number) => {
+  const pathKey = catalogMaterialId
+    ? `/data/catalog/materials/${catalogMaterialId}/equivalence`
+    : null;
+
+  const { data, error, isLoading, mutate } = useSWR<
+    GenericResponse<IGetCatalogMaterialEquivalence[]>
+  >(pathKey, fetcher, {
+    revalidateOnFocus: false,
+    revalidateOnReconnect: false,
+    dedupingInterval: 60000
+  });
+
+  return {
+    data: data?.data ?? [],
+    isLoading,
+    error,
+    mutate
+  };
+};

--- a/src/services/dataQuality/dataQuality.ts
+++ b/src/services/dataQuality/dataQuality.ts
@@ -20,7 +20,8 @@ import {
   IUploadMassiveOrHistoricalRequest,
   IPOS,
   IPOSPayload,
-  IClientDetailArchiveClient
+  IClientDetailArchiveClient,
+  IPostCatalogMaterialEquivalence
 } from "@/types/dataQuality/IDataQuality";
 
 export const getSummaryCountries = async (projectId: number): Promise<ISummaryCountries> => {
@@ -592,6 +593,22 @@ export const uploadPointsOfSaleFile = async (file: File): Promise<any> => {
     return response.data;
   } catch (error) {
     console.error("Error uploading points of sale file:", error);
+    throw error;
+  }
+};
+
+export const createCatalogMaterialEquivalence = async (
+  catalogMaterialId: number,
+  equivalenceData: IPostCatalogMaterialEquivalence
+): Promise<any> => {
+  try {
+    const response: GenericResponse<any> = await API.post(
+      `${config.API_HOST}/data/catalog/materials/${catalogMaterialId}/equivalence`,
+      equivalenceData
+    );
+    return response.data;
+  } catch (error) {
+    console.error("Error creating catalog material equivalence:", error);
     throw error;
   }
 };

--- a/src/types/dataQuality/IDataQuality.ts
+++ b/src/types/dataQuality/IDataQuality.ts
@@ -423,3 +423,19 @@ export interface IPOS {
 
 export type IPOSPayload = Pick<IPOS, "sold_to" | "id_country" | "pos_id" | "pos_name"> &
   Partial<Omit<IPOS, "sold_to" | "id_country" | "pos_id" | "pos_name">>;
+
+export interface IGetCatalogMaterialEquivalence {
+  id: number;
+  catalog_material_id: number;
+  internal_sku: string;
+  internal_name: string;
+  conversion_factor: number;
+  valid_from: string;
+  valid_to: string | null;
+  is_active: number;
+}
+
+export type IPostCatalogMaterialEquivalence = Omit<
+  IGetCatalogMaterialEquivalence,
+  "id" | "catalog_material_id"
+>;

--- a/src/types/dataQuality/IDataQuality.ts
+++ b/src/types/dataQuality/IDataQuality.ts
@@ -435,7 +435,10 @@ export interface IGetCatalogMaterialEquivalence {
   is_active: number;
 }
 
-export type IPostCatalogMaterialEquivalence = Omit<
-  IGetCatalogMaterialEquivalence,
-  "id" | "catalog_material_id"
->;
+export interface IPostCatalogMaterialEquivalence {
+  material_code: number;
+  conversion_factor: number;
+  valid_from: string;
+  valid_to: string | null;
+  is_active: number;
+}


### PR DESCRIPTION
This pull request introduces a new feature for managing material equivalences within the catalog system, along with some minor UI updates. The most significant changes are the addition of a modal for creating material equivalences, integration of this modal into the catalog table, and a new action to view historical equivalences. Additionally, there are small improvements to the table headers.

**Material Equivalence Management:**

* Added a new component `ModalAddMaterialEquivalences` that provides a form for creating material equivalences, including validation, integration with backend services, and user feedback.
* Integrated the new `ModalMaterialEquivalences` modal into the `CatalogsTable` component, allowing users to view historical equivalences for a catalog material. [[1]](diffhunk://#diff-1f0a876a0df4fe81453b9ce32f2a20bc554568794d435b418acd50bf6fac927dR22) [[2]](diffhunk://#diff-1f0a876a0df4fe81453b9ce32f2a20bc554568794d435b418acd50bf6fac927dR420-R429)

**Catalog Table Enhancements:**

* Added a "Ver histórico" (View history) action to the dropdown menu for each catalog item, opening the material equivalence modal and passing relevant catalog information. [[1]](diffhunk://#diff-1f0a876a0df4fe81453b9ce32f2a20bc554568794d435b418acd50bf6fac927dR80) [[2]](diffhunk://#diff-1f0a876a0df4fe81453b9ce32f2a20bc554568794d435b418acd50bf6fac927dR335-R349)
* Updated the table header from "SKU" to "GMN" for improved clarity and accuracy.

**UI Improvements:**

* Added the `History` icon from `lucide-react` to support the new historical view action.