### PR TITLE
Feat/add donwload sales plane po list

### DIFF
--- a/src/modules/purchaseOrders/components/actions-modal-purchase-order/ActionsModalPurchaseOrder.tsx
+++ b/src/modules/purchaseOrders/components/actions-modal-purchase-order/ActionsModalPurchaseOrder.tsx
@@ -10,7 +10,8 @@ import {
   sendPackageToDispatch,
   sendPackageToBilling,
   removePurchaseOrdersFromPackage,
-  deletePurchaseOrders
+  deletePurchaseOrders,
+  getSalesPlane
 } from "@/services/purchaseOrders/purchaseOrders";
 
 import "./actionsModalPurchaseOrder.scss";
@@ -229,6 +230,17 @@ export const ActionsModalPurchaseOrder: React.FC<ActionsModalPurchaseOrderProps>
     setIsDownloadPlaneOpen(true);
   };
 
+  const handleDownloadSalesPlane = async () => {
+    try {
+      const res = await getSalesPlane();
+      window.open(res.url, "_blank");
+    } catch (error) {
+      message.error(
+        error instanceof Error ? error.message : "Error al descargar el plano de ventas"
+      );
+    }
+  };
+
   return (
     <>
       <Modal
@@ -289,6 +301,12 @@ export const ActionsModalPurchaseOrder: React.FC<ActionsModalPurchaseOrderProps>
               disabled={isDispatchLoading}
             />
           )}
+          <ButtonGenerateAction
+            icon={<PackageCheck className="h-4 w-4" />}
+            title="Exportar plano de ventas"
+            onClick={handleDownloadSalesPlane}
+            disabled={isDispatchLoading}
+          />
         </div>
       </Modal>
 

--- a/src/modules/purchaseOrders/components/actions-modal-purchase-order/ActionsModalPurchaseOrder.tsx
+++ b/src/modules/purchaseOrders/components/actions-modal-purchase-order/ActionsModalPurchaseOrder.tsx
@@ -231,6 +231,7 @@ export const ActionsModalPurchaseOrder: React.FC<ActionsModalPurchaseOrderProps>
   };
 
   const handleDownloadSalesPlane = async () => {
+    const hideLoading = message.loading("Descargando plano de ventas...", 0);
     try {
       const res = await getSalesPlane();
       window.open(res.url, "_blank");
@@ -238,6 +239,8 @@ export const ActionsModalPurchaseOrder: React.FC<ActionsModalPurchaseOrderProps>
       message.error(
         error instanceof Error ? error.message : "Error al descargar el plano de ventas"
       );
+    } finally {
+      hideLoading();
     }
   };
 

--- a/src/modules/purchaseOrders/containers/purchase-orders-view/PurchaseOrdersView.tsx
+++ b/src/modules/purchaseOrders/containers/purchase-orders-view/PurchaseOrdersView.tsx
@@ -140,17 +140,6 @@ export function PurchaseOrdersView() {
   };
 
   const handleOpenActionsModal = () => {
-    if (selectedPackageRows.length === 0 && selectedOrders.length === 0) {
-      message.info("Por favor selecciona al menos un pedido u orden para generar acciones.");
-      return;
-    }
-    const isDelivered =
-      selectedPackageRows.some((p) => p.orders.some((o) => o.status === "Entregado")) ||
-      selectedOrders.some((o) => o.status === "Entregado");
-    if (isDelivered) {
-      message.warning("No se pueden generar acciones para pedidos/ordenes con estado 'Entregado'.");
-      return;
-    }
     setWhichModalIsOpen({ selected: 1 });
   };
 

--- a/src/services/purchaseOrders/purchaseOrders.ts
+++ b/src/services/purchaseOrders/purchaseOrders.ts
@@ -432,3 +432,15 @@ export const getDownloadableFiles = async (packageIds?: string[], orderIds?: str
     throw error;
   }
 };
+
+export const getSalesPlane = async () => {
+  try {
+    const response: GenericResponse<{ url: string; filename: string }> = await API.get(
+      `${config.API_HOST}/purchaseOrder/products/export-all`
+    );
+    return response.data;
+  } catch (error) {
+    console.error("Error fetching sales plane:", error);
+    throw error;
+  }
+};


### PR DESCRIPTION
This pull request adds a new feature to allow users to export the "plano de ventas" (sales plan) from the purchase orders module. The main changes involve adding a new API service method, updating the actions modal with a new button to trigger the download, and implementing the corresponding handler. Additionally, a restriction that prevented opening the actions modal when no orders or packages were selected, or when delivered orders were selected, has been removed.

**New feature: Export sales plan**

* Added a new API method `getSalesPlane` in `purchaseOrders.ts` to fetch the sales plan export URL from the backend.
* Imported `getSalesPlane` into `ActionsModalPurchaseOrder.tsx` to enable its use in the component.
* Implemented a new handler `handleDownloadSalesPlane` in `ActionsModalPurchaseOrder.tsx` to call the API, display a loading message, and open the downloaded file in a new tab.
* Added a new "Exportar plano de ventas" button to the actions modal, which triggers the export functionality.

**User experience changes**

* Removed restrictions in `PurchaseOrdersView.tsx` that prevented opening the actions modal when no orders/packages were selected or when delivered orders were selected. Now, the modal can be opened regardless of selection state.