### PR TITLE
feat(payments): validate payment eligibility before application

### DIFF
--- a/src/components/molecules/modals/ModalActionPayment/ModalActionPayment.tsx
+++ b/src/components/molecules/modals/ModalActionPayment/ModalActionPayment.tsx
@@ -32,10 +32,7 @@ export const ModalActionPayment: React.FC<ModalActionPaymentProps> = ({
   selectedPayments
 }) => {
   const isApplyDisabled =
-    selectedPayments.length === 0 ||
-    selectedPayments.some(
-      (p) => p.payments_status_id !== 1 || p.status_description === "Identificado"
-    );
+    selectedPayments.length === 0 || selectedPayments.some((p) => p.payments_status_id !== 1);
 
   return (
     <Modal

--- a/src/components/molecules/modals/ModalActionPayment/ModalActionPayment.tsx
+++ b/src/components/molecules/modals/ModalActionPayment/ModalActionPayment.tsx
@@ -31,6 +31,12 @@ export const ModalActionPayment: React.FC<ModalActionPaymentProps> = ({
   addPaymentsToApplicationTable,
   selectedPayments
 }) => {
+  const isApplyDisabled =
+    selectedPayments.length === 0 ||
+    selectedPayments.some(
+      (p) => p.payments_status_id !== 1 || p.status_description === "Identificado"
+    );
+
   return (
     <Modal
       open={isOpen}
@@ -63,6 +69,7 @@ export const ModalActionPayment: React.FC<ModalActionPaymentProps> = ({
             }
             addPaymentsToApplicationTable();
           }}
+          disabled={isApplyDisabled}
         />
         <ButtonGenerateAction
           icon={<PushPin size={20} />}

--- a/src/modules/clients/components/payments-table/payments-table.tsx
+++ b/src/modules/clients/components/payments-table/payments-table.tsx
@@ -40,9 +40,9 @@ const PaymentsTable = ({
     setSelectedPayments((prevSelectedPayments) => {
       if (newSelectedRowKeys.length >= 1) {
         // Filter out newly selected rows that aren't already in prevSelectedPayments
-        const filteredNewRows = newSelectedRows.filter(
-          (newRow) => !prevSelectedPayments.some((prevRow) => prevRow.id === newRow.id)
-        );
+        const filteredNewRows = newSelectedRows
+          .filter((newRow) => !prevSelectedPayments.some((prevRow) => prevRow.id === newRow.id))
+          .map((newRow) => ({ ...newRow, payments_status_id: paymentStatusId }));
 
         // Filter out unselected rows for this payment status
         const remainingRows = prevSelectedPayments.filter(

--- a/src/types/clientPayments/IClientPayments.ts
+++ b/src/types/clientPayments/IClientPayments.ts
@@ -30,6 +30,7 @@ export interface IClientPayment {
   account_number: string;
   type_account: string;
   ID_ERP: string | null;
+  payments_status_id?: number;
 }
 
 export interface IClientPaymentStatus {


### PR DESCRIPTION
This pull request introduces improvements to the payment selection and application workflow in the client payments module. The main changes ensure that the payment status is consistently tracked when selecting payments, and that the "Apply" action is only enabled when appropriate payments are selected.

**Payment selection and status handling:**

* When selecting payments in the `PaymentsTable`, each newly selected payment now has its `payments_status_id` set to the current `paymentStatusId`, ensuring that the payment status is accurately tracked for each selected payment.
* The `IClientPayment` type was updated to include an optional `payments_status_id` property, supporting the new status-tracking logic.

**"Apply" action enablement:**

* In `ModalActionPayment`, a new `isApplyDisabled` flag disables the "Apply" button if no payments are selected or if any selected payment does not have a `payments_status_id` of 1. This prevents invalid or incomplete actions. [[1]](diffhunk://#diff-481728bc279aefc1186a7f2e4435b0bf292763c402fc3f6e588ae3d7db80e2c4R34-R36) [[2]](diffhunk://#diff-481728bc279aefc1186a7f2e4435b0bf292763c402fc3f6e588ae3d7db80e2c4R69)