### PR TITLE
Feat/add error style invoice modal po detail

### DIFF
--- a/src/modules/purchaseOrders/components/dialogs/invoice-modal/invoice-modal.tsx
+++ b/src/modules/purchaseOrders/components/dialogs/invoice-modal/invoice-modal.tsx
@@ -6,6 +6,7 @@ import { Upload, X, Check, AlertTriangle, Loader2 } from "lucide-react";
 import { message } from "antd";
 import { purchaseOrderActions } from "@/services/purchaseOrders/purchaseOrders";
 import { IInvoiceActionPayload } from "@/types/purchaseOrders/purchaseOrders";
+import { ApiError } from "@/utils/api/api";
 
 interface InvoiceEntry {
   id: string;
@@ -35,12 +36,14 @@ export function InvoiceModal({
   const [invoices, setInvoices] = useState<InvoiceEntry[]>([createEmptyInvoice()]);
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [errorInvoiceIds, setErrorInvoiceIds] = useState<string[]>([]);
   const fileInputRefs = useRef<Map<string, HTMLInputElement>>(new Map());
 
   useEffect(() => {
     if (!open) {
       setInvoices([createEmptyInvoice()]);
       setError(null);
+      setErrorInvoiceIds([]);
       setIsLoading(false);
     }
   }, [open]);
@@ -64,6 +67,7 @@ export function InvoiceModal({
     setInvoices((prev) =>
       prev.map((inv) => (inv.id === invoiceEntryId ? { ...inv, invoiceId: value } : inv))
     );
+    setErrorInvoiceIds((prev) => prev.filter((id) => id !== value));
   };
 
   const handleAddInvoice = () => {
@@ -84,6 +88,7 @@ export function InvoiceModal({
 
     setIsLoading(true);
     setError(null);
+    setErrorInvoiceIds([]);
 
     try {
       const invoiceIds = invoices.map((inv) => inv.invoiceId.trim());
@@ -107,6 +112,9 @@ export function InvoiceModal({
       const errorMessage = error instanceof Error ? error.message : "Error al agregar las facturas";
       setError(errorMessage);
       message.error(errorMessage);
+      if (error instanceof ApiError && Array.isArray(error.data?.invoices)) {
+        setErrorInvoiceIds(error.data.invoices);
+      }
     } finally {
       setIsLoading(false);
     }
@@ -162,7 +170,7 @@ export function InvoiceModal({
                     placeholder="ID de factura (Ej: FV-2024-001)"
                     value={invoice.invoiceId}
                     onChange={(e) => handleInvoiceIdChange(invoice.id, e.target.value)}
-                    className="border-gray-300"
+                    className={errorInvoiceIds.includes(invoice.invoiceId) ? "border-red-500 focus-visible:border-red-500 focus-visible:ring-red-500/50" : "border-gray-300"}
                   />
                 </div>
 

--- a/src/modules/purchaseOrders/components/dialogs/invoice-modal/invoice-modal.tsx
+++ b/src/modules/purchaseOrders/components/dialogs/invoice-modal/invoice-modal.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useRef } from "react";
+import React, { useState, useEffect, useRef, useMemo } from "react";
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/modules/chat/ui/dialog";
 import { Button } from "@/modules/chat/ui/button";
 import { Input } from "@/modules/chat/ui/input";
@@ -120,7 +120,14 @@ export function InvoiceModal({
     }
   };
 
-  const isFormValid = invoices.every((inv) => inv.invoiceId.trim() && inv.file);
+  const duplicateInvoiceIds = useMemo(() => {
+    const ids = invoices.map((inv) => inv.invoiceId.trim()).filter(Boolean);
+    return ids.filter((id, index) => ids.indexOf(id) !== index);
+  }, [invoices]);
+
+  const hasDuplicates = duplicateInvoiceIds.length > 0;
+
+  const isFormValid = invoices.every((inv) => inv.invoiceId.trim() && inv.file) && !hasDuplicates;
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
@@ -170,7 +177,13 @@ export function InvoiceModal({
                     placeholder="ID de factura (Ej: FV-2024-001)"
                     value={invoice.invoiceId}
                     onChange={(e) => handleInvoiceIdChange(invoice.id, e.target.value)}
-                    className={errorInvoiceIds.includes(invoice.invoiceId) ? "border-red-500 focus-visible:border-red-500 focus-visible:ring-red-500/50" : "border-gray-300"}
+                    className={
+                      errorInvoiceIds.includes(invoice.invoiceId) ||
+                      (invoice.invoiceId.trim() &&
+                        duplicateInvoiceIds.includes(invoice.invoiceId.trim()))
+                        ? "border-red-500 focus-visible:border-red-500 focus-visible:ring-red-500/50"
+                        : "border-gray-300"
+                    }
                   />
                 </div>
 
@@ -203,11 +216,13 @@ export function InvoiceModal({
             + Agregar otra factura
           </Button>
 
-          {error && (
+          {(error || hasDuplicates) && (
             <div className="bg-red-50 border border-red-200 rounded-lg p-3">
-              <div className="flex gap-2">
+              <div className="flex gap-2 items-center align-center">
                 <AlertTriangle className="h-5 w-5 text-red-600 flex-shrink-0 mt-0.5" />
-                <p className="text-sm text-red-800">{error}</p>
+                <p className="text-sm text-red-800">
+                  {hasDuplicates ? "Hay IDs de factura duplicados" : error}
+                </p>
               </div>
             </div>
           )}


### PR DESCRIPTION
This pull request enhances the invoice modal in the purchase orders module by improving error handling and validation for invoice IDs. The main improvements include detecting and highlighting duplicate invoice IDs, providing more granular error feedback for specific invoices, and updating the UI to clearly indicate problematic entries.

Validation and Error Handling Improvements:
- Added logic to detect duplicate invoice IDs in the form, preventing submission when duplicates exist and displaying a specific error message. [[1]](diffhunk://#diff-8bec1115a2881e84011c8e82721b0ef5bc040f07b5756bd5f702fae56306d02dR115-R130) [[2]](diffhunk://#diff-8bec1115a2881e84011c8e82721b0ef5bc040f07b5756bd5f702fae56306d02dL198-R225)
- Introduced `errorInvoiceIds` state to track and highlight invoice entries that have errors returned from the API, with corresponding UI feedback. [[1]](diffhunk://#diff-8bec1115a2881e84011c8e82721b0ef5bc040f07b5756bd5f702fae56306d02dR39-R46) [[2]](diffhunk://#diff-8bec1115a2881e84011c8e82721b0ef5bc040f07b5756bd5f702fae56306d02dL165-R186)
- Updated error display to show either API errors or duplicate ID warnings, depending on the validation state.

UI and UX Enhancements:
- Modified the input field styling to visually indicate errors for invoice IDs that are either duplicates or returned as problematic by the API.
- Reset error states and loading indicators more thoroughly when the modal is closed or a new submission is started. [[1]](diffhunk://#diff-8bec1115a2881e84011c8e82721b0ef5bc040f07b5756bd5f702fae56306d02dR39-R46) [[2]](diffhunk://#diff-8bec1115a2881e84011c8e82721b0ef5bc040f07b5756bd5f702fae56306d02dR91)

Code Quality:
- Added missing imports (`useMemo`, `ApiError`) to support new validation and error handling logic.