### PR TITLE
feat: add attachment support to email template creation

### DIFF
--- a/src/modules/massCommunications/components/ModalCreateEmailTemplate/ModalCreateEmailTemplate.tsx
+++ b/src/modules/massCommunications/components/ModalCreateEmailTemplate/ModalCreateEmailTemplate.tsx
@@ -147,7 +147,7 @@ export default function ModalCreateEmailTemplate({
         message: data.body,
         via: "email",
         contact_roles: Array.from(data.templateRoles).map((role) => Number(role.split("_")[1])),
-        other_mails: [],
+        attachment_ids: Array.from(data.selectedAttachments).map((att) => Number(att)),
         comunication_type: 3,
         action_type_ids: [17]
       });
@@ -161,13 +161,10 @@ export default function ModalCreateEmailTemplate({
     }
   };
 
-  const renderedSubject = subjectValue.replace(
-    /\{\{(.+?)\}\}/g,
-    (_: string, tag: string) => {
-      const found = templateTags.find((t) => t.label === tag);
-      return found?.mock ?? `[${tag}]`;
-    }
-  );
+  const renderedSubject = subjectValue.replace(/\{\{(.+?)\}\}/g, (_: string, tag: string) => {
+    const found = templateTags.find((t) => t.label === tag);
+    return found?.mock ?? `[${tag}]`;
+  });
   const renderedBody = bodyValue.replace(/\{\{(.+?)\}\}/g, (_: string, tag: string) => {
     const found = templateTags.find((t) => t.label === tag);
     return found?.mock ?? `[${tag}]`;

--- a/src/types/communications/ICommunications.ts
+++ b/src/types/communications/ICommunications.ts
@@ -238,7 +238,7 @@ export interface ICreateCommunicationTemplate {
   message: string;
   via: string;
   contact_roles: number[];
-  other_mails: string[];
+  attachment_ids: number[];
   comunication_type: number;
   action_type_ids: number[];
 }


### PR DESCRIPTION
Replace other_mails field with attachment_ids to enable sending attachments with email templates. The attachment IDs are now mapped from data.selectedAttachments.