### PR TITLE
fix: bypass amount validation for negative financial records

### DIFF
--- a/src/modules/clients/containers/apply-tab/Modals/ModalEditRow/ModalEditRow.tsx
+++ b/src/modules/clients/containers/apply-tab/Modals/ModalEditRow/ModalEditRow.tsx
@@ -97,9 +97,16 @@ const ModalEditRow: React.FC<IModalEditRowProps> = ({
                     value: /^-?\d+(\.\d+)?$/,
                     message: "Solo se permiten números"
                   },
-                  validate: (value) =>
-                    Number(value) <= amount ||
-                    `El valor no puede superar ${formatMoney(amount, { hideCurrencySymbol: true })}`
+                  validate: (value) => {
+                    const isNegativeFinancialRecord =
+                      row?.entity_type_name === "FINANCIAL_RECORD" && amount < 0;
+                    if (isNegativeFinancialRecord) return true;
+
+                    return (
+                      Number(value) <= amount ||
+                      `El valor no puede superar ${formatMoney(amount, { hideCurrencySymbol: true })}`
+                    );
+                  }
                 }}
               />
 


### PR DESCRIPTION
When the row is a FINANCIAL_RECORD with a negative amount, the previous validation incorrectly prevented editing. Now, the check is skipped for such rows, allowing users to edit them.
