### PR TITLE
Fix/86e13yjnn/wallet tab payment agreement modal

### DIFF
--- a/src/components/molecules/tables/InvoicesTable/InvoicesTable.tsx
+++ b/src/components/molecules/tables/InvoicesTable/InvoicesTable.tsx
@@ -19,6 +19,8 @@ interface PropsInvoicesTable {
   openInvoiceDetail: (invoice: IInvoice) => void;
   // eslint-disable-next-line no-unused-vars
   fetchData?: (newPage: number) => void;
+  // eslint-disable-next-line no-unused-vars
+  onOpenPaymentAgreement?: (incidentId: number) => void;
 
   selectedRows?: IInvoice[];
 }
@@ -29,7 +31,8 @@ export const InvoicesTable = ({
   setSelectedRows,
   fetchData: _fetchData,
   selectedRows,
-  openInvoiceDetail
+  openInvoiceDetail,
+  onOpenPaymentAgreement
 }: PropsInvoicesTable) => {
   const formatMoney = useAppStore((state) => state.formatMoney);
 
@@ -234,6 +237,11 @@ export const InvoicesTable = ({
               key={`A${record.id}`}
             >
               <Button
+                onClick={() => {
+                  if (record.agreement_info?.id) {
+                    onOpenPaymentAgreement?.(record.agreement_info.id);
+                  }
+                }}
                 icon={
                   <Handshake
                     size={"1.2rem"}

--- a/src/components/organisms/Customers/WalletTab/WalletTab.tsx
+++ b/src/components/organisms/Customers/WalletTab/WalletTab.tsx
@@ -28,6 +28,7 @@ import AccountStatementModal from "@/modules/chat/components/account-statement-m
 import { SelectedFiltersWallet } from "@/components/atoms/Filters/FilterWalletTab/FilterWalletTab";
 import SendExternalLinkModal from "@/components/molecules/modals/SendExternalLinkModal/SendExternalLinkModal";
 import ModalEnterProcess from "@/components/molecules/modals/ModalEnterProcess/ModalEnterProcess";
+import { ModalAgreementDetail } from "@/components/molecules/modals/ModalAgreementDetail/ModalAgreementDetail";
 
 import { IInvoice, InvoicesData } from "@/types/invoices/IInvoices";
 
@@ -61,6 +62,10 @@ export const WalletTab = () => {
   });
   const [isSelectOpen, setIsSelectOpen] = useState({
     selected: 0
+  });
+  const [isModalPaymentAgreementOpen, setIsModalPaymentAgreementOpen] = useState({
+    isOpen: false,
+    incident_id: 0
   });
   const [messageShow, contextHolder] = message.useMessage();
   const clientId = clientIdParam || "";
@@ -244,6 +249,9 @@ export const WalletTab = () => {
                   stateId={invoiceState.status_id}
                   setSelectedRows={setSelectedRows}
                   selectedRows={selectedRows}
+                  onOpenPaymentAgreement={(incidentId) =>
+                    setIsModalPaymentAgreementOpen({ isOpen: true, incident_id: incidentId })
+                  }
                   // fetchData={(page: number) => {
                   //   getAccountingAdjustmentsById(invoiceState.status_id, page);
                   // }}
@@ -344,6 +352,13 @@ export const WalletTab = () => {
         isOpen={isSelectOpen.selected === 9}
         onClose={onCloseModal}
         clientId={clientId}
+      />
+      <ModalAgreementDetail
+        isModalPaymentAgreementOpen={isModalPaymentAgreementOpen}
+        onClose={() => {
+          mutate();
+          setIsModalPaymentAgreementOpen({ isOpen: false, incident_id: 0 });
+        }}
       />
     </>
   );

--- a/src/modules/clients/components/wallet-tab-payment-agreement-modal/wallet-tab-payment-agreement-modal.tsx
+++ b/src/modules/clients/components/wallet-tab-payment-agreement-modal/wallet-tab-payment-agreement-modal.tsx
@@ -322,7 +322,6 @@ const PaymentAgreementModal: React.FC<Props> = ({
           loading={isSubmitting}
           handleCancel={() => setIsSecondView(false)}
           noModal
-          multipleFiles
         />
       )}
     </Modal>

--- a/src/modules/clients/containers/invoice-detail-modal/invoice-detail-modal.tsx
+++ b/src/modules/clients/containers/invoice-detail-modal/invoice-detail-modal.tsx
@@ -354,9 +354,17 @@ const InvoiceDetailModal: FC<InvoiceDetailModalProps> = ({
                               )}
                               {item.event_type_name === "Acuerdo de pago" ? (
                                 <div>
-                                  <div className={styles.icons}>
-                                    <Envelope size={14} onClick={() => {}} />
-                                  </div>
+                                  {item.files[0] && (
+                                    <div className={styles.icons}>
+                                      <Envelope
+                                        size={14}
+                                        onClick={() => {
+                                          window.open(item.files[0], "_blank");
+                                        }}
+                                      />
+                                    </div>
+                                  )}
+
                                   <div className={styles.name}>{`Acción: ${item.user_name}`}</div>
                                   <div
                                     className={styles.name}

--- a/src/services/accountingAdjustment/accountingAdjustment.ts
+++ b/src/services/accountingAdjustment/accountingAdjustment.ts
@@ -33,7 +33,7 @@ const getCorrectMimeType = (file: File): File => {
   if (!file.type || file.type === "application/octet-stream") {
     const extension = file.name.split(".").pop()?.toLowerCase();
     const correctType = extension ? MIME_TYPE_MAP[extension] : file.type;
-    
+
     if (correctType && correctType !== file.type) {
       return new File([file], file.name, { type: correctType });
     }
@@ -188,7 +188,12 @@ export const createPaymentAgreement = async (
 
     const response = await instance.post(
       `${config.API_HOST}/invoice/paymentAgreement/project/${projectId}/client/${clientId}`,
-      formData
+      formData,
+      {
+        headers: {
+          "Content-Type": undefined
+        }
+      }
     );
     return response;
   } catch (error) {

--- a/src/types/invoices/IInvoices.ts
+++ b/src/types/invoices/IInvoices.ts
@@ -48,6 +48,7 @@ export interface IInvoice {
     radication_type: string;
   } | null;
   agreement_info: {
+    id?: number;
     Fecha: string;
     Monto: number;
     Cumplido: string;


### PR DESCRIPTION
This pull request adds functionality to open and display payment agreement details from the invoices table within the wallet tab. The main changes include passing a new callback to the `InvoicesTable` component, managing the state for the payment agreement modal in the wallet tab, and updating UI components to support this flow. Additionally, there are minor improvements to file handling and API request headers.

**Payment Agreement Modal Integration:**

* Added a new optional `onOpenPaymentAgreement` callback prop to the `InvoicesTable` component, which is triggered when the user clicks the handshake button for an invoice with an associated payment agreement. (`src/components/molecules/tables/InvoicesTable/InvoicesTable.tsx`) [[1]](diffhunk://#diff-51df33810ada2a3ba95845c70bedb4f551f88adf4d24d5936c6881f8663dceb4R22-R23) [[2]](diffhunk://#diff-51df33810ada2a3ba95845c70bedb4f551f88adf4d24d5936c6881f8663dceb4L32-R35) [[3]](diffhunk://#diff-51df33810ada2a3ba95845c70bedb4f551f88adf4d24d5936c6881f8663dceb4R240-R244)
* Managed modal open state in the `WalletTab` component and rendered the `ModalAgreementDetail` modal when a payment agreement is selected. (`src/components/organisms/Customers/WalletTab/WalletTab.tsx`) [[1]](diffhunk://#diff-da5f45cf009cf70d50201ca3b24bfe534196942ffa7e616df71a5ad7dac1857bR66-R69) [[2]](diffhunk://#diff-da5f45cf009cf70d50201ca3b24bfe534196942ffa7e616df71a5ad7dac1857bR252-R254) [[3]](diffhunk://#diff-da5f45cf009cf70d50201ca3b24bfe534196942ffa7e616df71a5ad7dac1857bR356-R362)
* Updated the `IInvoice` type to allow the `agreement_info.id` field to be optional, improving type safety. (`src/types/invoices/IInvoices.ts`)

**UI and UX Improvements:**

* In the invoice detail modal, enabled opening the first file attached to a payment agreement event in a new browser tab when the envelope icon is clicked. (`src/modules/clients/containers/invoice-detail-modal/invoice-detail-modal.tsx`)
* Removed the unused `multipleFiles` prop from the payment agreement modal for cleaner code. (`src/modules/clients/components/wallet-tab-payment-agreement-modal/wallet-tab-payment-agreement-modal.tsx`)

**API Integration:**

* Updated the `createPaymentAgreement` service to explicitly set the `Content-Type` header to `undefined`, ensuring proper handling of multipart form data. (`src/services/accountingAdjustment/accountingAdjustment.ts`)