### PR TITLE
fix: use email details description instead of task description

### DIFF
--- a/src/modules/taskManager/components/modalTaskDetail/ModalContent.tsx
+++ b/src/modules/taskManager/components/modalTaskDetail/ModalContent.tsx
@@ -2,15 +2,7 @@
 
 import { ReactNode, useEffect, useState } from "react";
 
-import {
-  Mail,
-  Sparkles,
-  User,
-  Building,
-  FileText,
-  Paperclip,
-  Download
-} from "lucide-react";
+import { Mail, Sparkles, User, Building, FileText, Paperclip, Download } from "lucide-react";
 import { Button as AntButton, Dropdown, Select as AntSelect, message } from "antd";
 import { DotsThreeVertical, ArrowCounterClockwise } from "@phosphor-icons/react";
 import { Controller, useFormContext, useWatch } from "react-hook-form";
@@ -169,7 +161,7 @@ export function ModalContent({
           </div>
           <div className="pt-3 border-t border-gray-200">
             <p className="text-gray-700 text-sm leading-relaxed whitespace-pre-wrap">
-              {taskDetail.description}
+              {taskDetail.emailDetails?.details.details}
             </p>
           </div>
           {emailDetails.attachments && emailDetails.attachments.length > 0 && (
@@ -188,9 +180,7 @@ export function ModalContent({
                   >
                     <div className="flex items-center gap-2 flex-1 min-w-0">
                       <FileText className="h-4 w-4 text-gray-600 flex-shrink-0" />
-                      <span className="text-sm text-gray-900 truncate">
-                        {attachment.file_name}
-                      </span>
+                      <span className="text-sm text-gray-900 truncate">{attachment.file_name}</span>
                     </div>
                     <Badge
                       variant="secondary"
@@ -319,7 +309,9 @@ export function ModalContent({
                         taskTypes.length === 0 ? "Cargando tipos..." : "Seleccionar tipo..."
                       }
                       variant="borderless"
-                      className={ANT_SELECT_CLASS(field.value === null || field.value === undefined)}
+                      className={ANT_SELECT_CLASS(
+                        field.value === null || field.value === undefined
+                      )}
                     />
                   )}
                 />
@@ -360,7 +352,9 @@ export function ModalContent({
                           .includes(input.toLowerCase())
                       }
                       variant="borderless"
-                      className={ANT_SELECT_CLASS(field.value === null || field.value === undefined)}
+                      className={ANT_SELECT_CLASS(
+                        field.value === null || field.value === undefined
+                      )}
                       optionRender={(option) =>
                         option.data.isAI ? (
                           <div className="flex items-center gap-2">
@@ -422,9 +416,9 @@ export function ModalContent({
       </div>
 
       {/* Right Column - Original Message */}
-      <div className="overflow-y-auto px-10 py-8 border-l border-gray-200 bg-white">
+      <div className="overflow-y-auto px-10 py-8 pt-0 border-l border-gray-200 bg-white">
         <div className="space-y-6">
-          <h3 className="text-sm font-semibold text-gray-600 uppercase tracking-wide sticky top-0 bg-white py-2 z-10">
+          <h3 className="text-sm font-semibold text-gray-600 uppercase tracking-wide sticky top-0 bg-white py-2 pt-[40px] z-10">
             Mensaje Original
           </h3>
           {taskDetail.emailDetails ? (

--- a/src/modules/taskManager/components/modalTaskDetail/ModalContent.tsx
+++ b/src/modules/taskManager/components/modalTaskDetail/ModalContent.tsx
@@ -46,6 +46,7 @@ interface IModalContentProps {
   users: IUser[];
   usersLoading: boolean;
   onAttachmentReprocessed: () => void;
+  canEdit: boolean;
 }
 
 const formatDateTime = (dateString: string) => {
@@ -65,7 +66,8 @@ export function ModalContent({
   taskTypes,
   users,
   usersLoading,
-  onAttachmentReprocessed
+  onAttachmentReprocessed,
+  canEdit
 }: IModalContentProps) {
   const { control, setValue, getValues } = useFormContext<TaskFormValues>();
 
@@ -263,8 +265,10 @@ export function ModalContent({
                 <Controller
                   control={control}
                   name="client_id"
+                  disabled={!canEdit}
                   render={({ field }) => (
                     <AntSelect
+                      disabled={!canEdit}
                       showSearch
                       value={field.value || undefined}
                       onChange={(value) => field.onChange(value)}
@@ -297,6 +301,7 @@ export function ModalContent({
                 <Controller
                   control={control}
                   name="task_type"
+                  disabled={!canEdit}
                   render={({ field }) => (
                     <AntSelect
                       value={field.value ?? undefined}
@@ -304,7 +309,7 @@ export function ModalContent({
                       onBlur={field.onBlur}
                       options={taskTypeOptions}
                       loading={taskTypes.length === 0}
-                      disabled={taskTypes.length === 0}
+                      disabled={!canEdit || taskTypes.length === 0}
                       placeholder={
                         taskTypes.length === 0 ? "Cargando tipos..." : "Seleccionar tipo..."
                       }
@@ -332,6 +337,7 @@ export function ModalContent({
                   render={({ field }) => (
                     <AntSelect
                       showSearch
+                      disabled={!canEdit}
                       value={field.value ?? undefined}
                       onChange={(value) => {
                         if (value === CASHPORT_AI_USER_ID) {

--- a/src/modules/taskManager/components/modalTaskDetail/ModalTaskDetail.tsx
+++ b/src/modules/taskManager/components/modalTaskDetail/ModalTaskDetail.tsx
@@ -244,6 +244,7 @@ export function ModalTaskDetail({ task, isOpen, onClose, taskTypes }: IModalTask
                 users={users}
                 usersLoading={usersLoading}
                 onAttachmentReprocessed={fetchTaskDetail}
+                canEdit={canEdit}
               />
             ) : null}
           </div>


### PR DESCRIPTION
The task detail modal was displaying the generic task description instead of the email-specific details. Updated the data source to use `taskDetail.emailDetails.details.details` for the correct content. Also adjusted header padding for better layout.