### PR TITLE
feat(banks): reorder tabs and sort payment statuses

### DIFF
--- a/src/modules/banks/containers/active-payments-tab/active-payments-tab.tsx
+++ b/src/modules/banks/containers/active-payments-tab/active-payments-tab.tsx
@@ -40,6 +40,8 @@ interface ActivePaymentsTabProps {
   isActive: boolean;
 }
 
+const STATUS_ORDER = ["Sin identificar", "Pendiente ingreso a SAP", "Identificado", "Pago aplicado"];
+
 export const ActivePaymentsTab: FC<ActivePaymentsTabProps> = ({ isActive }) => {
   const [selectedRows, setSelectedRows] = useState<ISingleBank[]>();
   const [showBankRules, setShowBankRules] = useState<boolean>(false);
@@ -191,7 +193,11 @@ export const ActivePaymentsTab: FC<ActivePaymentsTabProps> = ({ isActive }) => {
             <Collapse
               stickyLabel
               labelStickyOffset={"6rem"}
-              items={data?.map((status) => ({
+              items={data?.slice().sort((a, b) => {
+                const ia = STATUS_ORDER.indexOf(a.payments_status);
+                const ib = STATUS_ORDER.indexOf(b.payments_status);
+                return (ia === -1 ? STATUS_ORDER.length : ia) - (ib === -1 ? STATUS_ORDER.length : ib);
+              }).map((status) => ({
                 key: status.payments_status_id,
                 label: (
                   <LabelCollapse

--- a/src/modules/banks/containers/banks-view/banks-view.tsx
+++ b/src/modules/banks/containers/banks-view/banks-view.tsx
@@ -40,14 +40,14 @@ export const BanksView: FC = () => {
       children: <ActivePaymentsTab isActive={activeKey === TAB_KEYS.activePayments} />
     },
     {
+      key: TAB_KEYS.walletPayments,
+      label: "Otros pagos",
+      children: <WalletPaymentsTab isActive={activeKey === TAB_KEYS.walletPayments} />
+    },
+    {
       key: TAB_KEYS.paymentApplications,
       label: "Aplicaciones de pago",
       children: <PaymentApplicationsTab isActive={activeKey === TAB_KEYS.paymentApplications} />
-    },
-    {
-      key: TAB_KEYS.walletPayments,
-      label: "Pagos wallet",
-      children: <WalletPaymentsTab isActive={activeKey === TAB_KEYS.walletPayments} />
     }
   ];
 


### PR DESCRIPTION
- Added STATUS_ORDER to sort payment statuses logically (Sin identificar -> Pendiente ingreso a SAP -> Identificado -> Pago aplicado).
- Moved "Otros pagos" (renamed from "Pagos wallet") before "Aplicaciones de pago" in tab order.