### PR TITLE
style(modal): update cancel button styling when okButton is hidden

### DIFF
--- a/src/components/molecules/modals/ModalConfirmAction/ModalConfirmAction.tsx
+++ b/src/components/molecules/modals/ModalConfirmAction/ModalConfirmAction.tsx
@@ -41,9 +41,10 @@ export const ModalConfirmAction = ({
       }}
       okText={okText}
       cancelButtonProps={{
-        className: "cancelButton",
+        className: !hideOkButton ? "cancelButton" : "acceptButton",
         onClick: onCancel ? onCancel : onClose,
-        loading: cancelLoading
+        loading: cancelLoading,
+        style: hideOkButton ? { gridColumn: "1 / span 2" } : undefined
       }}
       cancelText={cancelText}
       title={title}


### PR DESCRIPTION
When the okButton is hidden, the cancel button now uses "acceptButton" styling and spans full width to function as the primary action button.
<img width="481" height="255" alt="image" src="https://github.com/user-attachments/assets/4f98dfe4-b1a1-4b3d-942e-145570e4febd" />
