### PR TITLE
Feat/add bonus in marketplcae flow

### DIFF
--- a/src/modules/commerce/components/create-order-checkout/create-order-checkout.tsx
+++ b/src/modules/commerce/components/create-order-checkout/create-order-checkout.tsx
@@ -134,7 +134,8 @@ export default function CheckoutPage() {
     return {
       order_summary: orderSummary,
       is_electronic_invoicing: isElectronicInvoicing,
-      order_split_details
+      order_split_details,
+      promotion_id: bonus?.id || 0
     };
   };
 

--- a/src/modules/commerce/components/create-order-checkout/modal-shipping-info/modal-shipping-info.tsx
+++ b/src/modules/commerce/components/create-order-checkout/modal-shipping-info/modal-shipping-info.tsx
@@ -1,6 +1,7 @@
 "use client";
 
-import { Dispatch, SetStateAction, useEffect, useMemo } from "react";
+import { Dispatch, SetStateAction, useEffect, useMemo, useState } from "react";
+import { Flex } from "antd";
 import { Gift, X } from "lucide-react";
 
 import { DiscountItem, ICommerceAdresses } from "@/types/commerce/ICommerce";
@@ -8,6 +9,11 @@ import { DiscountItem, ICommerceAdresses } from "@/types/commerce/ICommerce";
 import { NEW_ADDRESS_OPTION } from "@/modules/commerce/utils/constants/checkout";
 import { IShippingInfo } from "../../create-order-checkout/create-order-checkout";
 import { BonusRow } from "../order-shipment-confirm/order-shipment-confirm";
