### PR TITLE
Feat/add id erp columns application tab and payments tab

### DIFF
--- a/src/modules/banks/components/payment-applications-table/PaymentApplicationsTable.tsx
+++ b/src/modules/banks/components/payment-applications-table/PaymentApplicationsTable.tsx
@@ -10,7 +10,10 @@ import {
 import { useAppStore } from "@/lib/store/store";
 import { formatDate } from "@/utils/utils";
 import { IPaymentApplication } from "@/types/paymentApplications/IPaymentApplication";
-import { ReprocessExcel, UploadFinalFile } from "@/services/paymentApplications/paymentApplications";
+import {
+  ReprocessExcel,
+  UploadFinalFile
+} from "@/services/paymentApplications/paymentApplications";
 
 import "./payment-applications-table.scss";
 
@@ -158,6 +161,25 @@ export const PaymentApplicationsTable = ({
       sorter: (a, b) => a.id - b.id,
       showSorterTooltip: false,
       width: 110
+    },
+    {
+      title: "Id ERP",
+      key: "id_erps",
+      dataIndex: "id_erps",
+      render: (ids: string[]) =>
+        ids?.length ? (
+          <span>
+            {ids.map((erpId, index) => (
+              <span key={`${erpId}-${index}`}>
+                <Text>{erpId}</Text>
+                {index < ids.length - 1 ? ", " : ""}
+              </span>
+            ))}
+          </span>
+        ) : (
+          <Text>-</Text>
+        ),
+      width: 130
     },
     {
       title: "Cliente",

--- a/src/modules/clients/components/payments-table/payments-table.tsx
+++ b/src/modules/clients/components/payments-table/payments-table.tsx
@@ -77,6 +77,15 @@ const PaymentsTable = ({
       width: 130
     },
     {
+      title: "Id ERP",
+      dataIndex: "ID_ERP",
+      key: "ID_ERP",
+      render: (erpId) => <p>{erpId || "-"}</p>,
+      sorter: (a, b) => a.id - b.id,
+      showSorterTooltip: false,
+      width: 130
+    },
+    {
       title: "Ingreso",
       dataIndex: "payment_date",
       key: "payment_date",

--- a/src/modules/clients/containers/payments-tab/payments-tab.tsx
+++ b/src/modules/clients/containers/payments-tab/payments-tab.tsx
@@ -62,11 +62,13 @@ const PaymentsTab: React.FC<PaymentProd> = ({ onChangeTab: _onChangeTab }) => {
       const description = payment.description?.toLowerCase() || "";
       const currentValue = payment.current_value?.toString() || "";
       const initialValue = payment.initial_value?.toString() || "";
+      const idErp = payment.ID_ERP?.toLowerCase() || "";
 
       return (
         description.includes(normalizedSearch) ||
         currentValue.includes(normalizedSearch) ||
-        initialValue.includes(normalizedSearch)
+        initialValue.includes(normalizedSearch) ||
+        idErp.includes(normalizedSearch)
       );
     });
   };

--- a/src/types/clientPayments/IClientPayments.ts
+++ b/src/types/clientPayments/IClientPayments.ts
@@ -29,6 +29,7 @@ export interface IClientPayment {
   bank_description: string;
   account_number: string;
   type_account: string;
+  ID_ERP: string | null;
 }
 
 export interface IClientPaymentStatus {
@@ -62,6 +63,7 @@ export interface IIdentifiedPayment {
   CLIENT_NAME: string | null;
   account_number: string;
   bank_name: string;
+  ID_ERP: string | null;
 }
 
 interface ISelect {

--- a/src/types/paymentApplications/IPaymentApplication.ts
+++ b/src/types/paymentApplications/IPaymentApplication.ts
@@ -13,6 +13,7 @@ export interface IPaymentApplication {
   client_name: string;
   created_at: string;
   payment_ids: number[];
+  id_erps: string[];
   userName: string;
   amount: number;
 }


### PR DESCRIPTION
This pull request introduces enhancements to both the payments and payment applications tables by displaying ERP IDs in the UI and updating the corresponding TypeScript types to support these changes. The updates improve data visibility for users and ensure type safety in the codebase.

**UI Enhancements:**
- Added an "Id ERP" column to both the `PaymentApplicationsTable` and `PaymentsTable` components to display ERP identifiers associated with each record. [[1]](diffhunk://#diff-92e9794197211a7f294b9f251d4cc01977c37e6be9cd4b3cfc6b6c15463322eeR165-R183) [[2]](diffhunk://#diff-316722f7fbc95e3042a059c473f56108a9b010a33b8b642e01be2ed9750d96f4R79-R87)

**TypeScript Type Updates:**
- Updated the `IPaymentApplication` interface to include a new `id_erps: string[]` property, supporting the display of multiple ERP IDs per payment application.
- Added an `ID_ERP: string | null` property to both `IClientPayment` and `IIdentifiedPayment` interfaces, ensuring ERP IDs are typed and available for client payment records. [[1]](diffhunk://#diff-a90381b5a3ecde7412fb95de26d60b081ddff95c64e1ab2a8497b0b0c6f7d227R32) [[2]](diffhunk://#diff-a90381b5a3ecde7412fb95de26d60b081ddff95c64e1ab2a8497b0b0c6f7d227R66)

**Code Style:**
- Minor formatting improvement in import statements for better readability in `PaymentApplicationsTable.tsx`.