### PR TITLE
feat: add Id ERP column and update ID column to use primary key

### DIFF
--- a/src/modules/banks/components/banks-table/Banks-table.tsx
+++ b/src/modules/banks/components/banks-table/Banks-table.tsx
@@ -112,19 +112,28 @@ export const BanksTable = ({
   const columns: TableProps<ISingleBank>["columns"] = [
     {
       title: "ID",
-      dataIndex: "ID_ERP",
-      key: "ID_ERP",
-      render: (ID_ERP, row) => (
+      dataIndex: "id",
+      key: "id",
+      render: (id) => (
         <Text
           className="idText"
-          onClick={() => handleOpenPaymentDetail && handleOpenPaymentDetail(row.id)}
+          onClick={() => handleOpenPaymentDetail && handleOpenPaymentDetail(id)}
         >
-          {ID_ERP}
+          {id}
         </Text>
       ),
       sorter: (a, b) => a.id - b.id,
       showSorterTooltip: false,
       width: 100
+    },
+    {
+      title: "Id ERP",
+      dataIndex: "ID_ERP",
+      key: "ID_ERP",
+      render: (ID_ERP) => <Text>{ID_ERP}</Text>,
+      sorter: (a, b) => Number(a.ID_ERP ?? 0) - Number(b.ID_ERP ?? 0),
+      showSorterTooltip: false,
+      width: 110
     },
     {
       title: "Cliente",


### PR DESCRIPTION
Modified the ID column to render the primary key `id` instead of `ID_ERP`, and added a new column "Id ERP" that displays the `ID_ERP` field with sorting capability. This provides a clearer distinction between internal IDs and ERP identifiers.