### PR TITLE
fix(chat): mark inbound messages as unread for active conversation

### DIFF
--- a/src/modules/chat/components/all-chats/AllChats.tsx
+++ b/src/modules/chat/components/all-chats/AllChats.tsx
@@ -95,7 +95,10 @@ export default function AllChats({
         { revalidate: false }
       );
 
-      if (activeConversation?.id !== data.ticketId) {
+      if (
+        activeConversation?.id !== data.ticketId &&
+        data.message.direction === "INBOUND"
+      ) {
         setUnreadTickets((prev) => new Set(prev).add(data.ticketId));
       }
     });


### PR DESCRIPTION
This pull request updates the logic for marking tickets as unread in the `AllChats` component. Now, a ticket is only marked as unread if the incoming message is of direction "INBOUND", preventing outbound messages from triggering the unread state.

Logic improvement for unread tickets:

* Updated the condition in `AllChats.tsx` to only add a ticket to the unread set if the new message is "INBOUND", ensuring that only incoming messages mark a ticket as unread.