### PR TITLE
fix: remove hardcoded motive_id filter to include financial adjustments

### DIFF
--- a/src/modules/clients/containers/accounting-adjustments-tab/accounting-adjustments-tab.tsx
+++ b/src/modules/clients/containers/accounting-adjustments-tab/accounting-adjustments-tab.tsx
@@ -50,7 +50,6 @@ const AccountingAdjustmentsTab = () => {
     zones: [],
     channels: []
   });
-  const JustOthersMotiveType = 2; // no trae ajustes financieros
   const {
     data,
     isLoading,
@@ -60,8 +59,7 @@ const AccountingAdjustmentsTab = () => {
     search: debouncedSearchQuery ? debouncedSearchQuery : undefined,
     line: filters.lines,
     zone: filters.zones,
-    channel: filters.channels,
-    motive_id: JustOthersMotiveType
+    channel: filters.channels
   });
 
   const { clientFilters } = useContext(ClientDetailsContext);


### PR DESCRIPTION
The constant `JustOthersMotiveType` (value 2) restricted results to "Others" motive type, excluding financial adjustments. Removing this filter allows all adjustment types to appear in the accounting adjustments tab.