### PR TITLE
feat(banks): add download plane action for wallet payments

### DIFF
--- a/src/modules/banks/components/modal-actions-wallet-payments/modal-actions-wallet-payments.tsx
+++ b/src/modules/banks/components/modal-actions-wallet-payments/modal-actions-wallet-payments.tsx
@@ -1,17 +1,48 @@
 "use client";
-import { Flex, Modal } from "antd";
+import { Flex, message, Modal } from "antd";
 import { FileArrowDown } from "@phosphor-icons/react";
 
 import { ButtonGenerateAction } from "@/components/atoms/ButtonGenerateAction/ButtonGenerateAction";
+import { downloadPaymentsPlane } from "@/services/banksPayments/banksPayments";
+import { ISingleBank } from "@/types/banks/IBanks";
 
 import "./modal-actions-wallet-payments.scss";
 
 interface Props {
   isOpen: boolean;
   onClose: () => void;
+  selectedRows: ISingleBank[] | undefined;
 }
 
-const ModalActionsWalletPayments = ({ isOpen, onClose }: Props) => {
+const ModalActionsWalletPayments = ({ isOpen, onClose, selectedRows }: Props) => {
+  const handleDowloadPlane = async () => {
+    if (!selectedRows?.length) {
+      message.warning("Selecciona al menos un pago");
+      return;
+    }
+
+    const paymentIds = selectedRows.map((row) => row.id);
+    const hideLoading = message.loading("Descargando plano...", 0);
+    try {
+      const blob = await downloadPaymentsPlane(paymentIds);
+      const url = window.URL.createObjectURL(blob);
+      const link = document.createElement("a");
+      link.href = url;
+      link.setAttribute("download", `plano_atemco_${Date.now()}.txt`);
+      document.body.appendChild(link);
+      link.click();
+      link.remove();
+      window.URL.revokeObjectURL(url);
+
+      message.success("Plano descargado correctamente");
+      onClose();
+    } catch (error) {
+      message.error(error instanceof Error ? error.message : "Error al descargar el plano");
+    } finally {
+      hideLoading();
+    }
+  };
+
   return (
     <Modal
       className="modalActionsWalletPayments"
@@ -25,7 +56,11 @@ const ModalActionsWalletPayments = ({ isOpen, onClose }: Props) => {
         Selecciona la acción que vas a realizar
       </p>
       <Flex vertical gap="0.75rem">
-        <ButtonGenerateAction icon={<FileArrowDown size={16} />} title="Descargar plano" />
+        <ButtonGenerateAction
+          onClick={handleDowloadPlane}
+          icon={<FileArrowDown size={16} />}
+          title="Descargar plano"
+        />
       </Flex>
     </Modal>
   );

--- a/src/modules/banks/containers/wallet-payments-tab/wallet-payments-tab.tsx
+++ b/src/modules/banks/containers/wallet-payments-tab/wallet-payments-tab.tsx
@@ -171,6 +171,7 @@ export const WalletPaymentsTab: FC<WalletPaymentsTabProps> = ({ isActive }) => {
         <ModalActionsWalletPayments
           isOpen={isGenerateActionOpen}
           onClose={() => setisGenerateActionOpen(false)}
+          selectedRows={selectedRows}
         />
 
         <ModalFilterSelectDates

--- a/src/services/banksPayments/banksPayments.ts
+++ b/src/services/banksPayments/banksPayments.ts
@@ -214,3 +214,26 @@ export const approvePayment = async ({ payments, project_id, client_id }: IAppro
     throw error;
   }
 };
+
+export const downloadPaymentsPlane = async (payment_ids: number[]): Promise<Blob> => {
+  try {
+    const response = await API.post(
+      "/bank/generate-atemco-txt",
+      { payment_ids },
+      { responseType: "blob" }
+    );
+    return response.data;
+  } catch (error: any) {
+    if (error?.response?.data instanceof Blob) {
+      const text = await error.response.data.text();
+      try {
+        const parsed = JSON.parse(text);
+        throw new Error(parsed.message || "Error al descargar el plano");
+      } catch {
+        throw new Error("Error al descargar el plano");
+      }
+    }
+    console.error("Error al descargar el plano:", error);
+    throw error;
+  }
+};


### PR DESCRIPTION
Implement download of "plano atemco" file from the payment actions modal. The modal now receives the selected payment rows, calls the new API endpoint `/bank/generate-atemco-txt`, and triggers a file download with loading/error handling.
This pull request adds functionality to download a payment plan file ("plano") for selected wallet payments. The main changes introduce a new service method for downloading the file, update the modal to handle the download action, and ensure user feedback during the process.

**Feature: Download payment plan file for selected payments**

* Added a new `downloadPaymentsPlane` service method in `banksPayments.ts` to request the plano file from the backend and handle errors, returning it as a `Blob`.
* Updated `ModalActionsWalletPayments` to accept `selectedRows`, implement the `handleDowloadPlane` function, and provide user feedback (loading, success, error messages) during the download process.
* Connected the download button in the modal to trigger the new download logic, requiring at least one payment to be selected.
* Passed `selectedRows` from `WalletPaymentsTab` to `ModalActionsWalletPayments` to enable the new functionality.