### PR TITLE
feat(purchaseOrders): add customer column to invoice upload modal

### DIFF
--- a/src/modules/purchaseOrders/components/dialogs/modal-upload-invoices-purchase-orders/ModalUploadInvoicesPurchaseOrders.tsx
+++ b/src/modules/purchaseOrders/components/dialogs/modal-upload-invoices-purchase-orders/ModalUploadInvoicesPurchaseOrders.tsx
@@ -3,7 +3,7 @@ import { Modal, Button, Input, message } from "antd";
 import { Paperclip, Plus, X, Upload } from "lucide-react";
 import { Badge } from "@/modules/chat/ui/badge";
 
-import { IOrder } from "@/types/purchaseOrders/purchaseOrders";
+import { IOrder, IPurchaseOrder } from "@/types/purchaseOrders/purchaseOrders";
 import { sendMultiplePurchaseOrdersToBilling } from "@/services/purchaseOrders/purchaseOrders";
 
 const renderStatusBadge = (status: string, statusColor: string, _noveltyTypes: string) => (
@@ -32,6 +32,7 @@ interface ModalUploadInvoicesPurchaseOrdersProps {
   isOpen: boolean;
   onClose: () => void;
   orders: IOrder[];
+  packages?: IPurchaseOrder[];
   onSuccess?: () => void;
 }
 
@@ -39,6 +40,7 @@ export function ModalUploadInvoicesPurchaseOrders({
   isOpen,
   onClose,
   orders,
+  packages = [],
   onSuccess
 }: ModalUploadInvoicesPurchaseOrdersProps) {
   const [facturaInputs, setFacturaInputs] = useState<Record<number, FacturaRow[]>>({});
@@ -133,7 +135,7 @@ export function ModalUploadInvoicesPurchaseOrders({
         </div>
       }
       centered
-      width={900}
+      width={1200}
     >
       {Object.keys(facturaInputs).length === 0 ? (
         <p className="text-sm text-gray-500 py-4 text-center">
@@ -145,6 +147,7 @@ export function ModalUploadInvoicesPurchaseOrders({
             <thead>
               <tr className="border-b-2 border-gray-200 bg-gray-50">
                 <th className="text-left px-4 py-3 font-semibold text-gray-700 w-44">OC</th>
+                <th className="text-left px-4 py-3 font-semibold text-gray-700">Cliente</th>
                 <th className="text-left px-4 py-3 font-semibold text-gray-700 w-36">Estado</th>
                 <th className="text-right px-4 py-3 font-semibold text-gray-700 w-36">Monto</th>
                 <th className="text-left px-4 py-3 font-semibold text-gray-700">No. Factura</th>
@@ -167,6 +170,31 @@ export function ModalUploadInvoicesPurchaseOrders({
                           {order.orderNumber}
                         </span>
                       ) : null}
+                    </td>
+                    {/* Cliente — only on first row */}
+                    <td className="px-4 py-2.5 align-middle max-w-64">
+                      {rowIdx === 0
+                        ? (() => {
+                            const customerName =
+                              packages.find((p) => p.packageId === order.packageId)
+                                ?.customerName || "";
+                            return (
+                              <div className="flex flex-col">
+                                <span className="truncate" title={customerName}>
+                                  {customerName || "-"}
+                                </span>
+                                {order.deliveryAddress && (
+                                  <span
+                                    className="text-xs text-gray-500 truncate"
+                                    title={order.deliveryAddress}
+                                  >
+                                    {order.deliveryAddress}
+                                  </span>
+                                )}
+                              </div>
+                            );
+                          })()
+                        : null}
                     </td>
 
                     {/* Estado — only on first row */}

--- a/src/modules/purchaseOrders/containers/purchase-orders-view/PurchaseOrdersView.tsx
+++ b/src/modules/purchaseOrders/containers/purchase-orders-view/PurchaseOrdersView.tsx
@@ -254,6 +254,7 @@ export function PurchaseOrdersView() {
         isOpen={whichModalIsOpen.selected === 3}
         onClose={closeModals}
         orders={selectedOrders}
+        packages={data}
         onSuccess={() => {
           mutate();
           setSelectedPackageRows([]);


### PR DESCRIPTION
This pull request enhances the `ModalUploadInvoicesPurchaseOrders` component to display additional customer information for each purchase order and improves the modal's layout for better usability. The main changes include passing and using the `packages` data to show customer details, updating the table to include a "Cliente" column, and increasing the modal's width.

**UI and Data Enhancements:**

* Added a new "Cliente" column to the invoices table, displaying the customer name and delivery address for each order by matching with the corresponding `packageId` in the `packages` prop. [[1]](diffhunk://#diff-cdc5814e7d6595b6530a835565c214772a9e49d209e691bf8d3678a73bec88d0R150) [[2]](diffhunk://#diff-cdc5814e7d6595b6530a835565c214772a9e49d209e691bf8d3678a73bec88d0R174-R198)
* Increased the modal width from 900 to 1200 to accommodate the additional information and improve readability.

**Component API Changes:**

* Updated the `ModalUploadInvoicesPurchaseOrders` component to accept an optional `packages` prop (of type `IPurchaseOrder[]`), which defaults to an empty array.
* Modified `PurchaseOrdersView` to pass the `data` as the `packages` prop when rendering the modal.

**Type Imports:**

* Imported `IPurchaseOrder` from the types file to support the new prop.