### PR TITLE
Feat/86e1ba040/financial discounts search param

### DIFF
--- a/src/hooks/useFinancialDiscounts.ts
+++ b/src/hooks/useFinancialDiscounts.ts
@@ -6,7 +6,7 @@ import { GenericResponse } from "@/types/global/IGlobal";
 
 interface Props {
   clientId: string;
-  id?: number;
+  search?: string;
   line?: number[];
   subline?: number[];
   channel?: number[];
@@ -18,28 +18,24 @@ interface Props {
 
 export const useFinancialDiscounts = ({
   clientId,
-  id,
+  search,
   line,
   subline,
   channel,
   zone,
-  searchQuery,
   motive_id,
   page = 1
 }: Props) => {
   const { ID: projectId } = useAppStore((state) => state.selectedProject);
 
-  const idQuery = id ? `&id=${id}` : "";
+  const searchQueryParam = search ? `&search=${search}` : "";
   const lineQuery = line && line.length > 0 ? `&line=${line.join(",")}` : "";
   const sublineQuery = subline && subline.length > 0 ? `&subline=${subline.join(",")}` : "";
   const channelQuery = channel && channel.length > 0 ? `&channel=${channel.join(",")}` : "";
   const zoneQuery = zone && zone.length > 0 ? `&zone=${zone.join(",")}` : "";
   const motiveQuery = motive_id ? `&motive_id=${motive_id}` : "";
-  const searchQueryParam = searchQuery
-    ? `&searchQuery=${encodeURIComponent(searchQuery.toLowerCase().trim())}`
-    : "";
 
-  const pathKey = `/financial-discount/project/${projectId}/client/${clientId}?page=${page}${idQuery}${lineQuery}${sublineQuery}${channelQuery}${zoneQuery}${searchQueryParam}${motiveQuery}`;
+  const pathKey = `/financial-discount/project/${projectId}/client/${clientId}?page=${page}${searchQueryParam}${lineQuery}${sublineQuery}${channelQuery}${zoneQuery}${motiveQuery}`;
 
   const { data, error, mutate } = useSWR<GenericResponse<StatusFinancialDiscounts[]>>(
     pathKey,

--- a/src/modules/clients/containers/accounting-adjustments-tab/accounting-adjustments-tab.tsx
+++ b/src/modules/clients/containers/accounting-adjustments-tab/accounting-adjustments-tab.tsx
@@ -57,7 +57,7 @@ const AccountingAdjustmentsTab = () => {
     mutate: mutateFinancialDiscounts
   } = useFinancialDiscounts({
     clientId,
-    id: debouncedSearchQuery ? parseInt(debouncedSearchQuery) : undefined,
+    search: debouncedSearchQuery ? debouncedSearchQuery : undefined,
     line: filters.lines,
     zone: filters.zones,
     channel: filters.channels,


### PR DESCRIPTION
This pull request updates the `useFinancialDiscounts` hook to replace the use of an `id` parameter with a more flexible `search` parameter, allowing for broader search functionality. The change is reflected both in the hook's interface and in its usage within the `AccountingAdjustmentsTab` component.

**Enhancements to search functionality:**

* Changed the `Props` interface in `useFinancialDiscounts.ts` to remove the optional `id` parameter and add a `search` parameter, enabling more general search queries.
* Updated the construction of the API query string in `useFinancialDiscounts.ts` to use the new `search` parameter instead of `id`, and removed the now-unused `searchQuery` logic.

**Component integration:**

* Updated the `AccountingAdjustmentsTab` component to pass the `debouncedSearchQuery` as the `search` parameter instead of converting it to an `id`, aligning with the new hook interface.