### PR TITLE
feat(purchase-orders): enable bulk document download for multiple pac…

### DIFF
--- a/src/modules/purchaseOrders/components/actions-modal-purchase-order/ActionsModalPurchaseOrder.tsx
+++ b/src/modules/purchaseOrders/components/actions-modal-purchase-order/ActionsModalPurchaseOrder.tsx
@@ -94,6 +94,19 @@ export const ActionsModalPurchaseOrder: React.FC<ActionsModalPurchaseOrderProps>
     return true;
   };
 
+  const validatePackagesSelection = (): boolean => {
+    if (selectedPackageRows.length === 0) {
+      message.warning("Selecciona al menos un pedido para realizar esta acción");
+      return false;
+    }
+    const firstStatus = selectedPackageRows[0].status;
+    if (selectedPackageRows.some((p) => p.status !== firstStatus)) {
+      message.warning("Todos los pedidos seleccionados deben tener el mismo estado");
+      return false;
+    }
+    return true;
+  };
+
   const validateOrderSelection = (): boolean => {
     if (selectedOrders.length === 0) {
       message.warning("Selecciona al menos una orden para realizar esta acción");
@@ -211,7 +224,7 @@ export const ActionsModalPurchaseOrder: React.FC<ActionsModalPurchaseOrderProps>
   };
 
   const handleOpenDownloadPlaneModal = () => {
-    if (!validatePackageSelection()) return;
+    if (!validatePackagesSelection()) return;
     onClose();
     setIsDownloadPlaneOpen(true);
   };
@@ -315,7 +328,7 @@ export const ActionsModalPurchaseOrder: React.FC<ActionsModalPurchaseOrderProps>
       <ModalDownloadPlane
         isOpen={isDownloadPlaneOpen}
         onClose={() => setIsDownloadPlaneOpen(false)}
-        packageId={String(selectedPackageRows[0]?.packageId)}
+        packageIds={selectedPackageRows.map((row) => String(row.packageId)) || []}
       />
     </>
   );

--- a/src/modules/purchaseOrders/components/modal-download-plane/ModalDownloadPlane.tsx
+++ b/src/modules/purchaseOrders/components/modal-download-plane/ModalDownloadPlane.tsx
@@ -13,10 +13,10 @@ import "./modalDownloadPlane.scss";
 type Props = {
   isOpen: boolean;
   onClose: () => void;
-  packageId: string;
+  packageIds: string[];
 };
 
