### PR TITLE
refactor: extract MIME type correction logic to shared utility

### DIFF
--- a/src/services/accountingAdjustment/accountingAdjustment.ts
+++ b/src/services/accountingAdjustment/accountingAdjustment.ts
@@ -5,41 +5,7 @@ import { DiscountRequestBody } from "@/types/accountingAdjustment/IAccountingAdj
 import { GenericResponse } from "@/types/global/IGlobal";
 import { IPaymentDetail } from "@/types/paymentAgreement/IPaymentAgreement";
 import instance, { API } from "@/utils/api/api";
-
-// Map file extensions to proper MIME types
-const MIME_TYPE_MAP: Record<string, string> = {
-  pdf: "application/pdf",
-  doc: "application/msword",
-  docx: "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
-  xls: "application/vnd.ms-excel",
-  xlsx: "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
-  ppt: "application/vnd.ms-powerpoint",
-  pptx: "application/vnd.openxmlformats-officedocument.presentationml.presentation",
-  txt: "text/plain",
-  csv: "text/csv",
-  jpg: "image/jpeg",
-  jpeg: "image/jpeg",
-  png: "image/png",
-  gif: "image/gif",
-  zip: "application/zip",
-  rar: "application/x-rar-compressed",
-  "7z": "application/x-7z-compressed",
-  msg: "application/vnd.ms-outlook",
-  eml: "message/rfc822"
-};
-
-// Helper function to get correct MIME type from file extension
-const getCorrectMimeType = (file: File): File => {
-  if (!file.type || file.type === "application/octet-stream") {
-    const extension = file.name.split(".").pop()?.toLowerCase();
-    const correctType = extension ? MIME_TYPE_MAP[extension] : file.type;
-
-    if (correctType && correctType !== file.type) {
-      return new File([file], file.name, { type: correctType });
-    }
-  }
-  return file;
-};
+import { getCorrectMimeType } from "@/utils/files/getCorrectMimeType";
 
 interface RadicationData {
   invoices_id: number[];

--- a/src/services/applyTabClients/applyTabClients.ts
+++ b/src/services/applyTabClients/applyTabClients.ts
@@ -5,6 +5,7 @@ import { IApplicationInvoice, InvoicesData } from "@/types/invoices/IInvoices";
 import { IClientPaymentStatus } from "@/types/clientPayments/IClientPayments";
 import { StatusGroup } from "@/hooks/useAcountingAdjustment";
 import { CLIENTUUID_DEMO, PROJECTID_DEMO } from "@/utils/constants/globalConstants";
+import { getCorrectMimeType } from "@/utils/files/getCorrectMimeType";
 
 export const addItemsToTable = async (
   project_id: number,
@@ -157,7 +158,7 @@ export const saveApplication = async ({
     formData.append("useExistingFile", "true"); // O "1"
   } else if (file) {
     // Adjunta el archivo, pero NO el flag
-    formData.append("files", file);
+    formData.append("files", getCorrectMimeType(file));
   }
 
   try {

--- a/src/utils/files/getCorrectMimeType.ts
+++ b/src/utils/files/getCorrectMimeType.ts
@@ -1,0 +1,32 @@
+const MIME_TYPE_MAP: Record<string, string> = {
+  pdf: "application/pdf",
+  doc: "application/msword",
+  docx: "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+  xls: "application/vnd.ms-excel",
+  xlsx: "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+  ppt: "application/vnd.ms-powerpoint",
+  pptx: "application/vnd.openxmlformats-officedocument.presentationml.presentation",
+  txt: "text/plain",
+  csv: "text/csv",
+  jpg: "image/jpeg",
+  jpeg: "image/jpeg",
+  png: "image/png",
+  gif: "image/gif",
+  zip: "application/zip",
+  rar: "application/x-rar-compressed",
+  "7z": "application/x-7z-compressed",
+  msg: "application/vnd.ms-outlook",
+  eml: "message/rfc822"
+};
+
+export const getCorrectMimeType = (file: File): File => {
+  if (!file.type || file.type === "application/octet-stream") {
+    const extension = file.name.split(".").pop()?.toLowerCase();
+    const correctType = extension ? MIME_TYPE_MAP[extension] : file.type;
+
+    if (correctType && correctType !== file.type) {
+      return new File([file], file.name, { type: correctType });
+    }
+  }
+  return file;
+};


### PR DESCRIPTION
Create `src/utils/files/getCorrectMimeType.ts` to centralize the MIME type mapping and correction function. Remove duplicated code from `accountingAdjustment.ts` and update `applyTabClients.ts` to use the imported utility, improving maintainability and reducing code duplication.
This pull request refactors the logic for correcting file MIME types by moving the MIME type mapping and helper function into a reusable utility module. The main benefit is improved code reuse and maintainability, as the logic for determining the correct MIME type for files is now centralized and imported where needed.

Key changes include:

**Code Reuse and Refactoring:**

* Moved the MIME type mapping and `getCorrectMimeType` helper function from `accountingAdjustment.ts` to a new utility file `src/utils/files/getCorrectMimeType.ts`, and updated imports to use this utility in both `accountingAdjustment.ts` and `applyTabClients.ts`. [[1]](diffhunk://#diff-7afdedaf85b6c4db7be2d36796b3eb73c081f152b5f10bbd0e2c39c882ad8bd8L8-R8) [[2]](diffhunk://#diff-66e95bbeb9108625b4bc84abe2fbb507acd3b7045415a4ad87cbe99cb17776a4R1-R32) [[3]](diffhunk://#diff-ee704b790fa4d1bb68085df83ea60c0204116e3a9d1ede2fc061bce08455c41eR8)

**Bug Fixes and Improvements:**

* Updated the file upload logic in `saveApplication` (in `applyTabClients.ts`) to use the new `getCorrectMimeType` utility, ensuring files are always uploaded with the correct MIME type.