### PR TITLE
feat: show order discount row always and display total in cross-selling

### DIFF
--- a/src/modules/commerce/components/create-order-checkout/order-shipment-confirm/order-shipment-confirm.tsx
+++ b/src/modules/commerce/components/create-order-checkout/order-shipment-confirm/order-shipment-confirm.tsx
@@ -307,12 +307,10 @@ export default function OrderShipmentConfirm({
     setOrderSplitDetails(splits);
   }, [multiEntrega, entregas, singleForm, discountItems, setOrderSplitDetails]);
 
-  const subtotal = confirmOrderData?.subtotal ?? 0;
   const totalDescuento = confirmOrderData?.discounts?.totalDiscount ?? 0;
   const descuentoDeOrden = confirmOrderData?.discounts?.totalOrderDiscount ?? 0;
   const descuentoDeProductos = confirmOrderData?.discounts?.totalProductDiscount ?? 0;
   const total = confirmOrderData?.total ?? 0;
-  const iva = confirmOrderData?.taxes ?? 0;
 
   const addressOptions = [
     NEW_ADDRESS_OPTION,
@@ -562,12 +560,12 @@ export default function OrderShipmentConfirm({
                 <p>-$0</p>
               )}
             </div>
-            {descuentoDeOrden > 0 && (
-              <div className="flex justify-between font-medium">
-                <p>Descuento de orden</p>
-                <p>-${formatNumber(descuentoDeOrden)}</p>
-              </div>
-            )}
+
+            <div className="flex justify-between font-medium">
+              <p>Descuento de orden</p>
+              <p>-${formatNumber(descuentoDeOrden)}</p>
+            </div>
+
             {totalDescuento > 0 && (
               <div className="flex justify-between text-xs text-red-500">
                 <span>Descuentos aplicados</span>

--- a/src/modules/commerce/components/create-order-checkout/products-details-and-discounts/products-details-and-discounts.tsx
+++ b/src/modules/commerce/components/create-order-checkout/products-details-and-discounts/products-details-and-discounts.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useContext, useState } from "react";
+import { useContext, useEffect, useState } from "react";
 import { ArrowLeft, Check, Pencil, Trash2 } from "lucide-react";
 
 import { OrderViewContext } from "@/modules/commerce/contexts/orderViewContext";
@@ -94,7 +94,7 @@ export default function ProductsDetailsAndDiscounts({
     selectedCategories,
     setSelectedCategories,
     deactivateCrossSelling,
-    setDeactivateCrossSelling,
+    setDeactivateCrossSelling
   } = useContext(OrderViewContext);
 
   const handleRemoveProduct = (productSku: string) => {
@@ -111,6 +111,15 @@ export default function ProductsDetailsAndDiscounts({
   const discountItems: DiscountItem[] = confirmOrderData?.discounts?.discountItems ?? [];
 
   const secondaryDiscount = confirmOrderData?.discounts?.secondaryDiscount;
+
+  const [orderTotalDiscount, setOrderTotalDiscount] = useState(0);
+
+  useEffect(() => {
+    const incoming = confirmOrderData?.discounts?.totalOrderDiscount ?? 0;
+    if (incoming > 0) {
+      setOrderTotalDiscount(incoming);
+    }
+  }, [confirmOrderData?.discounts?.totalOrderDiscount]);
 
   const updatePrimaryDiscount = (item: DiscountItem, newValue: number) => {
     setExecutiveDiscounts((prev) => {
@@ -274,6 +283,9 @@ export default function ProductsDetailsAndDiscounts({
             </div>
             <div className="flex items-center gap-3 px-4 py-3">
               <span className="flex-1 text-sm text-[#141414]">{secondaryDiscount.name}</span>
+              <span className="text-sm font-semibold text-red-500">
+                -{formatPrice(orderTotalDiscount)}
+              </span>
               <button
                 onClick={() => setDeactivateCrossSelling((prev) => !prev)}
                 className={`w-5 h-5 rounded flex items-center justify-center border transition-colors flex-shrink-0 ${


### PR DESCRIPTION
- Always render the order discount row (previously hidden when zero) to improve visibility of discounts applied.
- Add state and effect to capture total order discount and display it in the cross-selling discount section.
- Remove unused `subtotal` and `iva` variables to clean up code.

This pull request introduces improvements to the order discount display logic in the checkout components, ensuring that order-level discounts are handled and shown more accurately. The changes focus on better state management for discounts and UI consistency across the order confirmation and product details sections.

**Order discount handling and display improvements:**

* Added local state `orderTotalDiscount` with a `useEffect` to track and display the order-level discount in `ProductsDetailsAndDiscounts`, ensuring the discount is updated reactively when the data changes. [[1]](diffhunk://#diff-fc98e019d55baffb41ca2d49154acf3cf08b54c0ff81380ad90a8d5700dec12cR115-R123) [[2]](diffhunk://#diff-fc98e019d55baffb41ca2d49154acf3cf08b54c0ff81380ad90a8d5700dec12cR286-R288)
* Updated the UI to always render the "Descuento de orden" section in `OrderShipmentConfirm`, regardless of the discount value, for consistent layout and clarity.

**Code and import enhancements:**

* Added missing `useEffect` import in `ProductsDetailsAndDiscounts` to support new state logic.
* Minor formatting and cleanup in destructuring context variables for readability.

**Removed unused variables:**

* Removed unused `subtotal` and `iva` variables from `OrderShipmentConfirm` to clean up the code.