### PR TITLE
refactor: use server URL for plane download instead of client blob

### DIFF
--- a/src/modules/banks/components/modal-actions-wallet-payments/modal-actions-wallet-payments.tsx
+++ b/src/modules/banks/components/modal-actions-wallet-payments/modal-actions-wallet-payments.tsx
@@ -24,16 +24,8 @@ const ModalActionsWalletPayments = ({ isOpen, onClose, selectedRows }: Props) =>
     const paymentIds = selectedRows.map((row) => row.id);
     const hideLoading = message.loading("Descargando plano...", 0);
     try {
-      const blob = await downloadPaymentsPlane(paymentIds);
-      const url = window.URL.createObjectURL(blob);
-      const link = document.createElement("a");
-      link.href = url;
-      link.setAttribute("download", `plano_atemco_${Date.now()}.txt`);
-      document.body.appendChild(link);
-      link.click();
-      link.remove();
-      window.URL.revokeObjectURL(url);
-
+      const res = await downloadPaymentsPlane(paymentIds);
+      window.open(res.url, "_blank");
       message.success("Plano descargado correctamente");
       onClose();
     } catch (error) {

--- a/src/services/banksPayments/banksPayments.ts
+++ b/src/services/banksPayments/banksPayments.ts
@@ -215,24 +215,16 @@ export const approvePayment = async ({ payments, project_id, client_id }: IAppro
   }
 };
 
-export const downloadPaymentsPlane = async (payment_ids: number[]): Promise<Blob> => {
+export const downloadPaymentsPlane = async (
+  payment_ids: number[]
+): Promise<{ url: string; filename?: string }> => {
   try {
-    const response = await API.post(
+    const response: GenericResponse<{ url: string; filename?: string }> = await API.post(
       "/bank/generate-atemco-txt",
-      { payment_ids },
-      { responseType: "blob" }
+      { payment_ids }
     );
     return response.data;
-  } catch (error: any) {
-    if (error?.response?.data instanceof Blob) {
-      const text = await error.response.data.text();
-      try {
-        const parsed = JSON.parse(text);
-        throw new Error(parsed.message || "Error al descargar el plano");
-      } catch {
-        throw new Error("Error al descargar el plano");
-      }
-    }
+  } catch (error) {
     console.error("Error al descargar el plano:", error);
     throw error;
   }


### PR DESCRIPTION
Change payments plane download logic to open a URL returned by the API instead of creating a blob locally. This simplifies frontend code and moves file generation to the server. Also clean up error handling by removing unnecessary blob error parsing.
This pull request updates the workflow for downloading payment files by changing the backend response from a file blob to a URL, and updates the frontend to handle this new response format. The key changes are grouped below:

**Frontend changes to file download logic:**

* Updated `ModalActionsWalletPayments` component to open the provided file URL in a new browser tab instead of generating a download from a blob.

**Backend service and API changes:**

* Modified the `downloadPaymentsPlane` service function to expect and return an object containing a URL (and optionally a filename), rather than a file blob. Error handling was also simplified to match the new response structure.