### PR TITLE
Rename current_value to current_amount

### DIFF
--- a/src/components/atoms/ItemsApplyModal/ItemsApplyModal.tsx
+++ b/src/components/atoms/ItemsApplyModal/ItemsApplyModal.tsx
@@ -7,7 +7,7 @@ interface ItemsApplyModalProps {
   type: number;
   item: {
     id: number;
-    current_value: number;
+    current_amount: number;
     motive_name?: string | null;
     percentage?: number | null;
     intialAmount?: number;

--- a/src/components/molecules/modals/ApplyAccountingAdjustment/ApplyAccountingAdjustment.tsx
+++ b/src/components/molecules/modals/ApplyAccountingAdjustment/ApplyAccountingAdjustment.tsx
@@ -25,7 +25,7 @@ interface Props {
 interface IcurrentInvoices {
   id: number;
   id_erp?: string;
-  current_value: number;
+  current_amount: number;
   newBalance: number;
 }
 interface NormalizedValue {
@@ -55,10 +55,10 @@ export const ApplyAccountingAdjustment = ({
   const [selectTab, setSelectTab] = useState(0);
   const [currentInvoices, setCurrentInvoices] = useState<IcurrentInvoices[]>([]);
   const [currentAdjustment, setCurrentAdjustment] = useState(
-    selectedNotes.map((row) => row.current_value)
+    selectedNotes.map((row) => row.current_amount)
   );
   const [currentAdjustmentStatic, _setCurrentAdjustmentStatic] = useState(
-    selectedNotes.map((row) => row.current_value)
+    selectedNotes.map((row) => row.current_amount)
   );
   const [applyValues, setApplyValues] = useState<{
     [key: string]: {
@@ -75,8 +75,8 @@ export const ApplyAccountingAdjustment = ({
       invoiceSelected.map((invoice) => ({
         id: invoice.id,
         id_erp: invoice.id_erp,
-        current_value: invoice.current_value,
-        newBalance: invoice.current_value
+        current_amount: invoice.current_amount,
+        newBalance: invoice.current_amount
       }))
     );
   }, [invoiceSelected]);
@@ -106,7 +106,7 @@ export const ApplyAccountingAdjustment = ({
     if (value && value > currentAdjustment[selectTab] && previousValue <= 0) {
       value = 0;
     }
-    if (value && value > selectedNotes[selectTab].current_value) {
+    if (value && value > selectedNotes[selectTab].current_amount) {
       value = 0;
     }
     if (value && value > previousValue && value > currentAdjustment[selectTab] + previousValue) {
@@ -143,6 +143,7 @@ export const ApplyAccountingAdjustment = ({
     handleValueChange(value ?? 0, selectTab, record);
   };
 
+  console.log("applyValues", invoiceSelected, applyValues);
   const handleOnChangeTextArea = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
     setCommentary(e.target.value);
   };
@@ -232,8 +233,8 @@ export const ApplyAccountingAdjustment = ({
     },
     {
       title: "Pendiente",
-      dataIndex: "current_value",
-      key: "current_value",
+      dataIndex: "current_amount",
+      key: "current_amount",
       render: (text) => `$${text}`.replace(/\B(?=(\d{3})+(?!\d))/g, ".")
     },
     {

--- a/src/components/molecules/modals/ApplyNoveltyModal/ApplyNoveltyModal.tsx
+++ b/src/components/molecules/modals/ApplyNoveltyModal/ApplyNoveltyModal.tsx
@@ -55,10 +55,10 @@ export const ApplyNoveltyModal = ({
   const [isLoading, setIsLoading] = useState(false);
   const [currentInvoices, setCurrentInvoices] = useState<IcurrentInvoices[]>([]);
   const [currentAdjustment, setCurrentAdjustment] = useState(
-    selectedNotes.map((row) => row.current_value)
+    selectedNotes.map((row) => row.current_amount)
   );
   const [currentAdjustmentStatic, _setCurrentAdjustmentStatic] = useState(
-    selectedNotes.map((row) => row.current_value)
+    selectedNotes.map((row) => row.current_amount)
   );
   const [applyValues, setApplyValues] = useState<{
     [key: string]: {
@@ -100,7 +100,7 @@ export const ApplyNoveltyModal = ({
     if (value && value > currentAdjustment[selectTab] && previousValue <= 0) {
       value = 0;
     }
-    if (value && value > selectedNotes[selectTab].current_value) {
+    if (value && value > selectedNotes[selectTab].current_amount) {
       value = 0;
     }
     if (value && value > previousValue && value > currentAdjustment[selectTab] + previousValue) {

--- a/src/components/molecules/modals/ModalActionDiscountCredit/ModalActionDiscountCredit.tsx
+++ b/src/components/molecules/modals/ModalActionDiscountCredit/ModalActionDiscountCredit.tsx
@@ -31,7 +31,7 @@ interface Props {
 }
 export interface ISelectedAccountingAdjustment {
   id: number;
-  current_amount: number;
+  current_value: number;
   motive_name: string | null;
   percentage?: number | null;
   intialAmount?: number;

--- a/src/components/molecules/modals/ModalActionDiscountCredit/ModalActionDiscountCredit.tsx
+++ b/src/components/molecules/modals/ModalActionDiscountCredit/ModalActionDiscountCredit.tsx
@@ -31,7 +31,7 @@ interface Props {
 }
 export interface ISelectedAccountingAdjustment {
   id: number;
-  current_value: number;
+  current_amount: number;
   motive_name: string | null;
   percentage?: number | null;
   intialAmount?: number;

--- a/src/components/molecules/modals/SelectAccountingAdjustment/SelectAccountingAdjustment.tsx
+++ b/src/components/molecules/modals/SelectAccountingAdjustment/SelectAccountingAdjustment.tsx
@@ -19,6 +19,7 @@ interface Props {
 interface ItemsSelected {
   id: number;
   current_value: number;
+  current_amount: number;
   selected: boolean;
   motive_name: string | null;
   percentage?: number | null;
@@ -59,6 +60,7 @@ export const SelectAccountingAdjustment = ({
           .map((item) => ({
             id: item.id,
             current_value: item.current_value,
+            current_amount: item.current_amount,
             selected: selectedRows.some((row) => row.id === item.id),
             motive_name: item.motive_name,
             percentage: item.percentage,

--- a/src/hooks/useAcountingAdjustment.ts
+++ b/src/hooks/useAcountingAdjustment.ts
@@ -11,6 +11,7 @@ export interface IFinancialDiscount {
   dependecy_sucursal: number;
   initial_value: number;
   current_value: number;
+  current_amount: number;
   expiration_date: string;
   comments: string | null;
   files: string | null;

--- a/src/modules/clients/containers/accounting-adjustments-tab/Modals/ModalEditAdjustments/ModalEditAdjustments.tsx
+++ b/src/modules/clients/containers/accounting-adjustments-tab/Modals/ModalEditAdjustments/ModalEditAdjustments.tsx
@@ -77,7 +77,7 @@ const ModalEditAdjustments = ({ isOpen, onClose, selectedRows, handleDeleteRow }
           label: row.motive_description || ""
         },
         commentary: row.entity_description || "",
-        amount: String(row.current_value) || "",
+        amount: String(row.current_amount) || "",
         applicationId: row.id
       }));
 

--- a/src/modules/clients/containers/apply-tab/Modals/ModalApplySpecificAdjustment/ModalApplySpecificAdjustment.tsx
+++ b/src/modules/clients/containers/apply-tab/Modals/ModalApplySpecificAdjustment/ModalApplySpecificAdjustment.tsx
@@ -50,8 +50,8 @@ const ModalApplySpecificAdjustment = ({
     selectedInvoices?.map((invoice) => ({
       id: invoice.financial_record_id ?? 0,
       id_erp: invoice.id_erp,
-      current_value: invoice.current_value,
-      new_balance: invoice.current_value
+      current_value: invoice.current_amount,
+      new_balance: invoice.current_amount
     })) ?? []
   );
 

--- a/src/modules/clients/containers/apply-tab/tables/DiscountTable.tsx
+++ b/src/modules/clients/containers/apply-tab/tables/DiscountTable.tsx
@@ -76,7 +76,7 @@ const DiscountTable: React.FC<DiscountTableProps> = ({
       dataIndex: "current_value",
       key: "current_value",
       render: (current_value) => <p className="fontMonoSpace">{formatMoney(current_value)}</p>,
-      sorter: (a, b) => a.current_value - b.current_value,
+      sorter: (a, b) => a.current_amount - b.current_amount,
       showSorterTooltip: false,
       align: "right"
     },

--- a/src/modules/clients/containers/apply-tab/tables/PaymentsTable.tsx
+++ b/src/modules/clients/containers/apply-tab/tables/PaymentsTable.tsx
@@ -88,7 +88,7 @@ const PaymentsTable: React.FC<PaymentsTableProps> = ({
       dataIndex: "current_value",
       key: "current_value",
       render: (current_value) => <p className="fontMonoSpace">{formatMoney(current_value)}</p>,
-      sorter: (a, b) => a.current_value - b.current_value,
+      sorter: (a, b) => a.current_amount - b.current_amount,
       showSorterTooltip: false,
       align: "right"
     },

--- a/src/types/applyTabClients/IApplyTabClients.ts
+++ b/src/types/applyTabClients/IApplyTabClients.ts
@@ -18,7 +18,7 @@ export interface IApplyTabRecord {
   entity_type_name: string;
   entity_description: string | null;
   initial_value: number;
-  current_value: number;
+  current_amount: number;
   created_by_name: string | null;
   applied_amount: number;
   total_adjustments: number | null;

--- a/src/types/invoices/IInvoices.ts
+++ b/src/types/invoices/IInvoices.ts
@@ -25,6 +25,7 @@ export interface IInvoice {
   cufe: string;
   initial_value: number;
   current_value: number;
+  current_amount: number;
   expiration_date: string;
   financial_record_date: string;
   comments: string;


### PR DESCRIPTION
Unify the field name from current_value to current_amount across types, hooks and components. Updated interfaces (IInvoice, IApplyTabRecord, ISelectedAccountingAdjustment, IFinancialDiscount), modal components, tables and related logic to use current_amount, adjusted table sorters and column keys. Also added a couple of console.log debug statements and a tiny UI text tweak in ApplyNoveltyModal.