### PR TITLE
feat(chat): refine hasUnreadUpdate logic to require inbound message

### DIFF
--- a/src/modules/chat/lib/ticketToConversation.ts
+++ b/src/modules/chat/lib/ticketToConversation.ts
@@ -26,7 +26,9 @@ export function ticketToConversation(ticket: ITicket, unreadTicketsSet: Set<stri
     tags: ticket.tags ? [ticket.tags] : [],
     timeline: [],
     metrics: { totalVencido: 0, ultimoPago: "" },
-    hasUnreadUpdate: ticket.lastViewedAt === null || unreadTicketsSet.has(ticket.id),
+    hasUnreadUpdate:
+      (ticket.lastViewedAt === null && ticket.lastMessage?.direction === "INBOUND") ||
+      unreadTicketsSet.has(ticket.id),
     lastMessageAt: ticket.lastMessageAt,
     countMessages: ticket._count?.messages || 0
   };


### PR DESCRIPTION
Changed the unread status condition to only mark a ticket as having unread updates when it has never been viewed AND contains an inbound message, in addition to the existing unread tickets set check. This improves accuracy by preventing tickets with only outbound messages from appearing as unread.