+import { ModalConfirmAction } from "@/components/molecules/modals/ModalConfirmAction/ModalConfirmAction";
+import { GALDERMA_PROJECT_ID } from "@/utils/constants/globalConstants";
+import { useAppStore } from "@/lib/store/store";
+
+const MINIMUM_ORDER_AMOUNT = 1_600_000;
 
 interface ModalShippingInfoProps {
   mode: "new" | string;
@@ -42,6 +48,11 @@ export default function ModalShippingInfo({
   callingCodeOptions,
   isLoadingOptions
 }: ModalShippingInfoProps) {
+  const { projectId, formatMoney } = useAppStore((s) => ({
+    projectId: s.selectedProject.ID,
+    formatMoney: s.formatMoney
+  }));
+
   const hasBonus = bonusItems.length + otherBonusItems.length > 0;
   const isNewAddress = draft.addressSelectValue === NEW_ADDRESS_OPTION.value;
   const isSaveDisabled =
@@ -50,6 +61,56 @@ export default function ModalShippingInfo({
     !draft.dispatch_address.trim() ||
     !draft.email.trim() ||
     !draft.telefono.trim();
+
+  const [showConfirmModal, setShowConfirmModal] = useState(false);
+  const [showCanulasModal, setShowCanulasModal] = useState(false);
+  const [showOnlyCanulasOrAguaModal, setShowOnlyCanulasOrAguaModal] = useState(false);
+
+  const splitTotal = useMemo(() => {
+    return discountItems.reduce((sum, item) => {
+      const qty = draft.cantidades[item.product_sku] ?? 0;
+      const unitPrice = item.discount?.primary?.new_price ?? item.price;
+      return sum + unitPrice * qty;
+    }, 0);
+  }, [discountItems, draft.cantidades]);
+
+  const isTotalLessThanMinimum = splitTotal < MINIMUM_ORDER_AMOUNT;
+
+  const splitProductDescriptions = useMemo(() => {
+    const descs: string[] = [];
+    for (const i of discountItems) {
+      if ((draft.cantidades[i.product_sku] ?? 0) > 0) descs.push(i.description ?? "");
+    }
+    for (const b of bonusItems) {
+      if ((draft.bonusCantidades[b.product_sku] ?? 0) > 0) descs.push(b.description ?? "");
+    }
+    for (const b of otherBonusItems) {
+      if ((draft.otherBonusCantidades[b.product_sku] ?? 0) > 0) descs.push(b.description ?? "");
+    }
+    return descs;
+  }, [
+    discountItems,
+    bonusItems,
+    otherBonusItems,
+    draft.cantidades,
+    draft.bonusCantidades,
+    draft.otherBonusCantidades
+  ]);
+
+  const hasNoCanulasOrAgua = useMemo(() => {
+    return !splitProductDescriptions.some((d) => {
+      const n = d.toLowerCase();
+      return n.includes("canula") || n.includes("agua");
+    });
+  }, [splitProductDescriptions]);
+
+  const hasOnlyCanulasOrAgua = useMemo(() => {
+    if (splitProductDescriptions.length === 0) return false;
+    return splitProductDescriptions.every((d) => {
+      const n = d.toLowerCase();
+      return n.includes("canula") || n.includes("agua");
+    });
+  }, [splitProductDescriptions]);
 
   const addressOptions = useMemo(
     () => [
@@ -89,6 +150,32 @@ export default function ModalShippingInfo({
       }
     }
   }, [draft.addressSelectValue, addresses]);
+
+  const handleSave = () => {
+    if (isSaveDisabled) return;
+
+    if (projectId === GALDERMA_PROJECT_ID) {
+      if (hasOnlyCanulasOrAgua) {
+        setShowOnlyCanulasOrAguaModal(true);
+        return;
+      }
+      if (isTotalLessThanMinimum) {
+        setShowConfirmModal(true);
+        return;
+      }
+      if (hasNoCanulasOrAgua) {
+        setShowCanulasModal(true);
+        return;
+      }
+    }
+
+    onSave();
+  };
+
+  const handleConfirmCanulas = () => {
+    setShowCanulasModal(false);
+    onSave();
+  };
 
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40">
@@ -365,11 +452,7 @@ export default function ModalShippingInfo({
             Cancelar
           </button>
           <button
-            onClick={() => {
-              if (!isSaveDisabled) {
-                onSave();
-              }
-            }}
+            onClick={handleSave}
             disabled={isSaveDisabled}
             className={`flex-1 py-2.5 text-sm font-semibold rounded-lg transition-colors ${
               isSaveDisabled
@@ -381,6 +464,49 @@ export default function ModalShippingInfo({
           </button>
         </div>
       </div>
+
+      <ModalConfirmAction
+        isOpen={showConfirmModal}
+        onClose={() => setShowConfirmModal(false)}
+        title="No puedes guardar esta entrega"
+        content={
+          <Flex vertical gap="0.5rem">
+            <p>Cada entrega debe ser mínimo de {formatMoney(MINIMUM_ORDER_AMOUNT)}</p>
+            <p>Reasigna cantidades a esta entrega para continuar.</p>
+          </Flex>
+        }
+        cancelText="Entendido"
+        hideOkButton
+      />
+
+      <ModalConfirmAction
+        isOpen={showOnlyCanulasOrAguaModal}
+        onClose={() => setShowOnlyCanulasOrAguaModal(false)}
+        title="No puedes guardar esta entrega"
+        content={
+          <Flex vertical gap="0.5rem">
+            <p>No se pueden facturar solo cánulas ni aguas</p>
+            <p>Agrega otros productos a esta entrega para continuar.</p>
+          </Flex>
+        }
+        cancelText="Entendido"
+        hideOkButton
+      />
+
+      <ModalConfirmAction
+        isOpen={showCanulasModal}
+        onClose={() => setShowCanulasModal(false)}
+        onOk={handleConfirmCanulas}
+        title="¿Está seguro que desea continuar?"
+        content={
+          <Flex vertical gap="0.5rem">
+            <p>No has seleccionado Cánulas y/o Agua estéril en esta entrega</p>
+            <p>Te recomendamos revisar la orden</p>
+          </Flex>
+        }
+        okText="Confirmar"
+        cancelText="Cancelar"
+      />
     </div>
   );
 }

--- a/src/modules/commerce/components/modal-bonus/modal-bonus.tsx
+++ b/src/modules/commerce/components/modal-bonus/modal-bonus.tsx
@@ -22,10 +22,13 @@ const ModalBonus = ({ isOpen, onClose }: Props) => {
   const giftOptions: IGiftOption[] = promotion?.active_range?.gift_options ?? [];
   const otherBonificated = confirmOrderData?.other_bonificated_products ?? [];
 
-  const tabOptions = giftOptions.filter((o) => o.items.some((g) => !g.fixed));
+  const tabOptions = giftOptions;
 
   const [activeTab, setActiveTab] = useState(0);
   const [poolQty, setPoolQty] = useState<Record<number, Record<number, number>>>({});
+  const [otherQty, setOtherQty] = useState<Record<number, number>>(() =>
+    Object.fromEntries(otherBonificated.map((p) => [p.product_id, p.qty]))
+  );
 
   const getPoolGroupTotal = (groupId: number) => {
     const group = poolQty[groupId] ?? {};
@@ -43,11 +46,20 @@ const ModalBonus = ({ isOpen, onClose }: Props) => {
     });
   };
 
+  const updateOther = (productId: number, delta: number, max: number) => {
+    setOtherQty((prev) => {
+      const current = prev[productId] ?? 0;
+      const next = Math.max(0, current + delta);
+      if (delta > 0 && next > max) return prev;
+      return { ...prev, [productId]: next };
+    });
+  };
+
   const totalBonificados = () => {
     const poolTotal = Object.values(poolQty)
       .flatMap(Object.values)
       .reduce((s, v) => s + v, 0);
-    const otherTotal = otherBonificated.reduce((s, p) => s + p.qty, 0);
+    const otherTotal = Object.values(otherQty).reduce((s, v) => s + v, 0);
     const fixedTotal = giftOptions
       .flatMap((opt) => opt.items)
       .filter((g) => g.fixed)
@@ -66,7 +78,7 @@ const ModalBonus = ({ isOpen, onClose }: Props) => {
                 ...rest,
                 qty: group.fixed
                   ? rest.qty
-                  : (poolQty[group.gift_item_group_id]?.[rest.product_id] ?? 0)
+                  : poolQty[group.gift_item_group_id]?.[rest.product_id] ?? 0
               }))
               .filter((item) => item.qty > 0)
           }))
@@ -74,7 +86,10 @@ const ModalBonus = ({ isOpen, onClose }: Props) => {
       : [];
 
     const otherBonificatedPayload = otherBonificated
-      .map(({ image: _img, max_selection_qty: _max, ...rest }) => rest)
+      .map(({ image: _img, max_selection_qty: _max, ...rest }) => ({
+        ...rest,
+        qty: otherQty[rest.product_id] ?? 0
+      }))
       .filter((item) => item.qty > 0);
 
     if (promotion || otherBonificatedPayload.length > 0) {
@@ -201,7 +216,9 @@ const ModalBonus = ({ isOpen, onClose }: Props) => {
                             {group.items.map((item, idx) => (
                               <tr
                                 key={item.product_id}
-                                className={idx < group.items.length - 1 ? styles.rowBorderGreen : ""}
+                                className={
+                                  idx < group.items.length - 1 ? styles.rowBorderGreen : ""
+                                }
                               >
                                 <td className={styles.cellName}>{item.description}</td>
                                 <td className={styles.cellBadge}>
@@ -223,15 +240,45 @@ const ModalBonus = ({ isOpen, onClose }: Props) => {
                 <div className={styles.genericTable}>
                   <table className={styles.table}>
                     <tbody>
-                      {otherBonificated.map((item, idx, arr) => (
-                        <tr
-                          key={item.product_id}
-                          className={idx < arr.length - 1 ? styles.rowBorder : ""}
-                        >
-                          <td className={styles.cellName}>{item.description}</td>
-                          <td className={styles.cellBadge}>{item.qty}</td>
-                        </tr>
-                      ))}
+                      {otherBonificated.map((item, idx, arr) => {
+                        const qty = otherQty[item.product_id] ?? 0;
+                        return (
+                          <tr
+                            key={item.product_id}
+                            className={idx < arr.length - 1 ? styles.rowBorder : ""}
+                          >
+                            <td className={styles.cellName}>
+                              {item.description}
+                              <span className={styles.saldoHint}>
+                                ({qty}/{item.max_selection_qty})
+                              </span>
+                            </td>
+                            <td className={styles.cellControl}>
+                              <div className={styles.counter}>
+                                <button
+                                  onClick={() =>
+                                    updateOther(item.product_id, -1, item.max_selection_qty)
+                                  }
+                                  disabled={qty <= 0}
+                                  className={styles.counterBtn}
+                                >
+                                  -
+                                </button>
+                                <span className={styles.counterVal}>{qty}</span>
+                                <button
+                                  onClick={() =>
+                                    updateOther(item.product_id, 1, item.max_selection_qty)
+                                  }
+                                  disabled={qty >= item.max_selection_qty}
+                                  className={styles.counterBtn}
+                                >
+                                  +
+                                </button>
+                              </div>
+                            </td>
+                          </tr>
+                        );
+                      })}
                     </tbody>
                   </table>
                 </div>

--- a/src/types/commerce/ICommerce.ts
+++ b/src/types/commerce/ICommerce.ts
@@ -269,6 +269,7 @@ export interface ICreateOrderData {
   order_summary: IOrderSummaryPayload;
   is_electronic_invoicing: number;
   order_split_details: IOrderSplitDetail[];
+  promotion_id: number;
 }
 
 export interface ISucessCreateOrder {


### PR DESCRIPTION
This pull request introduces several enhancements and validations to the checkout and shipping experience, particularly for the Galderma project. The most significant changes include new business logic for order validation in the shipping modal, improvements to the bonus selection modal for "other bonificated products", and the addition of a `promotion_id` to the order payload. These changes aim to ensure that orders comply with specific requirements and improve the user interface for bonus selection.

**Order validation and modal logic for Galderma project:**

- Added new validations in the `ModalShippingInfo` component to enforce Galderma-specific business rules: minimum order amount per delivery, restrictions on orders containing only "canulas" or "agua", and prompts when these products are missing or exclusively present. Corresponding confirmation modals are shown to guide the user through these validations. [[1]](diffhunk://#diff-2e1f1a59b8dddb69323f5ee3f61a1d246defd5d9f86c4f374ae07dd17f276762L3-R16) [[2]](diffhunk://#diff-2e1f1a59b8dddb69323f5ee3f61a1d246defd5d9f86c4f374ae07dd17f276762R51-R55) [[3]](diffhunk://#diff-2e1f1a59b8dddb69323f5ee3f61a1d246defd5d9f86c4f374ae07dd17f276762R65-R114) [[4]](diffhunk://#diff-2e1f1a59b8dddb69323f5ee3f61a1d246defd5d9f86c4f374ae07dd17f276762R154-R179) [[5]](diffhunk://#diff-2e1f1a59b8dddb69323f5ee3f61a1d246defd5d9f86c4f374ae07dd17f276762L368-R455) [[6]](diffhunk://#diff-2e1f1a59b8dddb69323f5ee3f61a1d246defd5d9f86c4f374ae07dd17f276762R467-R509)

**Bonus and promotion selection improvements:**

- Enhanced the "other bonificated products" section in the `ModalBonus` component to allow users to increment or decrement quantities for each product, with visual feedback and quantity controls. The selected quantities are now included in the payload sent on confirmation. [[1]](diffhunk://#diff-aa693f7f15112a16ec868895743cd41b1fe41938e382dd6f78e3dbfe8c12b5e6L25-R31) [[2]](diffhunk://#diff-aa693f7f15112a16ec868895743cd41b1fe41938e382dd6f78e3dbfe8c12b5e6R49-R62) [[3]](diffhunk://#diff-aa693f7f15112a16ec868895743cd41b1fe41938e382dd6f78e3dbfe8c12b5e6L69-R92) [[4]](diffhunk://#diff-aa693f7f15112a16ec868895743cd41b1fe41938e382dd6f78e3dbfe8c12b5e6L204-R221) [[5]](diffhunk://#diff-aa693f7f15112a16ec868895743cd41b1fe41938e382dd6f78e3dbfe8c12b5e6L226-R281)

**Order payload updates:**

- Added a `promotion_id` field to the order payload in both the frontend (`ICreateOrderData` interface and order creation logic) to ensure the selected promotion is properly tracked and sent to the backend. [[1]](diffhunk://#diff-946724022fb5b4dbf7742f549668679cba81a28440e35673a4b2b0ff7b8eb7bbL137-R138) [[2]](diffhunk://#diff-9f81dfc02cbe3385da8783726a173ee0bc277725cacbbc0a1b64cd54323a7e05R272)