### PR TITLE
Refactor/change digital record action wallet tab

### DIFF
--- a/src/components/organisms/Customers/WalletTab/WalletTab.tsx
+++ b/src/components/organisms/Customers/WalletTab/WalletTab.tsx
@@ -6,9 +6,7 @@ import { AxiosError } from "axios";
 
 import { extractSingleParam } from "@/utils/utils";
 import { addItemsToTable } from "@/services/applyTabClients/applyTabClients";
-import {
-  markInvoiceAsBalance
-} from "@/services/accountingAdjustment/accountingAdjustment";
+import { markInvoiceAsBalance } from "@/services/accountingAdjustment/accountingAdjustment";
 import { useApplicationTable } from "@/hooks/useApplicationTable";
 import { useInvoices } from "@/hooks/useInvoices";
 import { useDebounce } from "@/hooks/useDeabouce";
@@ -26,7 +24,7 @@ import PaymentAgreementModal from "@/modules/clients/components/wallet-tab-payme
 import { ModalActionDiscountCredit } from "@/components/molecules/modals/ModalActionDiscountCredit/ModalActionDiscountCredit";
 import RadicationInvoice from "@/components/molecules/modals/Radication/RadicationInvoice";
 import RegisterNews from "@/components/molecules/modals/RegisterNews/RegisterNews";
-import DigitalRecordModal from "@/components/molecules/modals/DigitalRecordModal/DigitalRecordModal";
+import AccountStatementModal from "@/modules/chat/components/account-statement-modal";
 import { SelectedFiltersWallet } from "@/components/atoms/Filters/FilterWalletTab/FilterWalletTab";
 import SendExternalLinkModal from "@/components/molecules/modals/SendExternalLinkModal/SendExternalLinkModal";
 import ModalEnterProcess from "@/components/molecules/modals/ModalEnterProcess/ModalEnterProcess";
@@ -329,12 +327,9 @@ export const WalletTab = () => {
           });
         }}
       />
-      <DigitalRecordModal
-        isOpen={isSelectOpen.selected === 7}
+      <AccountStatementModal
+        showModal={isSelectOpen.selected === 7}
         onClose={onCloseModal}
-        messageShow={messageShow}
-        projectId={projectId}
-        invoiceSelected={selectedRows}
         clientId={clientId}
       />
       <SendExternalLinkModal

--- a/src/modules/chat/components/account-statement-modal/AccountStatementModal.tsx
+++ b/src/modules/chat/components/account-statement-modal/AccountStatementModal.tsx
@@ -32,14 +32,14 @@ interface IAccountStatementForm {
 
 interface AccountStatementModalProps {
   showModal: boolean;
-  setShowModal: Dispatch<SetStateAction<boolean>>;
+  onClose: () => void;
   clientId?: string | null;
   contactPhone?: string | null;
 }
 
 const AccountStatementModal = ({
   showModal,
-  setShowModal,
+  onClose,
   clientId,
   contactPhone
 }: AccountStatementModalProps) => {
@@ -230,7 +230,7 @@ const AccountStatementModal = ({
       }
 
       // Cerrar modal y resetear form después de éxito
-      setShowModal(false);
+      onClose();
       reset();
     } catch (error) {
       console.error("Error processing account statement:", error);
@@ -257,7 +257,7 @@ const AccountStatementModal = ({
   };
 
   const handleClose = () => {
-    setShowModal(false);
+    onClose();
   };
 
   // Show error if clientId is missing

--- a/src/modules/chat/containers/chat-view/ChatView.tsx
+++ b/src/modules/chat/containers/chat-view/ChatView.tsx
@@ -105,7 +105,7 @@ export default function ChatInbox() {
 
       <AccountStatementModal
         showModal={showAccountStatementModal}
-        setShowModal={setShowAccountStatementModal}
+        onClose={() => setShowAccountStatementModal(false)}
         clientId={activeConversation?.customerCashportUUID}
         contactPhone={activeConversation?.phone}
       />


### PR DESCRIPTION
This pull request primarily refactors how the `AccountStatementModal` is integrated and handled in the application, improving its API and replacing the older `DigitalRecordModal` in the wallet tab. The most important changes are grouped below:

**Modal Integration and API Simplification:**

* Replaced the use of `DigitalRecordModal` with `AccountStatementModal` in `WalletTab.tsx`, updating the props to match the new modal's API. (`src/components/organisms/Customers/WalletTab/WalletTab.tsx`) [[1]](diffhunk://#diff-da5f45cf009cf70d50201ca3b24bfe534196942ffa7e616df71a5ad7dac1857bL29-R27) [[2]](diffhunk://#diff-da5f45cf009cf70d50201ca3b24bfe534196942ffa7e616df71a5ad7dac1857bL332-L337)
* Simplified the `AccountStatementModal` API by replacing the `setShowModal` prop with a more conventional `onClose` callback for closing the modal. (`src/modules/chat/components/account-statement-modal/AccountStatementModal.tsx`) [[1]](diffhunk://#diff-176823449673c9f84cf19cb7a890b612d0852f9e59a7524c31629b24dcc46538L35-R42) [[2]](diffhunk://#diff-176823449673c9f84cf19cb7a890b612d0852f9e59a7524c31629b24dcc46538L233-R233) [[3]](diffhunk://#diff-176823449673c9f84cf19cb7a890b612d0852f9e59a7524c31629b24dcc46538L260-R260)
* Updated all usages of `AccountStatementModal` to use the new `onClose` prop, including in `ChatView.tsx`. (`src/modules/chat/containers/chat-view/ChatView.tsx`)

**Code Clean-up:**

* Cleaned up import statements in `WalletTab.tsx` for better readability and maintainability. (`src/components/organisms/Customers/WalletTab/WalletTab.tsx`)