### PR TITLE
Add es-CO date handling and clickable payment ID

### DIFF
--- a/src/modules/clients/components/history-tab/history-tab-table/history-tab-table.tsx
+++ b/src/modules/clients/components/history-tab/history-tab-table/history-tab-table.tsx
@@ -46,7 +46,7 @@ const HistoryTable = ({
       title: "Fecha",
       dataIndex: "created_at",
       key: "created_at",
-      render: (created_at) => <Text className="cell">{formatDate(created_at)}</Text>,
+      render: (created_at) => <Text className="cell">{formatDate(created_at, 'es-CO')}</Text>,
       sorter: (a, b) => a.created_at.localeCompare(b.created_at),
       showSorterTooltip: false,
       width: 120

--- a/src/modules/clients/containers/invoice-detail-modal/invoice-detail-modal.tsx
+++ b/src/modules/clients/containers/invoice-detail-modal/invoice-detail-modal.tsx
@@ -530,7 +530,15 @@ const InvoiceDetailModal: FC<InvoiceDetailModalProps> = ({
                                   {item.payment_id && (
                                     <div className={styles.adjustment}>
                                       ID del pago:
-                                      <div className={styles.idAdjustment}>{item.payment_id}</div>
+                                      <div
+                                        className={styles.idAdjustment}
+                                        onClick={() =>
+                                          item.payment_identification_url &&
+                                          handleDocumentClick(item.payment_identification_url)
+                                        }
+                                      >
+                                        {item.payment_id}
+                                      </div>
                                     </div>
                                   )}
                                 </div>

--- a/src/types/clients/invoice-detail.ts
+++ b/src/types/clients/invoice-detail.ts
@@ -34,6 +34,7 @@ export interface IData {
   is_legalized: number;
   is_rejected: number | null;
   payment_id: number | null;
+  payment_identification_url?: string;
   payment_agreement_id: number;
   previous_status: string | null;
   previous_status_id: number | null;

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -158,8 +158,12 @@ export function extractSingleParam(value: string | string[] | undefined): string
   }
   return value;
 }
-export function formatDate(dateString: string): string {
+export function formatDate(dateString: string, locale?: "es-CO" | string): string {
   const date = new Date(dateString);
+  if (locale === "es-CO") {
+    const hsToSub = 5;
+    date.setHours(date.getHours() - hsToSub);
+  }
 
   if (isNaN(date.getTime())) {
     return "-"; // Return empty string for invalid dates


### PR DESCRIPTION
Update formatDate to accept an optional locale and adjust times for 'es-CO' (subtracts 5 hours). Use the new locale in the history table rendering so dates display in Colombia time. Add payment_identification_url to the invoice detail type and make the payment ID element clickable in InvoiceDetailModal to open the identification document when a URL is present.