### PR TITLE
refactor(payment-applications-table): rename columns and add responsi…

### DIFF
--- a/src/components/molecules/modals/ModalGenerateAction/ModalGenerateAction.tsx
+++ b/src/components/molecules/modals/ModalGenerateAction/ModalGenerateAction.tsx
@@ -146,7 +146,7 @@ export const ModalGenerateAction = ({
         />
         <ButtonGenerateAction
           icon={<PaperPlaneTilt size={16} />}
-          title="Acta digital"
+          title="Estado de cuenta"
           onClick={() => {
             handleOpenModal(7);
           }}

--- a/src/modules/banks/components/payment-applications-table/PaymentApplicationsTable.tsx
+++ b/src/modules/banks/components/payment-applications-table/PaymentApplicationsTable.tsx
@@ -1,5 +1,15 @@
 import { Dispatch, ReactNode, SetStateAction, useEffect, useState } from "react";
-import { Button, Dropdown, Flex, MenuProps, Table, TableProps, Typography, message } from "antd";
+import {
+  Button,
+  Dropdown,
+  Flex,
+  Grid,
+  MenuProps,
+  Table,
+  TableProps,
+  Typography,
+  message
+} from "antd";
 import {
   ArrowCounterClockwise,
   DotsThreeVertical,
@@ -46,6 +56,9 @@ export const PaymentApplicationsTable = ({
   mutate
 }: PropsPaymentApplicationsTable) => {
   const formatMoney = useAppStore((state) => state.formatMoney);
+
+  const screens = Grid.useBreakpoint();
+  const isXXL = !!screens.xxl;
 
   const [selectedRowKeys, setSelectedRowKeys] = useState<React.Key[]>([]);
 
@@ -154,31 +167,12 @@ export const PaymentApplicationsTable = ({
 
   const columns: TableProps<applicationByStatus>["columns"] = [
     {
-      title: "Id",
+      title: "Id. Aplicación",
       dataIndex: "id",
       key: "id",
       render: (id) => <Text className="idText">{id}</Text>,
       sorter: (a, b) => a.id - b.id,
       showSorterTooltip: false,
-      width: 110
-    },
-    {
-      title: "Id ERP",
-      key: "id_erps",
-      dataIndex: "id_erps",
-      render: (ids: string[]) =>
-        ids?.length ? (
-          <span>
-            {ids.map((erpId, index) => (
-              <span key={`${erpId}-${index}`}>
-                <Text>{erpId}</Text>
-                {index < ids.length - 1 ? ", " : ""}
-              </span>
-            ))}
-          </span>
-        ) : (
-          <Text>-</Text>
-        ),
       width: 130
     },
     {
@@ -199,7 +193,7 @@ export const PaymentApplicationsTable = ({
       width: 115
     },
     {
-      title: "Id Pago",
+      title: "Id. Pago Cashport",
       key: "payment_ids",
       dataIndex: "payment_ids",
       render: (ids: number[]) =>
@@ -213,6 +207,25 @@ export const PaymentApplicationsTable = ({
                 >
                   {paymentId}
                 </Text>
+                {index < ids.length - 1 ? ", " : ""}
+              </span>
+            ))}
+          </span>
+        ) : (
+          <Text>-</Text>
+        ),
+      width: isXXL ? "auto" : 130
+    },
+    {
+      title: "Id. Pago ERP",
+      key: "id_erps",
+      dataIndex: "id_erps",
+      render: (ids: string[]) =>
+        ids?.length ? (
+          <span>
+            {ids.map((erpId, index) => (
+              <span key={`${erpId}-${index}`}>
+                <Text>{erpId}</Text>
                 {index < ids.length - 1 ? ", " : ""}
               </span>
             ))}
@@ -241,13 +254,14 @@ export const PaymentApplicationsTable = ({
       ),
       sorter: (a, b) => (a.amount ?? 0) - (b.amount ?? 0),
       showSorterTooltip: false,
-      width: 200
+      width: 150
     },
     {
       title: "",
       key: "seeDetail",
       align: "right",
       dataIndex: "",
+      width: 50,
       render: (_, record) => {
         const items: MenuProps["items"] = [
           {


### PR DESCRIPTION
…ve width

This pull request updates the `PaymentApplicationsTable` component to improve column organization, naming consistency, and responsiveness. It also includes a minor UI label update elsewhere. The main focus is on reorganizing table columns for clarity and adapting column widths for better display on different screen sizes.

Table column improvements and reorganization:

* Renamed columns for clarity: changed "Id" to "Id. Aplicación" and "Id Pago" to "Id. Pago Cashport" to better reflect their content. [[1]](diffhunk://#diff-92e9794197211a7f294b9f251d4cc01977c37e6be9cd4b3cfc6b6c15463322eeL157-L181) [[2]](diffhunk://#diff-92e9794197211a7f294b9f251d4cc01977c37e6be9cd4b3cfc6b6c15463322eeL202-R196)
* Moved the "Id ERP" column (now "Id. Pago ERP") to a new position and adjusted its rendering logic for consistency. [[1]](diffhunk://#diff-92e9794197211a7f294b9f251d4cc01977c37e6be9cd4b3cfc6b6c15463322eeL157-L181) [[2]](diffhunk://#diff-92e9794197211a7f294b9f251d4cc01977c37e6be9cd4b3cfc6b6c15463322eeR217-R235)
* Adjusted column widths for improved layout, including making the "amount" column narrower and making the "payment_ids" column responsive to screen size. [[1]](diffhunk://#diff-92e9794197211a7f294b9f251d4cc01977c37e6be9cd4b3cfc6b6c15463322eeL244-R264) [[2]](diffhunk://#diff-92e9794197211a7f294b9f251d4cc01977c37e6be9cd4b3cfc6b6c15463322eeR217-R235)

Responsiveness enhancements:

* Introduced use of `Grid.useBreakpoint()` from Ant Design to adjust column widths based on screen size, improving table display on larger and smaller screens. [[1]](diffhunk://#diff-92e9794197211a7f294b9f251d4cc01977c37e6be9cd4b3cfc6b6c15463322eeL2-R12) [[2]](diffhunk://#diff-92e9794197211a7f294b9f251d4cc01977c37e6be9cd4b3cfc6b6c15463322eeR60-R62) [[3]](diffhunk://#diff-92e9794197211a7f294b9f251d4cc01977c37e6be9cd4b3cfc6b6c15463322eeR217-R235)

Minor UI label update:

* Changed the button title from "Acta digital" to "Estado de cuenta" in `ModalGenerateAction`.
<img width="1169" height="546" alt="image" src="https://github.com/user-attachments/assets/dda0bdf2-e590-4976-b1d7-524009a6e67e" />
