### PR TITLE
Feat/add fixes and search in tabs

### DIFF
--- a/src/app/comercio/cetaphil/page.tsx
+++ b/src/app/comercio/cetaphil/page.tsx
@@ -59,6 +59,8 @@ export interface IOrderViewContext {
   discountsLoading: boolean;
   executiveDiscounts: IExecutiveDiscount[];
   setExecutiveDiscounts: Dispatch<SetStateAction<IExecutiveDiscount[]>>;
+  deactivateCrossSelling: boolean;
+  setDeactivateCrossSelling: Dispatch<SetStateAction<boolean>>;
   order_split_details: IOrderSplitDetail[];
   setOrderSplitDetails: Dispatch<SetStateAction<IOrderSplitDetail[]>>;
   toggleCart?: () => void;
@@ -82,6 +84,7 @@ const CreateOrderView: FC = () => {
   const [discounts, setDiscounts] = useState<IDiscountPackageAvailable[]>([]);
   const [discountsLoading, setDiscountsLoading] = useState(false);
   const [executiveDiscounts, setExecutiveDiscounts] = useState<IExecutiveDiscount[]>([]);
+  const [deactivateCrossSelling, setDeactivateCrossSelling] = useState(false);
   const [orderSplitDetails, setOrderSplitDetails] = useState<IOrderSplitDetail[]>([]);
   const { selectedProject } = useAppStore((state) => state);
   const decoder = useDecodeToken();
@@ -152,6 +155,8 @@ const CreateOrderView: FC = () => {
         discountsLoading,
         executiveDiscounts,
         setExecutiveDiscounts,
+        deactivateCrossSelling,
+        setDeactivateCrossSelling,
         order_split_details: orderSplitDetails,
         setOrderSplitDetails
       }}

--- a/src/components/organisms/discounts/discount-package/create/CreateDiscountPackageView.tsx
+++ b/src/components/organisms/discounts/discount-package/create/CreateDiscountPackageView.tsx
@@ -39,8 +39,10 @@ export function CreateDiscountPackageView({ params }: Readonly<Props>) {
     removeDiscount,
     removeAdditionalDiscount,
     isLoadingSelect,
-    optionsDiscounts,
-    discountList,
+    optionsPrimaryDiscounts,
+    optionsSecondaryDiscounts,
+    primaryDiscountList,
+    secondaryDiscountList,
     //discountId,
     isFormDisabled,
     form,
@@ -51,7 +53,8 @@ export function CreateDiscountPackageView({ params }: Readonly<Props>) {
   const [typeDiscount, setTypeDiscount] = useState<TypeDiscount | null>(null);
 
   const handleConfirmModal = (id: number) => {
-    const completeOptionSelected = discountList?.find((d) => d.id === id);
+    const list = typeDiscount === "principal" ? primaryDiscountList : secondaryDiscountList;
+    const completeOptionSelected = list?.find((d) => d.id === id);
     if (completeOptionSelected) {
       if (typeDiscount === "principal") {
         appendDiscount(completeOptionSelected);
@@ -76,11 +79,11 @@ export function CreateDiscountPackageView({ params }: Readonly<Props>) {
   const filteredOptions = useMemo(
     () =>
       filterAvailableDiscountOptions(
-        optionsDiscounts,
+        typeDiscount === "principal" ? optionsPrimaryDiscounts : optionsSecondaryDiscounts,
         primaryDiscountsFields,
         secondaryDiscountsFields
       ),
-    [optionsDiscounts, primaryDiscountsFields, secondaryDiscountsFields]
+    [typeDiscount, optionsPrimaryDiscounts, optionsSecondaryDiscounts, primaryDiscountsFields, secondaryDiscountsFields]
   );
 
   return (

--- a/src/components/organisms/discounts/discount-package/create/CreateDiscountPackageView.tsx
+++ b/src/components/organisms/discounts/discount-package/create/CreateDiscountPackageView.tsx
@@ -239,7 +239,7 @@ export function CreateDiscountPackageView({ params }: Readonly<Props>) {
                 columns={discountsFormColumns({ remove: removeAdditionalDiscount, isFormDisabled })}
                 pagination={false}
               />
-              {!isFormDisabled && (
+              {!isFormDisabled && secondaryDiscountsFields.length === 0 && (
                 <Flex justify="flex-end">
                   <PrincipalButton
                     onClick={() => {

--- a/src/components/organisms/discounts/discount-package/create/hooks/useCreateDiscountPackage.ts
+++ b/src/components/organisms/discounts/discount-package/create/hooks/useCreateDiscountPackage.ts
@@ -105,21 +105,49 @@ export default function useCreateDiscountPackage({ params }: Props) {
     {}
   );
 
-  const optionsDiscounts = useMemo(
+  const CROSS_DISCOUNT_TYPE_IDS = [3, 4];
+
+  const optionsPrimaryDiscounts = useMemo(
     () =>
-      dataDiscountList?.data.map((option) => ({
-        value: option.id,
-        label: option.discount_name ?? ""
-      })),
+      dataDiscountList?.data
+        .filter((option) => !CROSS_DISCOUNT_TYPE_IDS.includes(option.discount_type_id!))
+        .map((option) => ({
+          value: option.id,
+          label: option.discount_name ?? ""
+        })),
     [dataDiscountList]
   );
 
-  const discountList = useMemo(
+  const optionsSecondaryDiscounts = useMemo(
     () =>
-      dataDiscountList?.data.map((discount) => ({
-        ...discount,
-        packageId: discount.id
-      })),
+      dataDiscountList?.data
+        .filter((option) => CROSS_DISCOUNT_TYPE_IDS.includes(option.discount_type_id!))
+        .map((option) => ({
+          value: option.id,
+          label: option.discount_name ?? ""
+        })),
+    [dataDiscountList]
+  );
+
+  const primaryDiscountList = useMemo(
+    () =>
+      dataDiscountList?.data
+        .filter((discount) => !CROSS_DISCOUNT_TYPE_IDS.includes(discount.discount_type_id!))
+        .map((discount) => ({
+          ...discount,
+          packageId: discount.id
+        })),
+    [dataDiscountList]
+  );
+
+  const secondaryDiscountList = useMemo(
+    () =>
+      dataDiscountList?.data
+        .filter((discount) => CROSS_DISCOUNT_TYPE_IDS.includes(discount.discount_type_id!))
+        .map((discount) => ({
+          ...discount,
+          packageId: discount.id
+        })),
     [dataDiscountList]
   );
 
@@ -183,9 +211,11 @@ export default function useCreateDiscountPackage({ params }: Props) {
     removeDiscount,
     removeAdditionalDiscount,
     watch,
-    optionsDiscounts,
+    optionsPrimaryDiscounts,
+    optionsSecondaryDiscounts,
     isLoadingSelect,
-    discountList,
+    primaryDiscountList,
+    secondaryDiscountList,
     discountId: discountPackageId,
     isFormDisabled: disabled,
     clients,

--- a/src/hooks/useBankPayments.ts
+++ b/src/hooks/useBankPayments.ts
@@ -4,14 +4,21 @@ import { useAppStore } from "@/lib/store/store";
 import { GenericResponse } from "@/types/global/IGlobal";
 import { IPaymentsByStatus } from "@/types/banks/IBanks";
 import { IActivePaymentsFilters } from "@/components/atoms/Filters/FilterActivePaymentsTab/FilterActivePaymentsTab";
+import { PaymentTransactionType } from "@/modules/banks/constants/paymentTransactionType";
 
 interface Props {
   like?: string;
   selectedFilters?: IActivePaymentsFilters;
   enabled?: boolean;
+  transaction_type?: PaymentTransactionType[];
 }
 
-export const useBankPayments = ({ like, selectedFilters, enabled = true }: Props) => {
+export const useBankPayments = ({
+  like,
+  selectedFilters,
+  enabled = true,
+  transaction_type
+}: Props) => {
   const { ID: projectId } = useAppStore((state) => state.selectedProject);
 
   const startDate = selectedFilters?.dates?.length
@@ -26,9 +33,12 @@ export const useBankPayments = ({ like, selectedFilters, enabled = true }: Props
   const startDateQuery = startDate ? `&start_date=${startDate}` : "";
   const endDateQuery = endDate ? `&end_date=${endDate}` : "";
   const statusQuery = status !== undefined ? `&status=${status}` : "";
+  const typeQuery = transaction_type?.length
+    ? `&transaction_type=${transaction_type.join(",")}`
+    : "";
 
   const pathKey = enabled
-    ? `/bank/get-payments?project_id=${projectId}${likeQuery}${startDateQuery}${endDateQuery}${statusQuery}`
+    ? `/bank/get-payments?project_id=${projectId}${likeQuery}${startDateQuery}${endDateQuery}${statusQuery}${typeQuery}`
     : null;
 
   const { data, error, mutate } = useSWR<GenericResponse<IPaymentsByStatus[]>>(pathKey, fetcher, {

--- a/src/hooks/useFinancialDiscounts.ts
+++ b/src/hooks/useFinancialDiscounts.ts
@@ -6,7 +6,7 @@ import { GenericResponse } from "@/types/global/IGlobal";
 
 interface Props {
   clientId: string;
-  id?: number;
+  search?: string;
   line?: number[];
   subline?: number[];
   channel?: number[];
@@ -18,28 +18,24 @@ interface Props {
 
 export const useFinancialDiscounts = ({
   clientId,
-  id,
+  search,
   line,
   subline,
   channel,
   zone,
-  searchQuery,
   motive_id,
   page = 1
 }: Props) => {
   const { ID: projectId } = useAppStore((state) => state.selectedProject);
 
-  const idQuery = id ? `&id=${id}` : "";
+  const searchQueryParam = search ? `&search=${search}` : "";
   const lineQuery = line && line.length > 0 ? `&line=${line.join(",")}` : "";
   const sublineQuery = subline && subline.length > 0 ? `&subline=${subline.join(",")}` : "";
   const channelQuery = channel && channel.length > 0 ? `&channel=${channel.join(",")}` : "";
   const zoneQuery = zone && zone.length > 0 ? `&zone=${zone.join(",")}` : "";
   const motiveQuery = motive_id ? `&motive_id=${motive_id}` : "";
-  const searchQueryParam = searchQuery
-    ? `&searchQuery=${encodeURIComponent(searchQuery.toLowerCase().trim())}`
-    : "";
 
-  const pathKey = `/financial-discount/project/${projectId}/client/${clientId}?page=${page}${idQuery}${lineQuery}${sublineQuery}${channelQuery}${zoneQuery}${searchQueryParam}${motiveQuery}`;
+  const pathKey = `/financial-discount/project/${projectId}/client/${clientId}?page=${page}${searchQueryParam}${lineQuery}${sublineQuery}${channelQuery}${zoneQuery}${motiveQuery}`;
 
   const { data, error, mutate } = useSWR<GenericResponse<StatusFinancialDiscounts[]>>(
     pathKey,

--- a/src/modules/banks/components/modal-actions-wallet-payments/index.ts
+++ b/src/modules/banks/components/modal-actions-wallet-payments/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./modal-actions-wallet-payments";

--- a/src/modules/banks/components/modal-actions-wallet-payments/modal-actions-wallet-payments.scss
+++ b/src/modules/banks/components/modal-actions-wallet-payments/modal-actions-wallet-payments.scss
@@ -1,0 +1,31 @@
+@import "@/styles/variables.scss";
+
+.modalActionsWalletPayments {
+    max-height: 90%;
+    .ant-modal-content {
+        padding: 2rem !important;
+
+        .ant-modal-close {
+            margin: 1.2rem;
+        }
+    }
+
+    &__title {
+        margin-bottom: 0.5rem !important;
+    }
+
+    &__description {
+        font-size: 1rem;
+        font-weight: 300;
+    }
+
+    .ant-modal-body {
+        display: flex;
+        flex-direction: column;
+        gap: 1.5rem;
+    }
+
+    .ant-collapse-header {
+        border-radius: 8px !important;
+    }
+}

--- a/src/modules/banks/components/modal-actions-wallet-payments/modal-actions-wallet-payments.tsx
+++ b/src/modules/banks/components/modal-actions-wallet-payments/modal-actions-wallet-payments.tsx
@@ -1,17 +1,48 @@
 "use client";
-import { Flex, Modal } from "antd";
+import { Flex, message, Modal } from "antd";
 import { FileArrowDown } from "@phosphor-icons/react";
 
 import { ButtonGenerateAction } from "@/components/atoms/ButtonGenerateAction/ButtonGenerateAction";
+import { downloadPaymentsPlane } from "@/services/banksPayments/banksPayments";
+import { ISingleBank } from "@/types/banks/IBanks";
 
 import "./modal-actions-wallet-payments.scss";
 
 interface Props {
   isOpen: boolean;
   onClose: () => void;
+  selectedRows: ISingleBank[] | undefined;
 }
 
-const ModalActionsWalletPayments = ({ isOpen, onClose }: Props) => {
+const ModalActionsWalletPayments = ({ isOpen, onClose, selectedRows }: Props) => {
+  const handleDowloadPlane = async () => {
+    if (!selectedRows?.length) {
+      message.warning("Selecciona al menos un pago");
+      return;
+    }
+
+    const paymentIds = selectedRows.map((row) => row.id);
+    const hideLoading = message.loading("Descargando plano...", 0);
+    try {
+      const blob = await downloadPaymentsPlane(paymentIds);
+      const url = window.URL.createObjectURL(blob);
+      const link = document.createElement("a");
+      link.href = url;
+      link.setAttribute("download", `plano_atemco_${Date.now()}.txt`);
+      document.body.appendChild(link);
+      link.click();
+      link.remove();
+      window.URL.revokeObjectURL(url);
+
+      message.success("Plano descargado correctamente");
+      onClose();
+    } catch (error) {
+      message.error(error instanceof Error ? error.message : "Error al descargar el plano");
+    } finally {
+      hideLoading();
+    }
+  };
+
   return (
     <Modal
       className="modalActionsWalletPayments"
@@ -25,7 +56,11 @@ const ModalActionsWalletPayments = ({ isOpen, onClose }: Props) => {
         Selecciona la acción que vas a realizar
       </p>
       <Flex vertical gap="0.75rem">
-        <ButtonGenerateAction icon={<FileArrowDown size={16} />} title="Descargar plano" />
+        <ButtonGenerateAction
+          onClick={handleDowloadPlane}
+          icon={<FileArrowDown size={16} />}
+          title="Descargar plano"
+        />
       </Flex>
     </Modal>
   );

--- a/src/modules/banks/components/modal-actions-wallet-payments/modal-actions-wallet-payments.tsx
+++ b/src/modules/banks/components/modal-actions-wallet-payments/modal-actions-wallet-payments.tsx
@@ -1,0 +1,34 @@
+"use client";
+import { Flex, Modal } from "antd";
+import { FileArrowDown } from "@phosphor-icons/react";
+
+import { ButtonGenerateAction } from "@/components/atoms/ButtonGenerateAction/ButtonGenerateAction";
+
+import "./modal-actions-wallet-payments.scss";
+
+interface Props {
+  isOpen: boolean;
+  onClose: () => void;
+}
+
+const ModalActionsWalletPayments = ({ isOpen, onClose }: Props) => {
+  return (
+    <Modal
+      className="modalActionsWalletPayments"
+      width={686}
+      open={isOpen}
+      title={null}
+      footer={null}
+      onCancel={onClose}
+    >
+      <p className="modalActionsWalletPayments__description">
+        Selecciona la acción que vas a realizar
+      </p>
+      <Flex vertical gap="0.75rem">
+        <ButtonGenerateAction icon={<FileArrowDown size={16} />} title="Descargar plano" />
+      </Flex>
+    </Modal>
+  );
+};
+
+export default ModalActionsWalletPayments;

--- a/src/modules/banks/constants/paymentTransactionType.ts
+++ b/src/modules/banks/constants/paymentTransactionType.ts
@@ -1,0 +1,6 @@
+export enum PaymentTransactionType {
+  Formal = 1,
+  Informal = 2,
+  Homemarket = 3,
+  Wallet = 4
+}

--- a/src/modules/banks/containers/active-payments-tab/active-payments-tab.tsx
+++ b/src/modules/banks/containers/active-payments-tab/active-payments-tab.tsx
@@ -7,6 +7,7 @@ import { useModalDetail } from "@/context/ModalContext";
 import { useMessageApi } from "@/context/MessageContext";
 import { useAppStore } from "@/lib/store/store";
 import { useBankPayments } from "@/hooks/useBankPayments";
+import { PaymentTransactionType } from "@/modules/banks/constants/paymentTransactionType";
 import { approvePayment } from "@/services/banksPayments/banksPayments";
 import { markPaymentsAsUnidentified } from "@/services/applyTabClients/applyTabClients";
 
@@ -60,7 +61,8 @@ export const ActivePaymentsTab: FC<ActivePaymentsTabProps> = ({ isActive }) => {
   const { data, isLoading, mutate } = useBankPayments({
     like: searchQuery,
     selectedFilters,
-    enabled: isActive
+    enabled: isActive,
+    transaction_type: [PaymentTransactionType.Formal, PaymentTransactionType.Homemarket]
   });
 
   const handleOpenBankRules = () => {

--- a/src/modules/banks/containers/banks-view/banks-view.tsx
+++ b/src/modules/banks/containers/banks-view/banks-view.tsx
@@ -6,10 +6,12 @@ import UiTab from "@/components/ui/ui-tab";
 import styles from "./banks-view.module.scss";
 import ActivePaymentsTab from "../active-payments-tab";
 import PaymentApplicationsTab from "../payment-applications-tab";
+import WalletPaymentsTab from "../wallet-payments-tab";
 
 const TAB_KEYS = {
   activePayments: "active-payments",
-  paymentApplications: "payment-applications"
+  paymentApplications: "payment-applications",
+  walletPayments: "wallet-payments"
 };
 
 const VALID_TABS = new Set<string>(Object.values(TAB_KEYS));
@@ -41,6 +43,11 @@ export const BanksView: FC = () => {
       key: TAB_KEYS.paymentApplications,
       label: "Aplicaciones de pago",
       children: <PaymentApplicationsTab isActive={activeKey === TAB_KEYS.paymentApplications} />
+    },
+    {
+      key: TAB_KEYS.walletPayments,
+      label: "Pagos wallet",
+      children: <WalletPaymentsTab isActive={activeKey === TAB_KEYS.walletPayments} />
     }
   ];
 

--- a/src/modules/banks/containers/wallet-payments-tab/index.ts
+++ b/src/modules/banks/containers/wallet-payments-tab/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./wallet-payments-tab";

--- a/src/modules/banks/containers/wallet-payments-tab/wallet-payments-tab.module.scss
+++ b/src/modules/banks/containers/wallet-payments-tab/wallet-payments-tab.module.scss
@@ -1,0 +1,21 @@
+@import "@/styles/variables.scss";
+
+.walletPaymentsTab {
+    .header {
+        display: flex;
+        box-sizing: content-box;
+        height: 48px;
+        gap: 0.5rem;
+    }
+
+    .button__actions {
+        padding: 0.75rem 1rem;
+        background-color: $background;
+        border: solid 1px transparent;
+        font-weight: 600;
+        display: flex;
+        align-items: center;
+        height: 3rem;
+        font-size: 1rem;
+    }
+}

--- a/src/modules/banks/containers/wallet-payments-tab/wallet-payments-tab.tsx
+++ b/src/modules/banks/containers/wallet-payments-tab/wallet-payments-tab.tsx
@@ -171,6 +171,7 @@ export const WalletPaymentsTab: FC<WalletPaymentsTabProps> = ({ isActive }) => {
         <ModalActionsWalletPayments
           isOpen={isGenerateActionOpen}
           onClose={() => setisGenerateActionOpen(false)}
+          selectedRows={selectedRows}
         />
 
         <ModalFilterSelectDates

--- a/src/modules/banks/containers/wallet-payments-tab/wallet-payments-tab.tsx
+++ b/src/modules/banks/containers/wallet-payments-tab/wallet-payments-tab.tsx
@@ -1,0 +1,186 @@
+import { FC, useState } from "react";
+import { Button, Flex, Spin } from "antd";
+import { Bank, DotsThree } from "phosphor-react";
+import dayjs from "dayjs";
+
+import { useModalDetail } from "@/context/ModalContext";
+import { useMessageApi } from "@/context/MessageContext";
+import { useAppStore } from "@/lib/store/store";
+import { useBankPayments } from "@/hooks/useBankPayments";
+import { PaymentTransactionType } from "@/modules/banks/constants/paymentTransactionType";
+import { approvePayment } from "@/services/banksPayments/banksPayments";
+import { markPaymentsAsUnidentified } from "@/services/applyTabClients/applyTabClients";
+
+import PrincipalButton from "@/components/atoms/buttons/principalButton/PrincipalButton";
+import Collapse from "@/components/ui/collapse";
+import LabelCollapse from "@/components/ui/label-collapse";
+import BanksTable from "../../components/banks-table/Banks-table";
+import BanksRules from "../bank-rules";
+import ModalActionsBanksPayments from "../../components/modal-actions-banks-payments";
+import ModalActionsEditClient from "../../components/modal-actions-edit-client";
+import ModalActionsUploadEvidence from "../../components/modal-actions-upload-evidence";
+import ModalActionsAssignClient from "../../components/modal-actions-assign-client";
+import ModalActionsSplitPayment from "../../components/modal-actions-split-payment";
+import ModalActionsChangeStatus from "../../components/modal-actions-change-status";
+import { ModalConfirmAction } from "@/components/molecules/modals/ModalConfirmAction/ModalConfirmAction";
+import OptimizedSearchComponent from "@/components/atoms/inputs/OptimizedSearchComponent/OptimizedSearchComponent";
+import {
+  FilterActivePaymentsTab,
+  IActivePaymentsFilters
+} from "@/components/atoms/Filters/FilterActivePaymentsTab/FilterActivePaymentsTab";
+import ModalFilterSelectDates from "../../components/modal-filter-select-dates";
+
+import { ISingleBank } from "@/types/banks/IBanks";
+import { IClientPayment } from "@/types/clientPayments/IClientPayments";
+import { IFormFilterDates } from "../../components/modal-filter-select-dates/modal-filter-select-dates";
+
+import styles from "./wallet-payments-tab.module.scss";
+import { FilterPaymentApplicationsTab } from "@/components/atoms/Filters/FilterPaymentApplicationsTab/FilterPaymentApplicationsTab";
+import ModalActionsWalletPayments from "../../components/modal-actions-wallet-payments";
+
+interface WalletPaymentsTabProps {
+  isActive: boolean;
+}
+
+export const WalletPaymentsTab: FC<WalletPaymentsTabProps> = ({ isActive }) => {
+  const [selectedRows, setSelectedRows] = useState<ISingleBank[]>();
+  const [isGenerateActionOpen, setisGenerateActionOpen] = useState(false);
+  const [clearSelected, setClearSelected] = useState(false);
+  const [whichModalIsOpen, setWhichModalIsOpen] = useState(0);
+  const [mutatedPaymentDetail, mutatePaymentDetail] = useState<boolean>(false);
+  const [searchQuery, setSearchQuery] = useState<string>("");
+  const [selectedFilters, setSelectedFilters] = useState<IActivePaymentsFilters>({
+    dates: [],
+    active: []
+  });
+  const [customDate, setCustomDate] = useState<string>("");
+  const { openModal } = useModalDetail();
+  const { data, isLoading, mutate } = useBankPayments({
+    like: searchQuery,
+    selectedFilters,
+    enabled: isActive,
+    transaction_type: [PaymentTransactionType.Informal, PaymentTransactionType.Wallet]
+  });
+
+  const handleActionInDetail = (selectedPayment: ISingleBank | IClientPayment): void => {
+    setisGenerateActionOpen(!isGenerateActionOpen);
+    setSelectedRows([selectedPayment as ISingleBank]);
+    mutate();
+  };
+
+  const handleOpenPaymentDetail = (paymentId: number) => {
+    openModal("payment", {
+      paymentId,
+      handleActionInDetail,
+      handleOpenPaymentDetail,
+      mutatedPaymentDetail
+    });
+  };
+
+  const onCloseModal = (cancelClicked?: Boolean) => {
+    setWhichModalIsOpen(0);
+
+    if (cancelClicked) return setisGenerateActionOpen(!isGenerateActionOpen);
+
+    setClearSelected(!clearSelected);
+    setSelectedRows([]);
+    mutate();
+
+    mutatePaymentDetail((prev) => !prev);
+    openModal("payment", {
+      paymentId: selectedRows?.[0]?.id || 0,
+      handleActionInDetail,
+      handleOpenPaymentDetail,
+      mutatedPaymentDetail: !mutatedPaymentDetail
+    });
+  };
+
+  const handleSearch = (query: string) => {
+    const searchQuery = query.trim().replaceAll(" ", ",");
+    setSearchQuery(searchQuery);
+  };
+
+  const handleFilterDates = (data: IFormFilterDates) => {
+    const { start_date, end_date } = data;
+    setSelectedFilters((prev) => ({
+      ...prev,
+      dates: [`${dayjs(start_date).format("YYYY-MM-DD")}|${dayjs(end_date).format("YYYY-MM-DD")}`]
+    }));
+    setCustomDate(
+      `${dayjs(start_date).format("YYYY-MM-DD")}|${dayjs(end_date).format("YYYY-MM-DD")}`
+    );
+  };
+
+  return (
+    <>
+      <Flex className={styles.walletPaymentsTab} vertical>
+        <div className={`${styles.header} banksStickyHeader`}>
+          <OptimizedSearchComponent title="Buscar" onSearch={handleSearch} />
+          <FilterPaymentApplicationsTab
+            setSelectedFilters={setSelectedFilters}
+            handleOpenCustomDate={() => setWhichModalIsOpen(1)}
+            customDate={customDate}
+            setCustomDate={setCustomDate}
+          />
+          <Button
+            className={styles.button__actions}
+            icon={<DotsThree size={"1.5rem"} />}
+            onClick={() => {
+              setisGenerateActionOpen(true);
+            }}
+          >
+            Generar acción
+          </Button>
+        </div>
+
+        {isLoading ? (
+          <Flex justify="center">
+            <Spin style={{ margin: "30px" }} />
+          </Flex>
+        ) : (
+          <Collapse
+            stickyLabel
+            labelStickyOffset={"6rem"}
+            items={data?.map((status) => ({
+              key: status.payments_status_id,
+              label: (
+                <LabelCollapse
+                  status={status.payments_status}
+                  color={status.color}
+                  quantity={status.payments.length}
+                  total={status.total_account || 0}
+                />
+              ),
+              children: (
+                <BanksTable
+                  clientsByStatus={status.payments.map((client) => ({
+                    ...client,
+                    client_status_id: status.payments_status_id
+                  }))}
+                  handleOpenPaymentDetail={handleOpenPaymentDetail}
+                  selectedRows={selectedRows}
+                  setSelectedRows={setSelectedRows}
+                  bankStatusId={status.payments_status_id}
+                  clearSelected={clearSelected}
+                />
+              )
+            }))}
+          />
+        )}
+
+        <ModalActionsWalletPayments
+          isOpen={isGenerateActionOpen}
+          onClose={() => setisGenerateActionOpen(false)}
+        />
+
+        <ModalFilterSelectDates
+          isOpen={whichModalIsOpen === 1}
+          onClose={() => setWhichModalIsOpen(0)}
+          selectDates={handleFilterDates}
+        />
+      </Flex>
+    </>
+  );
+};
+
+export default WalletPaymentsTab;

--- a/src/modules/clients/containers/accounting-adjustments-tab/accounting-adjustments-tab.tsx
+++ b/src/modules/clients/containers/accounting-adjustments-tab/accounting-adjustments-tab.tsx
@@ -57,7 +57,7 @@ const AccountingAdjustmentsTab = () => {
     mutate: mutateFinancialDiscounts
   } = useFinancialDiscounts({
     clientId,
-    id: debouncedSearchQuery ? parseInt(debouncedSearchQuery) : undefined,
+    search: debouncedSearchQuery ? debouncedSearchQuery : undefined,
     line: filters.lines,
     zone: filters.zones,
     channel: filters.channels,

--- a/src/modules/commerce/components/create-order-cart/create-order-cart.tsx
+++ b/src/modules/commerce/components/create-order-cart/create-order-cart.tsx
@@ -71,7 +71,8 @@ const CreateOrderCart: FC<CreateOrderCartProps> = ({ onClose }) => {
     selectedDiscount,
     categories,
     setCategories,
-    executiveDiscounts
+    executiveDiscounts,
+    deactivateCrossSelling
   } = useContext(OrderViewContext);
   const numberOfSelectedProducts = selectedCategories.reduce(
     (acc, category) => acc + category.products.length,
@@ -234,7 +235,8 @@ const CreateOrderCart: FC<CreateOrderCartProps> = ({ onClose }) => {
         const confirmOrderData = {
           discount_package: selectedDiscount,
           order_summary: products,
-          executive_discounts: executiveDiscounts
+          executive_discounts: executiveDiscounts,
+          deactivate_cross_selling: !deactivateCrossSelling
         };
         try {
           const response = await confirmOrder(projectId, client?.id || "", confirmOrderData);

--- a/src/modules/commerce/components/create-order-checkout/create-order-checkout.tsx
+++ b/src/modules/commerce/components/create-order-checkout/create-order-checkout.tsx
@@ -53,7 +53,8 @@ export default function CheckoutPage() {
     executiveDiscounts,
     setConfirmOrderData,
     confirmOrderData,
-    order_split_details
+    order_split_details,
+    deactivateCrossSelling
   } = useContext(OrderViewContext);
   const { showMessage } = useMessageApi();
 
@@ -79,7 +80,8 @@ export default function CheckoutPage() {
       const payload: IConfirmOrderData = {
         discount_package: selectedDiscount,
         order_summary: products,
-        executive_discounts: executiveDiscounts
+        executive_discounts: executiveDiscounts,
+        deactivate_cross_selling: !deactivateCrossSelling
       };
       try {
         const response = await confirmOrder(projectId, client?.id || "", payload);
@@ -101,7 +103,7 @@ export default function CheckoutPage() {
     return () => {
       clearTimeout(timeOut);
     };
-  }, [selectedCategories, selectedDiscount, executiveDiscounts]);
+  }, [selectedCategories, selectedDiscount, executiveDiscounts, deactivateCrossSelling]);
 
   const cantidadesAsignadas = (sku: string) =>
     entregas.reduce((s, e) => s + (e.cantidades[sku] ?? 0), 0);
@@ -113,7 +115,8 @@ export default function CheckoutPage() {
     const orderSummary: IOrderSummaryPayload = {
       ...confirmOrderData,
       discount_package: selectedDiscount as IDiscountPackageAvailable,
-      executive_discounts: executiveDiscounts
+      executive_discounts: executiveDiscounts,
+      deactivate_cross_selling: !deactivateCrossSelling
     };
     return {
       order_summary: orderSummary,

--- a/src/modules/commerce/components/create-order-checkout/order-shipment-confirm/order-shipment-confirm.tsx
+++ b/src/modules/commerce/components/create-order-checkout/order-shipment-confirm/order-shipment-confirm.tsx
@@ -307,12 +307,10 @@ export default function OrderShipmentConfirm({
     setOrderSplitDetails(splits);
   }, [multiEntrega, entregas, singleForm, discountItems, setOrderSplitDetails]);
 
-  const subtotal = confirmOrderData?.subtotal ?? 0;
   const totalDescuento = confirmOrderData?.discounts?.totalDiscount ?? 0;
   const descuentoDeOrden = confirmOrderData?.discounts?.totalOrderDiscount ?? 0;
   const descuentoDeProductos = confirmOrderData?.discounts?.totalProductDiscount ?? 0;
   const total = confirmOrderData?.total ?? 0;
-  const iva = confirmOrderData?.taxes ?? 0;
 
   const addressOptions = [
     NEW_ADDRESS_OPTION,
@@ -562,12 +560,12 @@ export default function OrderShipmentConfirm({
                 <p>-$0</p>
               )}
             </div>
-            {descuentoDeOrden > 0 && (
-              <div className="flex justify-between font-medium">
-                <p>Descuento de orden</p>
-                <p>-${formatNumber(descuentoDeOrden)}</p>
-              </div>
-            )}
+
+            <div className="flex justify-between font-medium">
+              <p>Descuento de orden</p>
+              <p>-${formatNumber(descuentoDeOrden)}</p>
+            </div>
+
             {totalDescuento > 0 && (
               <div className="flex justify-between text-xs text-red-500">
                 <span>Descuentos aplicados</span>

--- a/src/modules/commerce/components/create-order-checkout/order-shipment-confirm/order-shipment-confirm.tsx
+++ b/src/modules/commerce/components/create-order-checkout/order-shipment-confirm/order-shipment-confirm.tsx
@@ -13,14 +13,11 @@ import {
 import { useContactModalOptions } from "@/hooks/useContactModalOptions";
 import { getAdresses as getAdressesAndNumber } from "@/services/commerce/commerce";
 import { useAppStore } from "@/lib/store/store";
+import { formatNumber } from "@/utils/utils";
 
 import ModalShippingInfo from "../modal-shipping-info";
 import { NEW_ADDRESS_OPTION } from "@/modules/commerce/utils/constants/checkout";
 import { IShippingInfo } from "../../create-order-checkout/create-order-checkout";
-
-function formatPrice(n: number) {
-  return "$" + (n ?? 0).toLocaleString("es-CO");
-}
 
 interface OrderShipmentConfirmProps {
   multiEntrega: boolean;
@@ -56,7 +53,7 @@ export default function OrderShipmentConfirm({
   loadingFinish,
   loadingDraft
 }: OrderShipmentConfirmProps) {
-  const { client, confirmOrderData, setOrderSplitDetails, shippingInfo } =
+  const { client, confirmOrderData, setOrderSplitDetails, shippingInfo, selectedDiscount } =
     useContext(OrderViewContext);
   const { callingCodeOptions, isLoading: isLoadingOptions } = useContactModalOptions();
   const draftInfo = useAppStore((state) => state.draftInfo);
@@ -310,11 +307,6 @@ export default function OrderShipmentConfirm({
     setOrderSplitDetails(splits);
   }, [multiEntrega, entregas, singleForm, discountItems, setOrderSplitDetails]);
 
-  const subtotal = confirmOrderData?.subtotal ?? 0;
-  const totalDescuento = confirmOrderData?.discounts?.totalDiscount ?? 0;
-  const total = confirmOrderData?.total ?? 0;
-  const iva = confirmOrderData?.taxes ?? 0;
-
   const addressOptions = [
     NEW_ADDRESS_OPTION,
     ...addresses.map((a) => ({ value: String(a.id), label: a.address }))
@@ -547,52 +539,77 @@ export default function OrderShipmentConfirm({
           )}
         </div>
 
-        {/* Totals */}
-        <div className="border-t border-[#EEEEEE] px-5 py-3 flex-shrink-0">
-          <div className="rounded-lg bg-[#F7F7F7] px-4 py-3 flex flex-col gap-1.5">
-            <div className="flex justify-between text-xs text-[#666666]">
-              <span>Subtotal</span>
-              <span>{formatPrice(subtotal)}</span>
+        {/* Footer */}
+        <div className="border-t border-[#EEEEEE]  px-5 py-3 pb-4 flex-shrink-0 bg-[#fcffed]">
+          {/* Totals */}
+          <div className="rounded-[7px] py-3 flex flex-col gap-1">
+            <div className="flex justify-between font-medium">
+              <p>Subtotal</p>
+              <p>${formatNumber(confirmOrderData?.subtotal)}</p>
             </div>
-            {totalDescuento > 0 && (
-              <div className="flex justify-between text-xs text-red-500">
-                <span>Descuentos aplicados</span>
-                <span>-{formatPrice(totalDescuento)}</span>
-              </div>
-            )}
-            <div className="flex justify-between text-sm font-bold text-[#141414] pt-1.5 border-t border-[#DDDDDD] mt-0.5">
-              <span>Total</span>
-              <span>{formatPrice(total)}</span>
+            <div className="flex justify-between font-medium">
+              <p>Descuentos ({selectedDiscount?.name})</p>
+              {confirmOrderData?.discounts ? (
+                <p>-${formatNumber(confirmOrderData.discounts?.totalDiscount)}</p>
+              ) : (
+                <p>-$0</p>
+              )}
             </div>
-            <div className="flex justify-between text-xs text-[#999999]">
-              <span>IVA (19%)</span>
-              <span>{formatPrice(iva)}</span>
+            <div className="flex justify-between mt-[0.2rem]">
+              <p className="text-sm text-[#909090]">Descuentos de productos</p>
+              {confirmOrderData?.discounts ? (
+                <p className="text-sm text-[#909090]">
+                  -${formatNumber(confirmOrderData.discounts?.totalProductDiscount)}
+                </p>
+              ) : (
+                <p className="text-sm text-[#909090]">-$0</p>
+              )}
             </div>
-            <div className="flex justify-between text-xs font-semibold text-[#141414]">
-              <span>Total con IVA</span>
-              <span>{formatPrice(total + iva)}</span>
+            <div className="flex justify-between mt-[0.2rem]">
+              <p className="text-sm text-[#909090]">Descuentos de la orden (Cross selling)</p>
+              {confirmOrderData?.discounts ? (
+                <p className="text-sm text-[#909090]">
+                  -${formatNumber(confirmOrderData.discounts?.totalOrderDiscount)}
+                </p>
+              ) : (
+                <p className="text-sm text-[#909090]">-$0</p>
+              )}
+            </div>
+            <div className="flex justify-between mt-2">
+              <strong className="font-extrabold text-[1.25rem]">Total</strong>
+              <strong className="font-extrabold text-[1.25rem]">
+                ${formatNumber(confirmOrderData?.total)}
+              </strong>
+            </div>
+            <div className="flex justify-between font-medium">
+              <p>IVA</p>
+              <p>${formatNumber(confirmOrderData?.taxes)}</p>
+            </div>
+            <div className="flex justify-between font-medium">
+              <p>Total con pronto pago</p>
+              <p>${formatNumber(confirmOrderData?.total_pronto_pago)}</p>
             </div>
           </div>
-        </div>
 
-        {/* Actions */}
-        <div className="flex gap-3 px-5 pb-4 flex-shrink-0">
-          <button
-            onClick={onDraft}
-            disabled={loadingDraft || loadingFinish || !!draftInfo?.id}
-            className="flex-1 py-3 text-sm font-semibold bg-[#141414] text-white rounded-lg hover:bg-[#333333] transition-colors disabled:opacity-40 disabled:cursor-not-allowed"
-          >
-            {loadingDraft ? "Guardando…" : "Guardar borrador"}
-          </button>
-          <button
-            onClick={onConfirm}
-            disabled={
-              loadingFinish || loadingDraft || (multiEntrega ? hayDesbalance : !isSingleFormValid)
-            }
-            className="flex-1 py-3 text-sm font-semibold text-[#141414] bg-[#CBE71E] rounded-lg hover:bg-[#b8d11a] transition-colors disabled:opacity-40 disabled:cursor-not-allowed"
-          >
-            {loadingFinish ? "Procesando…" : "Finalizar pedido"}
-          </button>
+          {/* Actions */}
+          <div className="flex gap-3 pt-2 pb-4 flex-shrink-0">
+            <button
+              onClick={onDraft}
+              disabled={loadingDraft || loadingFinish || !!draftInfo?.id}
+              className="flex-1 py-3 text-sm font-semibold bg-[#141414] text-white rounded-lg hover:bg-[#333333] transition-colors disabled:opacity-40 disabled:cursor-not-allowed"
+            >
+              {loadingDraft ? "Guardando…" : "Guardar borrador"}
+            </button>
+            <button
+              onClick={onConfirm}
+              disabled={
+                loadingFinish || loadingDraft || (multiEntrega ? hayDesbalance : !isSingleFormValid)
+              }
+              className="flex-1 py-3 text-sm font-semibold text-[#141414] bg-[#CBE71E] rounded-lg hover:bg-[#b8d11a] transition-colors disabled:opacity-40 disabled:cursor-not-allowed"
+            >
+              {loadingFinish ? "Procesando…" : "Finalizar pedido"}
+            </button>
+          </div>
         </div>
       </div>
     </div>

--- a/src/modules/commerce/components/create-order-checkout/order-shipment-confirm/order-shipment-confirm.tsx
+++ b/src/modules/commerce/components/create-order-checkout/order-shipment-confirm/order-shipment-confirm.tsx
@@ -312,6 +312,8 @@ export default function OrderShipmentConfirm({
 
   const subtotal = confirmOrderData?.subtotal ?? 0;
   const totalDescuento = confirmOrderData?.discounts?.totalDiscount ?? 0;
+  const orderTotalDiscount = confirmOrderData?.discounts?.totalOrderDiscount ?? 0;
+  const productsTotalDiscount = confirmOrderData?.discounts?.totalProductDiscount ?? 0;
   const total = confirmOrderData?.total ?? 0;
   const iva = confirmOrderData?.taxes ?? 0;
 
@@ -554,12 +556,18 @@ export default function OrderShipmentConfirm({
               <span>Subtotal</span>
               <span>{formatPrice(subtotal)}</span>
             </div>
-            {totalDescuento > 0 && (
+            {
               <div className="flex justify-between text-xs text-red-500">
-                <span>Descuentos aplicados</span>
-                <span>-{formatPrice(totalDescuento)}</span>
+                <span>Descuentos de productos</span>
+                <span>-{formatPrice(productsTotalDiscount)}</span>
               </div>
-            )}
+            }
+            {
+              <div className="flex justify-between text-xs text-red-500">
+                <span>Descuentos de la orden (Cross selling)</span>
+                <span>-{formatPrice(orderTotalDiscount)}</span>
+              </div>
+            }
             <div className="flex justify-between text-sm font-bold text-[#141414] pt-1.5 border-t border-[#DDDDDD] mt-0.5">
               <span>Total</span>
               <span>{formatPrice(total)}</span>

--- a/src/modules/commerce/components/create-order-checkout/order-shipment-confirm/order-shipment-confirm.tsx
+++ b/src/modules/commerce/components/create-order-checkout/order-shipment-confirm/order-shipment-confirm.tsx
@@ -592,7 +592,7 @@ export default function OrderShipmentConfirm({
           </div>
 
           {/* Actions */}
-          <div className="flex gap-3 pt-2 pb-4 flex-shrink-0">
+          <div className="flex gap-3 pt-2 pb-1 flex-shrink-0">
             <button
               onClick={onDraft}
               disabled={loadingDraft || loadingFinish || !!draftInfo?.id}

--- a/src/modules/commerce/components/create-order-checkout/products-details-and-discounts/products-details-and-discounts.tsx
+++ b/src/modules/commerce/components/create-order-checkout/products-details-and-discounts/products-details-and-discounts.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useContext, useState } from "react";
+import { useContext, useEffect, useState } from "react";
 import { ArrowLeft, Check, Pencil, Trash2 } from "lucide-react";
 
 import { OrderViewContext } from "@/modules/commerce/contexts/orderViewContext";
@@ -94,7 +94,7 @@ export default function ProductsDetailsAndDiscounts({
     selectedCategories,
     setSelectedCategories,
     deactivateCrossSelling,
-    setDeactivateCrossSelling,
+    setDeactivateCrossSelling
   } = useContext(OrderViewContext);
 
   const handleRemoveProduct = (productSku: string) => {
@@ -111,6 +111,15 @@ export default function ProductsDetailsAndDiscounts({
   const discountItems: DiscountItem[] = confirmOrderData?.discounts?.discountItems ?? [];
 
   const secondaryDiscount = confirmOrderData?.discounts?.secondaryDiscount;
+
+  const [orderTotalDiscount, setOrderTotalDiscount] = useState(0);
+
+  useEffect(() => {
+    const incoming = confirmOrderData?.discounts?.totalOrderDiscount ?? 0;
+    if (incoming > 0) {
+      setOrderTotalDiscount(incoming);
+    }
+  }, [confirmOrderData?.discounts?.totalOrderDiscount]);
 
   const updatePrimaryDiscount = (item: DiscountItem, newValue: number) => {
     setExecutiveDiscounts((prev) => {
@@ -274,6 +283,9 @@ export default function ProductsDetailsAndDiscounts({
             </div>
             <div className="flex items-center gap-3 px-4 py-3">
               <span className="flex-1 text-sm text-[#141414]">{secondaryDiscount.name}</span>
+              <span className="text-sm font-semibold text-red-500">
+                -{formatPrice(orderTotalDiscount)}
+              </span>
               <button
                 onClick={() => setDeactivateCrossSelling((prev) => !prev)}
                 className={`w-5 h-5 rounded flex items-center justify-center border transition-colors flex-shrink-0 ${

--- a/src/modules/commerce/components/create-order-checkout/products-details-and-discounts/products-details-and-discounts.tsx
+++ b/src/modules/commerce/components/create-order-checkout/products-details-and-discounts/products-details-and-discounts.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useContext, useState } from "react";
-import { ArrowLeft, Check, Pencil } from "lucide-react";
+import { ArrowLeft, Check, Pencil, Trash2 } from "lucide-react";
 
 import { OrderViewContext } from "@/modules/commerce/contexts/orderViewContext";
 import { DiscountItem, IExecutiveDiscount } from "@/types/commerce/ICommerce";
@@ -90,8 +90,26 @@ export default function ProductsDetailsAndDiscounts({
   multiEntrega,
   cantidadesAsignadas
 }: ProductsDetailsAndDiscountsProps) {
-  const { client, confirmOrderData, setCheckingOut, executiveDiscounts, setExecutiveDiscounts } =
-    useContext(OrderViewContext);
+  const {
+    client,
+    confirmOrderData,
+    setCheckingOut,
+    executiveDiscounts,
+    setExecutiveDiscounts,
+    selectedCategories,
+    setSelectedCategories
+  } = useContext(OrderViewContext);
+
+  const handleRemoveProduct = (productSku: string) => {
+    const next = selectedCategories
+      .map((cat) => ({
+        ...cat,
+        products: cat.products.filter((p) => p.SKU !== productSku)
+      }))
+      .filter((cat) => cat.products.length > 0);
+    setSelectedCategories(next);
+    setExecutiveDiscounts((prev) => prev.filter((e) => e.product_sku !== productSku));
+  };
 
   const discountItems: DiscountItem[] = confirmOrderData?.discounts?.discountItems ?? [];
 
@@ -132,8 +150,8 @@ export default function ProductsDetailsAndDiscounts({
   }, 0);
 
   const cols = multiEntrega
-    ? "grid-cols-[2fr_90px_100px_120px_100px_70px_110px_56px]"
-    : "grid-cols-[2fr_90px_100px_120px_100px_70px_110px]";
+    ? "grid-cols-[2fr_90px_100px_120px_100px_70px_110px_56px_32px]"
+    : "grid-cols-[2fr_90px_100px_120px_100px_70px_110px_32px]";
 
   return (
     <div className="flex-1 min-w-0 flex flex-col overflow-hidden bg-[#F7F7F7]">
@@ -171,6 +189,7 @@ export default function ProductsDetailsAndDiscounts({
               {multiEntrega && (
                 <span className="text-xs font-medium text-[#AAAAAA] text-right">Rest.</span>
               )}
+              <span />
             </div>
 
             {/* Rows */}
@@ -230,6 +249,17 @@ export default function ProductsDetailsAndDiscounts({
                         {restante}
                       </p>
                     )}
+                    {precioFinal === 0 ? (
+                      <button
+                        onClick={() => handleRemoveProduct(item.product_sku)}
+                        title="Eliminar producto"
+                        className="w-5 h-5 rounded flex items-center justify-center text-[#CCCCCC] hover:text-red-500 hover:bg-red-50 transition-colors flex-shrink-0 justify-self-end"
+                      >
+                        <Trash2 size={12} />
+                      </button>
+                    ) : (
+                      <span />
+                    )}
                   </div>
                 );
               })}
@@ -249,6 +279,7 @@ export default function ProductsDetailsAndDiscounts({
                 {formatPrice(totalMonto)}
               </span>
               {multiEntrega && <span />}
+              <span />
             </div>
           </div>
         </div>

--- a/src/modules/commerce/components/create-order-checkout/products-details-and-discounts/products-details-and-discounts.tsx
+++ b/src/modules/commerce/components/create-order-checkout/products-details-and-discounts/products-details-and-discounts.tsx
@@ -6,11 +6,6 @@ import { ArrowLeft, Check, Pencil } from "lucide-react";
 import { OrderViewContext } from "@/modules/commerce/contexts/orderViewContext";
 import { DiscountItem, IExecutiveDiscount } from "@/types/commerce/ICommerce";
 
-const getPrimaryMaxPct = (item: DiscountItem) =>
-  item.discount?.primary?.discount_applied?.max_discount ??
-  item.discount?.primary?.discount_applied?.discount ??
-  0;
-
 const getSecondaryMaxPct = (item: DiscountItem) =>
   item.discount?.secondary?.discount_applied?.max_discount ??
   item.discount?.secondary?.discount_applied?.discount ??
@@ -90,12 +85,12 @@ export default function ProductsDetailsAndDiscounts({
   multiEntrega,
   cantidadesAsignadas
 }: ProductsDetailsAndDiscountsProps) {
-  const { client, confirmOrderData, setCheckingOut, executiveDiscounts, setExecutiveDiscounts } =
+  const { client, confirmOrderData, setCheckingOut, executiveDiscounts, setExecutiveDiscounts, deactivateCrossSelling, setDeactivateCrossSelling } =
     useContext(OrderViewContext);
 
   const discountItems: DiscountItem[] = confirmOrderData?.discounts?.discountItems ?? [];
 
-  const otrosDescuentosItems = discountItems.filter((it) => it.discount?.secondary);
+  const secondaryDiscount = confirmOrderData?.discounts?.secondaryDiscount;
 
   const updatePrimaryDiscount = (item: DiscountItem, newValue: number) => {
     setExecutiveDiscounts((prev) => {
@@ -105,21 +100,6 @@ export default function ProductsDetailsAndDiscounts({
         primary_discount_pct: newValue,
         secondary_discount_pct:
           idx >= 0 ? prev[idx].secondary_discount_pct : getSecondaryMaxPct(item)
-      };
-      return idx >= 0 ? prev.map((e, i) => (i === idx ? nextEntry : e)) : [...prev, nextEntry];
-    });
-  };
-
-  const toggleSecondaryDiscount = (item: DiscountItem) => {
-    setExecutiveDiscounts((prev) => {
-      const idx = prev.findIndex((e) => e.product_sku === item.product_sku);
-      const original = getSecondaryMaxPct(item);
-      const currentSecondary = idx >= 0 ? prev[idx].secondary_discount_pct : original;
-      const currentPrimary = idx >= 0 ? prev[idx].primary_discount_pct : getPrimaryMaxPct(item);
-      const nextEntry: IExecutiveDiscount = {
-        product_sku: item.product_sku,
-        primary_discount_pct: currentPrimary,
-        secondary_discount_pct: currentSecondary > 0 ? 0 : original
       };
       return idx >= 0 ? prev.map((e, i) => (i === idx ? nextEntry : e)) : [...prev, nextEntry];
     });
@@ -254,42 +234,23 @@ export default function ProductsDetailsAndDiscounts({
         </div>
 
         {/* Otros descuentos */}
-        {otrosDescuentosItems.length > 0 && (
+        {secondaryDiscount && (
           <div className="mx-5 mt-4 mb-5 rounded-xl border border-[#EEEEEE] overflow-hidden flex-shrink-0">
             <div className="px-4 py-3 bg-[#FAFAFA] border-b border-[#EEEEEE]">
               <p className="text-xs font-semibold text-[#141414]">Otros descuentos</p>
             </div>
-            <div className="flex flex-col divide-y divide-[#F4F4F4]">
-              {otrosDescuentosItems.map((it) => {
-                const sec = it.discount.secondary!;
-                const key = `${it.product_sku}-${sec.discount_applied.id}`;
-                const entry = executiveDiscounts.find((e) => e.product_sku === it.product_sku);
-                const activo = entry ? entry.secondary_discount_pct > 0 : true;
-                const porcentaje = sec.discount_applied.max_discount;
-                const monto = sec.new_price;
-                const label = sec.discount_applied.discount_name || sec.description;
-                return (
-                  <div key={key} className="flex items-center gap-3 px-4 py-3">
-                    <span className="flex-1 text-sm text-[#141414]">{label}</span>
-                    <span className="text-sm font-semibold text-red-500 w-8 text-right">
-                      {porcentaje}%
-                    </span>
-                    <span className="text-sm text-[#666666] w-24 text-right">
-                      {formatPrice(monto)}
-                    </span>
-                    <button
-                      onClick={() => toggleSecondaryDiscount(it)}
-                      className={`w-5 h-5 rounded flex items-center justify-center border transition-colors flex-shrink-0 ${
-                        activo
-                          ? "bg-[#141414] border-[#141414] text-white"
-                          : "bg-white border-[#DDDDDD] hover:border-[#141414]"
-                      }`}
-                    >
-                      {activo && <Check size={11} />}
-                    </button>
-                  </div>
-                );
-              })}
+            <div className="flex items-center gap-3 px-4 py-3">
+              <span className="flex-1 text-sm text-[#141414]">{secondaryDiscount.name}</span>
+              <button
+                onClick={() => setDeactivateCrossSelling((prev) => !prev)}
+                className={`w-5 h-5 rounded flex items-center justify-center border transition-colors flex-shrink-0 ${
+                  deactivateCrossSelling
+                    ? "bg-[#141414] border-[#141414] text-white"
+                    : "bg-white border-[#DDDDDD] hover:border-[#141414]"
+                }`}
+              >
+                {deactivateCrossSelling && <Check size={11} />}
+              </button>
             </div>
           </div>
         )}

--- a/src/modules/commerce/components/create-order-market/create-order-market.module.scss
+++ b/src/modules/commerce/components/create-order-market/create-order-market.module.scss
@@ -10,7 +10,6 @@
     padding: 1.625rem 1.5rem;
     border-radius: 1rem;
     border: 1px solid $dark-gray;
-    overflow-y: auto;
     background-color: $white;
 
     .buttonGoBack {
@@ -26,6 +25,33 @@
         &:hover {
             opacity: 0.8;
             color: black;
+        }
+    }
+
+    :global {
+        .tabsContainer {
+            flex: 1 1 auto;
+            min-height: 0;
+            display: flex;
+            flex-direction: column;
+
+            .ant-tabs {
+                flex: 1 1 auto;
+                min-height: 0;
+                display: flex;
+                flex-direction: column;
+            }
+
+            .ant-tabs-content-holder {
+                flex: 1 1 auto;
+                min-height: 0;
+                overflow-y: auto;
+            }
+
+            .ant-tabs-content,
+            .ant-tabs-tabpane {
+                height: 100%;
+            }
         }
     }
 

--- a/src/modules/commerce/containers/comercio-layout/ComercioLayout.tsx
+++ b/src/modules/commerce/containers/comercio-layout/ComercioLayout.tsx
@@ -17,5 +17,9 @@ export default function ComercioLayout({ children }: ComercioLayoutClientProps) 
     headerTitle = "Dashboard";
   }
 
-  return <ViewWrapper headerTitle={headerTitle}>{children}</ViewWrapper>;
+  return (
+    <ViewWrapper headerTitle={headerTitle} hideHeader={pathname.startsWith("/comercio/pedido")}>
+      {children}
+    </ViewWrapper>
+  );
 }

--- a/src/modules/commerce/containers/create-order/create-order.tsx
+++ b/src/modules/commerce/containers/create-order/create-order.tsx
@@ -58,6 +58,8 @@ interface IOrderViewContext {
   discountsLoading: boolean;
   executiveDiscounts: IExecutiveDiscount[];
   setExecutiveDiscounts: Dispatch<SetStateAction<IExecutiveDiscount[]>>;
+  deactivateCrossSelling: boolean;
+  setDeactivateCrossSelling: Dispatch<SetStateAction<boolean>>;
   toggleCart?: () => void;
   isCartVisible?: boolean;
   numberOfItems?: number;
@@ -76,6 +78,7 @@ export const CreateOrderView: FC = () => {
   const [discounts, setDiscounts] = useState<IDiscountPackageAvailable[]>([]);
   const [discountsLoading, setDiscountsLoading] = useState(false);
   const [executiveDiscounts, setExecutiveDiscounts] = useState<IExecutiveDiscount[]>([]);
+  const [deactivateCrossSelling, setDeactivateCrossSelling] = useState(false);
   const [orderSplitDetails, setOrderSplitDetails] = useState<IOrderSplitDetail[]>([]);
   const [draftDetail, setDraftDetail] = useState<IDraftOrderDetail | null>(null);
   const [isCartVisible, setIsCartVisible] = useState(
@@ -232,6 +235,8 @@ export const CreateOrderView: FC = () => {
         discountsLoading,
         executiveDiscounts,
         setExecutiveDiscounts,
+        deactivateCrossSelling,
+        setDeactivateCrossSelling,
         order_split_details: orderSplitDetails,
         setOrderSplitDetails,
         toggleCart,

--- a/src/services/banksPayments/banksPayments.ts
+++ b/src/services/banksPayments/banksPayments.ts
@@ -214,3 +214,26 @@ export const approvePayment = async ({ payments, project_id, client_id }: IAppro
     throw error;
   }
 };
+
+export const downloadPaymentsPlane = async (payment_ids: number[]): Promise<Blob> => {
+  try {
+    const response = await API.post(
+      "/bank/generate-atemco-txt",
+      { payment_ids },
+      { responseType: "blob" }
+    );
+    return response.data;
+  } catch (error: any) {
+    if (error?.response?.data instanceof Blob) {
+      const text = await error.response.data.text();
+      try {
+        const parsed = JSON.parse(text);
+        throw new Error(parsed.message || "Error al descargar el plano");
+      } catch {
+        throw new Error("Error al descargar el plano");
+      }
+    }
+    console.error("Error al descargar el plano:", error);
+    throw error;
+  }
+};

--- a/src/types/commerce/ICommerce.ts
+++ b/src/types/commerce/ICommerce.ts
@@ -73,6 +73,7 @@ export interface IConfirmOrderData {
     quantity: number;
   }[];
   executive_discounts: IExecutiveDiscount[];
+  deactivate_cross_selling: boolean;
 }
 
 export interface IProductInDetail {
@@ -138,6 +139,10 @@ export interface OrderDiscount {
   totalProductDiscount: number;
   discountOrder: DiscountOrder[];
   discountItems: DiscountItem[];
+  secondaryDiscount: {
+    id: number;
+    name: string;
+  }
 }
 
 export interface IOrderConfirmedResponse {
@@ -157,6 +162,7 @@ export interface IOrderConfirmedResponse {
 export interface IOrderSummaryPayload extends Omit<IOrderConfirmedResponse, "discount_package"> {
   discount_package: IDiscountPackageAvailable;
   executive_discounts: IExecutiveDiscount[];
+  deactivate_cross_selling: boolean;
 }
 
 export interface IShippingInformation {


### PR DESCRIPTION
This pull request introduces several enhancements and refactors across the discounts and banks modules, with a particular focus on improving discount package management and adding support for "wallet payments" in the banks feature. The changes include new UI components, improved state management, and new filtering capabilities for payments.

**Banks Module: Wallet Payments Feature**

* Added a new "Pagos wallet" (Wallet Payments) tab to the banks view, including its own container, styles, and modal actions for batch operations like downloading payment files. [[1]](diffhunk://#diff-7b824464bb6fe410de7eda8846ea63b90750bb7648012d0e8395baa879544830R9-R14) [[2]](diffhunk://#diff-7b824464bb6fe410de7eda8846ea63b90750bb7648012d0e8395baa879544830R46-R50) [[3]](diffhunk://#diff-ccc9304dc301f98c80e2dc8f01d089eab7f148bf6a22829f95da70816cc9a5b7R1) [[4]](diffhunk://#diff-f1b55248bba2498066df65fdeaf781c05b9919e02f66f7cfc0a741882e6ac930R1-R21) [[5]](diffhunk://#diff-735f3e0d1bb0242de422ffbe1391e9421368891f55659798a732727b76e117daR1-R69) [[6]](diffhunk://#diff-68a3a4f968128819086b519361d1d3c959900e6508861b0ea230c784c6ef31d2R1-R31) [[7]](diffhunk://#diff-ed6ae538abdc64ae605a50ea024e8bacce19a29218142a436279af205502a49aR1)
* Introduced the `PaymentTransactionType` enum and updated the `useBankPayments` hook to support filtering by transaction type, enabling the wallet payments tab to show only relevant transactions. [[1]](diffhunk://#diff-9c038f87202cd8b2be46dc9d083af7b48b1d7591772f2c44e5977fa053a3030fR1-R6) [[2]](diffhunk://#diff-dc22f76a6a0676dfe19eb77aa19a2ca7eca9fc91502d6332a0df2d9d5cbe764eR7-R21) [[3]](diffhunk://#diff-dc22f76a6a0676dfe19eb77aa19a2ca7eca9fc91502d6332a0df2d9d5cbe764eR36-R41) [[4]](diffhunk://#diff-0e4db53181eb260b9096dc2f7aeebffa1d70bbcb43f75f492a59cfc0a5324fbbR10) [[5]](diffhunk://#diff-0e4db53181eb260b9096dc2f7aeebffa1d70bbcb43f75f492a59cfc0a5324fbbL63-R65)

**Discounts Module: Discount Package Refactor**

* Refactored discount package creation to clearly separate primary and secondary (cross-selling) discounts, with new state variables and filtered options for each type. This improves clarity and maintainability of discount logic. [[1]](diffhunk://#diff-c5d82cc17b54d9113ac103f835157736e17606fca0ef38998a6760bc077c5d41L42-R45) [[2]](diffhunk://#diff-c5d82cc17b54d9113ac103f835157736e17606fca0ef38998a6760bc077c5d41L54-R57) [[3]](diffhunk://#diff-c5d82cc17b54d9113ac103f835157736e17606fca0ef38998a6760bc077c5d41L79-R86) [[4]](diffhunk://#diff-c5d82cc17b54d9113ac103f835157736e17606fca0ef38998a6760bc077c5d41L239-R242) [[5]](diffhunk://#diff-73daf173704b44b54e3163371bbb98ccf921af04da83286f48181b7173ef10bcL108-R147) [[6]](diffhunk://#diff-73daf173704b44b54e3163371bbb98ccf921af04da83286f48181b7173ef10bcL186-R218)
* Added new context state (`deactivateCrossSelling`) to the order view, allowing toggling of cross-selling discounts at the order level. [[1]](diffhunk://#diff-e14bf5643c5d82ccb7800625ed684fb224045e6180a5fcf170c3ec7ecc553ee7R62-R63) [[2]](diffhunk://#diff-e14bf5643c5d82ccb7800625ed684fb224045e6180a5fcf170c3ec7ecc553ee7R87) [[3]](diffhunk://#diff-e14bf5643c5d82ccb7800625ed684fb224045e6180a5fcf170c3ec7ecc553ee7R158-R159)

**Other Improvements**

* Simplified and improved the `useFinancialDiscounts` hook by replacing the `id` and `searchQuery` parameters with a single `search` parameter for more flexible filtering. [[1]](diffhunk://#diff-274efb9fe4274daa4cd829a832fbaae8035ebcf0eb515293aa083dd9ff25de5dL9-R9) [[2]](diffhunk://#diff-274efb9fe4274daa4cd829a832fbaae8035ebcf0eb515293aa083dd9ff25de5dL21-R38)