### PR TITLE
Feat/add payment applications tab load and unload actions

### DIFF
--- a/src/modules/banks/components/payment-applications-table/PaymentApplicationsTable.tsx
+++ b/src/modules/banks/components/payment-applications-table/PaymentApplicationsTable.tsx
@@ -94,6 +94,14 @@ export const PaymentApplicationsTable = ({
     onChange: onSelectChange
   };
 
+  const handleDownload = (url?: string | null) => {
+    if (!url) {
+      message.error("No hay archivo disponible para descargar");
+      return;
+    }
+    window.open(url, "_blank");
+  };
+
   const handleUploadFile = (applicationId: number) => {
     const input = document.createElement("input");
     input.type = "file";
@@ -200,7 +208,11 @@ export const PaymentApplicationsTable = ({
           {
             key: "pdf",
             label: (
-              <Button icon={<DownloadSimple size={20} />} className="buttonNoBorder">
+              <Button
+                icon={<DownloadSimple size={20} />}
+                className="buttonNoBorder"
+                onClick={() => handleDownload(record.pdf_url)}
+              >
                 PDF
               </Button>
             )
@@ -208,7 +220,11 @@ export const PaymentApplicationsTable = ({
           {
             key: "template",
             label: (
-              <Button icon={<DownloadSimple size={20} />} className="buttonNoBorder">
+              <Button
+                icon={<DownloadSimple size={20} />}
+                className="buttonNoBorder"
+                onClick={() => handleDownload(record.excel_url)}
+              >
                 Template
               </Button>
             )

--- a/src/modules/banks/components/payment-applications-table/PaymentApplicationsTable.tsx
+++ b/src/modules/banks/components/payment-applications-table/PaymentApplicationsTable.tsx
@@ -1,16 +1,11 @@
 import { Dispatch, ReactNode, SetStateAction, useEffect, useState } from "react";
-import { Button, Dropdown, Flex, MenuProps, Table, TableProps, Typography } from "antd";
-import {
-  DotsThreeVertical,
-  DownloadSimple,
-  File,
-  FileArrowDown,
-  FileArrowUp
-} from "phosphor-react";
+import { Button, Dropdown, Flex, MenuProps, Table, TableProps, Typography, message } from "antd";
+import { DotsThreeVertical, DownloadSimple, FileArrowUp } from "phosphor-react";
 
 import { useAppStore } from "@/lib/store/store";
 import { formatDate } from "@/utils/utils";
 import { IPaymentApplication } from "@/types/paymentApplications/IPaymentApplication";
+import { UploadFinalFile } from "@/services/paymentApplications/paymentApplications";
 
 import "./payment-applications-table.scss";
 
@@ -28,6 +23,7 @@ interface PropsPaymentApplicationsTable {
   handleOpenDetail?: (paymentId: number) => void;
   statusId: number;
   clearSelected: boolean;
+  mutate: () => void;
 }
 
 export const PaymentApplicationsTable = ({
@@ -36,7 +32,8 @@ export const PaymentApplicationsTable = ({
   setSelectedRows,
   handleOpenDetail,
   statusId,
-  clearSelected
+  clearSelected,
+  mutate
 }: PropsPaymentApplicationsTable) => {
   const formatMoney = useAppStore((state) => state.formatMoney);
 
@@ -95,6 +92,30 @@ export const PaymentApplicationsTable = ({
   const rowSelection = {
     selectedRowKeys,
     onChange: onSelectChange
+  };
+
+  const handleUploadFile = (applicationId: number) => {
+    const input = document.createElement("input");
+    input.type = "file";
+    input.onchange = async (e) => {
+      const file = (e.target as HTMLInputElement).files?.[0];
+      if (!file) return;
+      const hide = message.open({
+        type: "loading",
+        content: "Cargando archivo...",
+        duration: 0
+      });
+      try {
+        await UploadFinalFile(String(applicationId), file);
+        message.success("Archivo cargado exitosamente");
+        mutate();
+      } catch (error) {
+        message.error(error instanceof Error ? error.message : "Error al cargar el archivo");
+      } finally {
+        hide();
+      }
+    };
+    input.click();
   };
 
   const columns: TableProps<applicationByStatus>["columns"] = [
@@ -195,7 +216,11 @@ export const PaymentApplicationsTable = ({
           {
             key: "upload-template",
             label: (
-              <Button icon={<FileArrowUp size={20} />} className="buttonNoBorder">
+              <Button
+                icon={<FileArrowUp size={20} />}
+                className="buttonNoBorder"
+                onClick={() => handleUploadFile(record.id)}
+              >
                 Cargar Template
               </Button>
             )

--- a/src/modules/banks/containers/payment-applications-tab/payment-applications-tab.tsx
+++ b/src/modules/banks/containers/payment-applications-tab/payment-applications-tab.tsx
@@ -1,13 +1,10 @@
 import { FC, useState } from "react";
 import { Button, Flex, Spin } from "antd";
-import { Bank, DotsThree } from "phosphor-react";
+import { DotsThree } from "phosphor-react";
 import dayjs from "dayjs";
 
 import { useModalDetail } from "@/context/ModalContext";
 import { useMessageApi } from "@/context/MessageContext";
-import { useAppStore } from "@/lib/store/store";
-import { approvePayment } from "@/services/banksPayments/banksPayments";
-import { markPaymentsAsUnidentified } from "@/services/applyTabClients/applyTabClients";
 
 import BanksRules from "../bank-rules";
 import OptimizedSearchComponent from "@/components/atoms/inputs/OptimizedSearchComponent/OptimizedSearchComponent";
@@ -133,6 +130,7 @@ export const PaymentApplicationsTab: FC = () => {
                     setSelectedRows={setSelectedRows}
                     statusId={status.status_id}
                     clearSelected={clearSelected}
+                    mutate={mutate}
                   />
                 )
               }))}

--- a/src/services/paymentApplications/paymentApplications.ts
+++ b/src/services/paymentApplications/paymentApplications.ts
@@ -1,0 +1,17 @@
+import config from "@/config";
+import { GenericResponse } from "@/types/global/IGlobal";
+import { API } from "@/utils/api/api";
+
+export const UploadFinalFile = async (applicationId: string, file: File): Promise<any> => {
+  const formData = new FormData();
+  formData.append("file", file);
+  try {
+    const response: GenericResponse<any> = await API.post(
+      `${config.API_HOST}/paymentApplication/applications/${applicationId}/final-file`,
+      formData
+    );
+    return response.data;
+  } catch (error) {
+    throw error;
+  }
+};

--- a/src/types/paymentApplications/IPaymentApplication.ts
+++ b/src/types/paymentApplications/IPaymentApplication.ts
@@ -8,6 +8,8 @@ export interface IPaymentApplicationByStatus {
 
 export interface IPaymentApplication {
   id: number;
+  pdf_url: string | null;
+  excel_url: string | null;
   client_name: string;
   created_at: string;
   payment_ids: number[];


### PR DESCRIPTION
This pull request enhances the payment applications table by adding file upload and download functionality for each application. It introduces new UI actions for downloading PDF and Excel files and uploading completed templates, with user feedback on success or error. The backend service for uploading files is also implemented, and the relevant data types are updated to support the new features.

**New file actions and UI enhancements:**
- Added download buttons for PDF and Excel template files in the payment applications table. Users receive an error message if a file is unavailable.
- Introduced an upload button for each application to allow uploading of completed templates. The UI provides loading, success, and error messages during the upload process. [[1]](diffhunk://#diff-92e9794197211a7f294b9f251d4cc01977c37e6be9cd4b3cfc6b6c15463322eeR97-R128) [[2]](diffhunk://#diff-92e9794197211a7f294b9f251d4cc01977c37e6be9cd4b3cfc6b6c15463322eeL182-R239)

**Backend and data model changes:**
- Implemented the `UploadFinalFile` API service to handle file uploads for payment applications.
- Updated the `IPaymentApplication` type to include `pdf_url` and `excel_url` fields for file links.

**Component integration:**
- Modified the `PaymentApplicationsTable` and its parent container to accept a `mutate` callback, ensuring the UI refreshes after file uploads. [[1]](diffhunk://#diff-92e9794197211a7f294b9f251d4cc01977c37e6be9cd4b3cfc6b6c15463322eeR26) [[2]](diffhunk://#diff-92e9794197211a7f294b9f251d4cc01977c37e6be9cd4b3cfc6b6c15463322eeL39-R36) [[3]](diffhunk://#diff-41d04635843c2afbef14521a42c11cd6e6e8c67930cac0cd2545e45dad1c5cefR133)