### PR TITLE
fix: enhance adjustment validation and align error text in modal

### DIFF
--- a/src/components/atoms/inputs/InputFormMoney/inputFormMoney.scss
+++ b/src/components/atoms/inputs/InputFormMoney/inputFormMoney.scss
@@ -67,6 +67,7 @@
     .textError {
         padding-left: 0.5rem;
         color: red;
+        text-align: left !important;
     }
 
     .inputFormError {

--- a/src/modules/clients/containers/apply-tab/Modals/ModalEditRow/ModalEditRow.tsx
+++ b/src/modules/clients/containers/apply-tab/Modals/ModalEditRow/ModalEditRow.tsx
@@ -90,18 +90,16 @@ const ModalEditRow: React.FC<IModalEditRowProps> = ({
                 hiddenTitle
                 nameInput={`adjustments.${index}.amount`}
                 control={control}
-                error={
-                  errors?.adjustments?.[index]?.amount && {
-                    type: "required",
-                    message: "Campo requerido"
-                  }
-                }
-                customStyle={{ width: "80%", textAlign: "center" }}
+                error={errors?.adjustments?.[index]?.amount}
+                customStyle={{ paddingRight: "1rem", textAlign: "center" }}
                 validationRules={{
                   pattern: {
                     value: /^-?\d+(\.\d+)?$/,
                     message: "Solo se permiten números"
-                  }
+                  },
+                  validate: (value) =>
+                    Number(value) <= amount ||
+                    `El valor no puede superar ${formatMoney(amount, { hideCurrencySymbol: true })}`
                 }}
               />
 
@@ -170,14 +168,6 @@ const ModalEditRow: React.FC<IModalEditRowProps> = ({
       showMessage("error", "Error al guardar los cambios");
     }
 
-    // Merge form input (amount) with original row data (id and adjustment name)
-    // Below is an example of how to merge the form data with the original row data for the adjustments if needed
-    // const formattedData = row?.adjustments?.map((adjustment, index) => ({
-    //   id: adjustment.adjustment_id,
-    //   adjustment: adjustment.description,
-    //   amount: adjustmentsData.adjustments[index]?.amount
-    // }));
-
     setLoading(false);
   };
 
@@ -201,7 +191,7 @@ const ModalEditRow: React.FC<IModalEditRowProps> = ({
       open={visible}
       onCancel={() => onCancel()}
       footer={null}
-      width={650}
+      width={680}
       className="modalEditRow"
     >
       <div className="header">


### PR DESCRIPTION
- Add validation to limit adjustment amount to available amount.
- Remove redundant error handling and unused commented code.
- Align error text to left in InputFormMoney.
- Adjust modal width for better spacing.
- 
This pull request focuses on improving the validation and UI experience for the adjustment amount input in the `ModalEditRow` component. The main changes include simplifying error handling, adding a custom validation rule to prevent input values from exceeding a specified amount, and making minor style adjustments for better alignment and layout.

**Validation and error handling improvements:**

* Simplified the error prop for the `amount` input by directly passing the error object, and added a custom validation rule to ensure the entered value does not exceed the allowed `amount`, displaying a formatted error message if it does.

**UI and style adjustments:**

* Increased the modal width from 650px to 680px for improved layout.
* Adjusted the input field's custom style to add right padding and maintained center text alignment.
* Updated the `.textError` class in `inputFormMoney.scss` to enforce left text alignment for error messages.

**Code cleanup:**

* Removed commented-out example code related to merging form data with original row data, resulting in a cleaner codebase.