### PR TITLE
feat(clients): enable pagination in accounting adjustments table

### DIFF
--- a/src/modules/clients/components/accounting-adjustments-table/accounting-adjustments-table.tsx
+++ b/src/modules/clients/components/accounting-adjustments-table/accounting-adjustments-table.tsx
@@ -189,7 +189,10 @@ const AccountingAdjustmentsTable = ({
         dataSource={data?.map((data) => ({ ...data, key: data.id }))}
         rowSelection={rowSelection}
         rowClassName={(record) => (selectedRowKeys.includes(record.id) ? "selectedRow" : "")}
-        pagination={false}
+        pagination={{
+          pageSize: 25,
+          showSizeChanger: false
+        }}
         sticky={{ offsetHeader: 160 }}
       />
     </>


### PR DESCRIPTION
Configure table pagination with 25 items per page and disable size changer to improve usability when displaying large datasets.