### PR TITLE
fix: render email body as HTML instead of plain text in client previe…

### DIFF
--- a/src/modules/massCommunications/components/ClientPreview/ClientPreview.tsx
+++ b/src/modules/massCommunications/components/ClientPreview/ClientPreview.tsx
@@ -6,7 +6,7 @@ import WhatsAppPreview from "../WhatsAppPreview/WhatsAppPreview";
 import { whatsappTemplates } from "../../lib/mockData";
 import { getCircularizationMessagePreview } from "@/services/communications/communications";
 import type { IMessagePreview } from "@/types/communications/ICommunications";
-import { extractBodyText } from "@/utils/utils";
+import { formatEmailBodyHtml } from "@/utils/utils";
 
 interface ClientPreviewProps {
   communicationId: string;
@@ -33,10 +33,7 @@ export default function ClientPreview({
       setLoading(true);
       try {
         const response = await getCircularizationMessagePreview(Number(communicationId), clientId);
-        setData({
-          ...response.data,
-          body: extractBodyText(response.data.body)
-        });
+        setData(response.data);
       } catch (error) {
         message.error(
           error instanceof Error ? error.message : "No se pudo cargar la vista previa del mensaje."
@@ -101,9 +98,16 @@ export default function ClientPreview({
                       {data.subject || "Sin asunto"}
                     </p>
                   </div>
-                  <div className="text-sm text-[#141414] leading-relaxed whitespace-pre-wrap">
-                    {data.body || <span className="italic text-gray-400">Sin contenido</span>}
-                  </div>
+                  {data.body ? (
+                    <div
+                      className="text-sm text-[#141414] leading-relaxed"
+                      dangerouslySetInnerHTML={{ __html: formatEmailBodyHtml(data.body) }}
+                    />
+                  ) : (
+                    <div className="text-sm text-[#141414] leading-relaxed">
+                      <span className="italic text-gray-400">Sin contenido</span>
+                    </div>
+                  )}
                   {attachments.length > 0 && (
                     <div className="mt-5 pt-4 border-t border-[#EEEEEE]">
                       <p className="text-xs text-gray-500 font-medium mb-2">Adjuntos:</p>

--- a/src/modules/massCommunications/components/ModalDetailClientCommunication/ModalDetailClientCommunication.tsx
+++ b/src/modules/massCommunications/components/ModalDetailClientCommunication/ModalDetailClientCommunication.tsx
@@ -4,7 +4,7 @@ import { PaperClipOutlined } from "@ant-design/icons";
 
 import { getCircularizationMessagePreview } from "@/services/communications/communications";
 import type { IMessagePreview, IPreviewClient } from "@/types/communications/ICommunications";
-import { extractBodyText } from "@/utils/utils";
+import { formatEmailBodyHtml } from "@/utils/utils";
 
 const { Text } = Typography;
 
@@ -34,10 +34,7 @@ export default function ModalDetailClientCommunication({
           Number(communicationId),
           client.client_id
         );
-        setData({
-          ...response.data,
-          body: extractBodyText(response.data.body)
-        });
+        setData(response.data);
       } catch (error) {
         message.error(
           error instanceof Error ? error.message : "No se pudo cargar la vista previa del mensaje."
@@ -150,21 +147,30 @@ export default function ModalDetailClientCommunication({
                 </Text>
               </div>
 
-              <div
-                style={{
-                  padding: "16px 20px",
-                  fontSize: 13,
-                  whiteSpace: "pre-wrap",
-                  lineHeight: 1.6,
-                  minHeight: 100
-                }}
-              >
-                {data.body || (
+              {data.body ? (
+                <div
+                  style={{
+                    padding: "16px 20px",
+                    fontSize: 13,
+                    lineHeight: 1.6,
+                    minHeight: 100
+                  }}
+                  dangerouslySetInnerHTML={{ __html: formatEmailBodyHtml(data.body) }}
+                />
+              ) : (
+                <div
+                  style={{
+                    padding: "16px 20px",
+                    fontSize: 13,
+                    lineHeight: 1.6,
+                    minHeight: 100
+                  }}
+                >
                   <Text type="secondary" italic>
                     Sin contenido
                   </Text>
-                )}
-              </div>
+                </div>
+              )}
 
               {attachments.length > 0 && (
                 <div

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -465,9 +465,14 @@ export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs));
 }
 
-export const extractBodyText = (html: string): string => {
-  if (!html) return "";
-  if (typeof window === "undefined") return html;
-  const doc = new DOMParser().parseFromString(html, "text/html");
-  return (doc.body?.textContent ?? "").trim();
+export const formatEmailBodyHtml = (body: string): string => {
+  if (!body) return "";
+  const trimmed = body.trim();
+  const isHtml = /<[a-z][\s\S]*>/i.test(trimmed);
+  if (isHtml) return trimmed;
+  return trimmed
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/\n/g, "<br/>");
 };


### PR DESCRIPTION
…w modals

Replace `extractBodyText` (which stripped HTML) with `formatEmailBodyHtml` and use `dangerouslySetInnerHTML` to properly display HTML email bodies. This preserves formatting and embedded content in message previews.