-export const ModalDownloadPlane: React.FC<Props> = ({ isOpen, onClose, packageId }) => {
+export const ModalDownloadPlane: React.FC<Props> = ({ isOpen, onClose, packageIds }) => {
   const [selectedTypes, setSelectedTypes] = useState<string[]>([]);
   const [files, setFiles] = useState<IAvailableDocument[]>([]);
   const [isLoading, setIsLoading] = useState(false);
@@ -28,7 +28,7 @@ export const ModalDownloadPlane: React.FC<Props> = ({ isOpen, onClose, packageId
     const fetchFiles = async () => {
       setIsLoading(true);
       try {
-        const data = await getDownloadableFiles(packageId);
+        const data = await getDownloadableFiles(packageIds);
         setFiles(data.documents);
       } catch (error) {
         message.error("Error al obtener los archivos disponibles");
@@ -39,7 +39,7 @@ export const ModalDownloadPlane: React.FC<Props> = ({ isOpen, onClose, packageId
     };
 
     fetchFiles();
-  }, [isOpen, packageId]);
+  }, [isOpen, packageIds]);
 
   const total = files.length;
   const selectedCount = selectedTypes.length;
@@ -64,7 +64,7 @@ export const ModalDownloadPlane: React.FC<Props> = ({ isOpen, onClose, packageId
     setIsDownloading(true);
     try {
       const blob = await downloadAvailableDocuments({
-        packageId: Number(packageId),
+        packageIds: packageIds.map((id) => Number(id)),
         documents: selectedTypes
       });
       const url = window.URL.createObjectURL(blob);

--- a/src/services/purchaseOrders/purchaseOrders.ts
+++ b/src/services/purchaseOrders/purchaseOrders.ts
@@ -378,26 +378,26 @@ export const getBatchesByProduct = async (purchaseOrderId: string, productId: st
 };
 
 export const downloadAvailableDocuments = async ({
-  packageId,
+  packageIds,
   orderIds,
   documents
 }: {
-  packageId?: number;
+  packageIds?: number[];
   orderIds?: number[];
   documents: string[];
 }): Promise<Blob> => {
-  if (!packageId && !orderIds) {
-    throw new Error("Debe proporcionar packageId o orderIds para descargar los documentos");
+  if (!packageIds && !orderIds) {
+    throw new Error("Debe proporcionar packageIds o orderIds para descargar los documentos");
   }
-  if (packageId && orderIds) {
-    throw new Error("Solo puede proporcionar packageId o orderIds, no ambos");
+  if (packageIds && orderIds) {
+    throw new Error("Solo puede proporcionar packageIds o orderIds, no ambos");
   }
   try {
     const response = await instance.post(
       `${config.API_HOST}/purchaseOrder/documents/download`,
       {
         ...(orderIds && { order_ids: orderIds }),
-        ...(packageId && { package_id: packageId }),
+        ...(packageIds && { package_ids: packageIds }),
         documents
       },
       { responseType: "blob", timeout: 60000 }
@@ -409,13 +409,13 @@ export const downloadAvailableDocuments = async ({
   }
 };
 
-export const getDownloadableFiles = async (packageId?: string, orderIds?: string[]) => {
-  if (!packageId && !orderIds) {
+export const getDownloadableFiles = async (packageIds?: string[], orderIds?: string[]) => {
+  if (!packageIds && !orderIds) {
     throw new Error(
       "Debe proporcionar packageId o orderIds para obtener los archivos descargables"
     );
   }
-  if (packageId && orderIds) {
+  if (packageIds && orderIds) {
     throw new Error("Solo puede proporcionar packageId o orderIds, no ambos");
   }
   try {
@@ -423,7 +423,7 @@ export const getDownloadableFiles = async (packageId?: string, orderIds?: string
       `${config.API_HOST}/purchaseOrder/documents/available`,
       {
         ...(orderIds && { order_ids: orderIds }),
-        ...(packageId && { package_id: packageId })
+        ...(packageIds && { package_ids: packageIds })
       }
     );
     return response.data;


### PR DESCRIPTION
…kages

Allow users to download documents for multiple selected packages at once instead of one at a time. Adds validation to ensure all selected packages have the same status before processing the bulk download.
This pull request updates the logic for downloading documents related to purchase order packages, allowing users to select and process multiple packages at once instead of being limited to a single package. The changes ensure consistent validation and update the relevant modal, service, and API interactions to handle arrays of package IDs.

**Multi-package download support:**

* Updated the `ActionsModalPurchaseOrder` component to validate that all selected packages have the same status before allowing document download, and to pass all selected package IDs to the download modal instead of just one. [[1]](diffhunk://#diff-4d8b4e74a776f8678328f3c871b6cf2296aec768225b57f4b689bfd0c2a6e729R97-R109) [[2]](diffhunk://#diff-4d8b4e74a776f8678328f3c871b6cf2296aec768225b57f4b689bfd0c2a6e729L214-R227) [[3]](diffhunk://#diff-4d8b4e74a776f8678328f3c871b6cf2296aec768225b57f4b689bfd0c2a6e729L318-R331)
* Modified the `ModalDownloadPlane` component to accept and process an array of `packageIds`, updating all logic and effects to work with multiple packages. [[1]](diffhunk://#diff-b333355049568af417506d7fa4810d17f7a58f5ae7dc164d246a3a76afb8b756L16-R19) [[2]](diffhunk://#diff-b333355049568af417506d7fa4810d17f7a58f5ae7dc164d246a3a76afb8b756L31-R31) [[3]](diffhunk://#diff-b333355049568af417506d7fa4810d17f7a58f5ae7dc164d246a3a76afb8b756L42-R42) [[4]](diffhunk://#diff-b333355049568af417506d7fa4810d17f7a58f5ae7dc164d246a3a76afb8b756L67-R67)

**Backend service and API changes:**

* Refactored the `downloadAvailableDocuments` and `getDownloadableFiles` service functions to accept arrays of package IDs (`packageIds`) instead of a single `packageId`, updating payloads and error handling accordingly. [[1]](diffhunk://#diff-2d0ea313032350d7ddb6483885f5f2af0dde217283b1f2726c97ed692cde2ce1L381-R400) [[2]](diffhunk://#diff-2d0ea313032350d7ddb6483885f5f2af0dde217283b1f2726c97ed692cde2ce1L412-R426)