### PR TITLE
Add ReprocessExcel and Regenerate action

### DIFF
--- a/src/modules/banks/components/payment-applications-table/PaymentApplicationsTable.tsx
+++ b/src/modules/banks/components/payment-applications-table/PaymentApplicationsTable.tsx
@@ -1,11 +1,16 @@
 import { Dispatch, ReactNode, SetStateAction, useEffect, useState } from "react";
 import { Button, Dropdown, Flex, MenuProps, Table, TableProps, Typography, message } from "antd";
-import { DotsThreeVertical, DownloadSimple, FileArrowUp } from "phosphor-react";
+import {
+  ArrowCounterClockwise,
+  DotsThreeVertical,
+  DownloadSimple,
+  FileArrowUp
+} from "phosphor-react";
 
 import { useAppStore } from "@/lib/store/store";
 import { formatDate } from "@/utils/utils";
 import { IPaymentApplication } from "@/types/paymentApplications/IPaymentApplication";
-import { UploadFinalFile } from "@/services/paymentApplications/paymentApplications";
+import { ReprocessExcel, UploadFinalFile } from "@/services/paymentApplications/paymentApplications";
 
 import "./payment-applications-table.scss";
 
@@ -128,6 +133,22 @@ export const PaymentApplicationsTable = ({
     input.click();
   };
 
+  const handleRegenerate = async (applicationId: number) => {
+    const hide = message.open({
+      type: "loading",
+      content: "Regenerando archivo...",
+      duration: 0
+    });
+    try {
+      const data = await ReprocessExcel(applicationId);
+      hide();
+      handleDownload(data.excel_url);
+    } catch (error) {
+      hide();
+      message.error(error instanceof Error ? error.message : "Error al regenerar el archivo");
+    }
+  };
+
   const columns: TableProps<applicationByStatus>["columns"] = [
     {
       title: "Id",
@@ -228,6 +249,18 @@ export const PaymentApplicationsTable = ({
                 onClick={() => handleDownload(record.excel_url)}
               >
                 Template
+              </Button>
+            )
+          },
+          {
+            key: "regenerate",
+            label: (
+              <Button
+                icon={<ArrowCounterClockwise size={20} />}
+                className="buttonNoBorder"
+                onClick={() => handleRegenerate(record.id)}
+              >
+                Regenerar
               </Button>
             )
           },

--- a/src/services/paymentApplications/paymentApplications.ts
+++ b/src/services/paymentApplications/paymentApplications.ts
@@ -1,13 +1,20 @@
-import config from "@/config";
 import { GenericResponse } from "@/types/global/IGlobal";
 import { API } from "@/utils/api/api";
+
+export const ReprocessExcel = async (applicationId: number): Promise<{ excel_url: string }> => {
+  const response: GenericResponse<{ excel_url: string }> = await API.post(
+    `/paymentApplication/reprocess-excel`,
+    { id: applicationId }
+  );
+  return response.data;
+};
 
 export const UploadFinalFile = async (applicationId: string, file: File): Promise<any> => {
   const formData = new FormData();
   formData.append("file", file);
   try {
     const response: GenericResponse<any> = await API.post(
-      `${config.API_HOST}/paymentApplication/applications/${applicationId}/final-file`,
+      `/paymentApplication/applications/${applicationId}/final-file`,
       formData
     );
     return response.data;


### PR DESCRIPTION
Add ReprocessExcel service to call /paymentApplication/reprocess-excel and return an excel_url. In PaymentApplicationsTable, import the new service and ArrowCounterClockwise icon, add handleRegenerate which shows a loading message, calls ReprocessExcel, downloads the returned excel_url and handles errors, and add a "Regenerar" button to the actions menu. Improves UX by allowing re-generation of the Excel file for a payment application.