### PR TITLE
Refactor/search accounting adjustments multiple ids

### DIFF
--- a/src/modules/banks/containers/active-payments-tab/active-payments-tab.tsx
+++ b/src/modules/banks/containers/active-payments-tab/active-payments-tab.tsx
@@ -40,6 +40,8 @@ interface ActivePaymentsTabProps {
   isActive: boolean;
 }
 
+const STATUS_ORDER = ["Sin identificar", "Pendiente ingreso a SAP", "Identificado", "Pago aplicado"];
+
 export const ActivePaymentsTab: FC<ActivePaymentsTabProps> = ({ isActive }) => {
   const [selectedRows, setSelectedRows] = useState<ISingleBank[]>();
   const [showBankRules, setShowBankRules] = useState<boolean>(false);
@@ -191,7 +193,11 @@ export const ActivePaymentsTab: FC<ActivePaymentsTabProps> = ({ isActive }) => {
             <Collapse
               stickyLabel
               labelStickyOffset={"6rem"}
-              items={data?.map((status) => ({
+              items={data?.slice().sort((a, b) => {
+                const ia = STATUS_ORDER.indexOf(a.payments_status);
+                const ib = STATUS_ORDER.indexOf(b.payments_status);
+                return (ia === -1 ? STATUS_ORDER.length : ia) - (ib === -1 ? STATUS_ORDER.length : ib);
+              }).map((status) => ({
                 key: status.payments_status_id,
                 label: (
                   <LabelCollapse

--- a/src/modules/banks/containers/banks-view/banks-view.tsx
+++ b/src/modules/banks/containers/banks-view/banks-view.tsx
@@ -40,14 +40,14 @@ export const BanksView: FC = () => {
       children: <ActivePaymentsTab isActive={activeKey === TAB_KEYS.activePayments} />
     },
     {
+      key: TAB_KEYS.walletPayments,
+      label: "Otros pagos",
+      children: <WalletPaymentsTab isActive={activeKey === TAB_KEYS.walletPayments} />
+    },
+    {
       key: TAB_KEYS.paymentApplications,
       label: "Aplicaciones de pago",
       children: <PaymentApplicationsTab isActive={activeKey === TAB_KEYS.paymentApplications} />
-    },
-    {
-      key: TAB_KEYS.walletPayments,
-      label: "Pagos wallet",
-      children: <WalletPaymentsTab isActive={activeKey === TAB_KEYS.walletPayments} />
     }
   ];
 

--- a/src/modules/clients/containers/accounting-adjustments-tab/accounting-adjustments-tab.tsx
+++ b/src/modules/clients/containers/accounting-adjustments-tab/accounting-adjustments-tab.tsx
@@ -142,6 +142,12 @@ const AccountingAdjustmentsTab = () => {
     setIsModalOpen({ selected });
   };
 
+  const handleSearchChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    const value = event.target.value?.trim();
+    // Separar los IDs por saltos de línea y luego unirlos con comas
+    const formattedValue = value.split(/\s+/).join(",");
+    setSearch(formattedValue);
+  };
   return (
     <>
       {selectedRows && selectedRows.length > 0 && (
@@ -160,9 +166,7 @@ const AccountingAdjustmentsTab = () => {
             <UiSearchInput
               className="standardSearch"
               placeholder="Buscar"
-              onChange={(event) => {
-                setSearch(event.target.value);
-              }}
+              onChange={handleSearchChange}
             />
             {/* <AccountingAdjustmentsFilter onFilterChange={setFilters} /> */}
             <Button

--- a/src/modules/clients/containers/accounting-adjustments-tab/accounting-adjustments-tab.tsx
+++ b/src/modules/clients/containers/accounting-adjustments-tab/accounting-adjustments-tab.tsx
@@ -50,7 +50,6 @@ const AccountingAdjustmentsTab = () => {
     zones: [],
     channels: []
   });
-  const JustOthersMotiveType = 2; // no trae ajustes financieros
   const {
     data,
     isLoading,
@@ -60,8 +59,7 @@ const AccountingAdjustmentsTab = () => {
     search: debouncedSearchQuery ? debouncedSearchQuery : undefined,
     line: filters.lines,
     zone: filters.zones,
-    channel: filters.channels,
-    motive_id: JustOthersMotiveType
+    channel: filters.channels
   });
 
   const { clientFilters } = useContext(ClientDetailsContext);

--- a/src/modules/clients/containers/apply-tab/Modals/ModalEditRow/ModalEditRow.tsx
+++ b/src/modules/clients/containers/apply-tab/Modals/ModalEditRow/ModalEditRow.tsx
@@ -97,9 +97,16 @@ const ModalEditRow: React.FC<IModalEditRowProps> = ({
                     value: /^-?\d+(\.\d+)?$/,
                     message: "Solo se permiten números"
                   },
-                  validate: (value) =>
-                    Number(value) <= amount ||
-                    `El valor no puede superar ${formatMoney(amount, { hideCurrencySymbol: true })}`
+                  validate: (value) => {
+                    const isNegativeFinancialRecord =
+                      row?.entity_type_name === "FINANCIAL_RECORD" && amount < 0;
+                    if (isNegativeFinancialRecord) return true;
+
+                    return (
+                      Number(value) <= amount ||
+                      `El valor no puede superar ${formatMoney(amount, { hideCurrencySymbol: true })}`
+                    );
+                  }
                 }}
               />
 


### PR DESCRIPTION
This pull request introduces several improvements and fixes across the banking and client modules, focusing on enhancing payment tab sorting, search input handling, and validation logic. The most significant changes are the introduction of a custom status order for active payments, improved search formatting in accounting adjustments, and a fix to allow negative values for certain financial records.

**Banking Module Updates:**

* Added a `STATUS_ORDER` constant and updated the sorting in `ActivePaymentsTab` so payment statuses are displayed in a specific, user-friendly order. [[1]](diffhunk://#diff-0e4db53181eb260b9096dc2f7aeebffa1d70bbcb43f75f492a59cfc0a5324fbbR43-R44) [[2]](diffhunk://#diff-0e4db53181eb260b9096dc2f7aeebffa1d70bbcb43f75f492a59cfc0a5324fbbL194-R200)
* Changed the label and order of the wallet payments tab in `BanksView` from "Pagos wallet" to "Otros pagos" and moved its position in the tab list.

**Client Module Improvements:**

* Modified the search input in `AccountingAdjustmentsTab` to trim whitespace and format multiple IDs entered by users (separated by newlines or spaces) into a comma-separated string for backend queries. [[1]](diffhunk://#diff-630ea3023eeabaf97263a144a91461c4235cbd3e49829c4b0b2166ce0177e384R145-R150) [[2]](diffhunk://#diff-630ea3023eeabaf97263a144a91461c4235cbd3e49829c4b0b2166ce0177e384L165-R169)
* Removed the hardcoded `JustOthersMotiveType` filter from the accounting adjustments query, allowing for more flexible filtering. [[1]](diffhunk://#diff-630ea3023eeabaf97263a144a91461c4235cbd3e49829c4b0b2166ce0177e384L53) [[2]](diffhunk://#diff-630ea3023eeabaf97263a144a91461c4235cbd3e49829c4b0b2166ce0177e384L63-R62)

**Validation Logic Fix:**

* Updated validation in `ModalEditRow` to allow negative values for rows with `entity_type_name` of `"FINANCIAL_RECORD"`, while maintaining the maximum value check for other cases.