### PR TITLE
Handle FormData Content-Type in API requests

### DIFF
--- a/src/services/accountingAdjustment/accountingAdjustment.ts
+++ b/src/services/accountingAdjustment/accountingAdjustment.ts
@@ -370,12 +370,7 @@ export const addCommentHistoricAction = async (
   try {
     const response: GenericResponse = await API.post(
       `${config.API_HOST}/portfolio/add-comment-history/client/${clientId}/project/${project_id}`,
-      formData,
-      {
-        headers: {
-          "Content-Type": "multipart/form-data"
-        }
-      }
+      formData
     );
     return response;
   } catch (error) {

--- a/src/utils/api/api.ts
+++ b/src/utils/api/api.ts
@@ -87,6 +87,10 @@ instance.interceptors.request.use(async (request) => {
 
 API.interceptors.request.use(async (request) => {
   request.headers.set("Accept", "application/json, text/plain, */*");
+  // Don't set Content-Type for FormData - let axios handle it automatically
+  if (!(request.data instanceof FormData)) {
+    request.headers.set("Content-Type", "application/json");
+  }
   if (!request?.url?.includes("/user/accept-invitation"))
     request.headers.set("Authorization", `Bearer ${await getIdToken()}`);
   return request;


### PR DESCRIPTION
Allow axios to set multipart/form-data boundaries by not forcing Content-Type for FormData payloads. Update API request interceptor to set Content-Type to application/json only when request.data is not a FormData, and remove the manual multipart Content-Type header from addCommentHistoricAction. This prevents incorrect/missing boundary headers and related upload issues.