### PR TITLE
feat(checkout): add phone number validation with country code indicator

### DIFF
--- a/src/modules/commerce/components/create-order-checkout/modal-shipping-info/modal-shipping-info.tsx
+++ b/src/modules/commerce/components/create-order-checkout/modal-shipping-info/modal-shipping-info.tsx
@@ -6,7 +6,12 @@ import { Gift, X } from "lucide-react";
 
 import { DiscountItem, ICommerceAdresses } from "@/types/commerce/ICommerce";
 
-import { NEW_ADDRESS_OPTION, isValidEmail } from "@/modules/commerce/utils/constants/checkout";
+import {
+  NEW_ADDRESS_OPTION,
+  isValidEmail,
+  isValidPhone,
+  phoneErrorMessage
+} from "@/modules/commerce/utils/constants/checkout";
 import { IShippingInfo } from "../../create-order-checkout/create-order-checkout";
 import { BonusRow } from "../order-shipment-confirm/order-shipment-confirm";
 import { ModalConfirmAction } from "@/components/molecules/modals/ModalConfirmAction/ModalConfirmAction";
@@ -60,9 +65,12 @@ export default function ModalShippingInfo({
     !draft.city.trim() ||
     !draft.dispatch_address.trim() ||
     !isValidEmail(draft.email) ||
-    !draft.telefono.trim();
+    !isValidPhone(draft.telefono, draft.indicativo);
 
   const isEmailInvalid = draft.email.trim() !== "" && !isValidEmail(draft.email);
+
+  const isPhoneInvalid =
+    draft.telefono.trim() !== "" && !isValidPhone(draft.telefono, draft.indicativo);
 
   const [showConfirmModal, setShowConfirmModal] = useState(false);
   const [showCanulasModal, setShowCanulasModal] = useState(false);
@@ -280,10 +288,19 @@ export default function ModalShippingInfo({
                 type="tel"
                 placeholder="3001234567"
                 value={draft.telefono}
-                onChange={(e) => setDraft((d) => ({ ...d, telefono: e.target.value }))}
-                className="flex-1 px-3 py-2.5 text-sm bg-[#F7F7F7] border border-[#DDDDDD] rounded-lg outline-none focus:border-[#141414] transition-colors text-[#141414] placeholder:text-[#999999]"
+                onChange={(e) =>
+                  setDraft((d) => ({ ...d, telefono: e.target.value.replace(/\D/g, "") }))
+                }
+                className={`flex-1 px-3 py-2.5 text-sm bg-[#F7F7F7] border rounded-lg outline-none transition-colors text-[#141414] placeholder:text-[#999999] ${
+                  isPhoneInvalid
+                    ? "border-red-400 focus:border-red-500"
+                    : "border-[#DDDDDD] focus:border-[#141414]"
+                }`}
               />
             </div>
+            {isPhoneInvalid && (
+              <p className="text-[10px] text-red-500">{phoneErrorMessage(draft.indicativo)}</p>
+            )}
           </div>
 
           <div className="flex flex-col gap-1.5">

--- a/src/modules/commerce/components/create-order-checkout/order-shipment-confirm/order-shipment-confirm.tsx
+++ b/src/modules/commerce/components/create-order-checkout/order-shipment-confirm/order-shipment-confirm.tsx
@@ -17,7 +17,12 @@ import { useAppStore } from "@/lib/store/store";
 import { formatNumber } from "@/utils/utils";
 
 import ModalShippingInfo from "../modal-shipping-info";
-import { NEW_ADDRESS_OPTION, isValidEmail } from "@/modules/commerce/utils/constants/checkout";
+import {
+  NEW_ADDRESS_OPTION,
+  isValidEmail,
+  isValidPhone,
+  phoneErrorMessage
+} from "@/modules/commerce/utils/constants/checkout";
 import { IShippingInfo } from "../../create-order-checkout/create-order-checkout";
 
 export type BonusRow = {
@@ -323,10 +328,14 @@ export default function OrderShipmentConfirm({
     singleForm.city.trim() !== "" &&
     singleForm.dispatch_address.trim() !== "" &&
     isValidEmail(singleForm.email) &&
-    singleForm.telefono.trim() !== "";
+    isValidPhone(singleForm.telefono, singleForm.indicativo);
 
   const isSingleEmailInvalid =
     singleForm.email.trim() !== "" && !isValidEmail(singleForm.email);
+
+  const isSinglePhoneInvalid =
+    singleForm.telefono.trim() !== "" &&
+    !isValidPhone(singleForm.telefono, singleForm.indicativo);
 
   // Sync order_split_details on context
   useEffect(() => {
@@ -549,10 +558,21 @@ export default function OrderShipmentConfirm({
                     type="tel"
                     placeholder="3001234567"
                     value={singleForm.telefono}
-                    onChange={(e) => setSingleForm((f) => ({ ...f, telefono: e.target.value }))}
-                    className="flex-1 px-3 py-2.5 text-sm bg-[#F7F7F7] border border-[#DDDDDD] rounded-lg outline-none focus:border-[#141414] transition-colors text-[#141414] placeholder:text-[#999999]"
+                    onChange={(e) =>
+                      setSingleForm((f) => ({ ...f, telefono: e.target.value.replace(/\D/g, "") }))
+                    }
+                    className={`flex-1 px-3 py-2.5 text-sm bg-[#F7F7F7] border rounded-lg outline-none transition-colors text-[#141414] placeholder:text-[#999999] ${
+                      isSinglePhoneInvalid
+                        ? "border-red-400 focus:border-red-500"
+                        : "border-[#DDDDDD] focus:border-[#141414]"
+                    }`}
                   />
                 </div>
+                {isSinglePhoneInvalid && (
+                  <p className="text-[10px] text-red-500">
+                    {phoneErrorMessage(singleForm.indicativo)}
+                  </p>
+                )}
               </div>
 
               <div className="flex flex-col gap-1.5">

--- a/src/modules/commerce/utils/constants/checkout.ts
+++ b/src/modules/commerce/utils/constants/checkout.ts
@@ -6,3 +6,15 @@ export const NEW_ADDRESS_OPTION = {
 export const EMAIL_REGEX = /^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$/;
 
 export const isValidEmail = (value: string) => EMAIL_REGEX.test(value.trim());
+
+export const isValidPhone = (telefono: string, indicativo: string) => {
+  const digits = telefono.trim();
+  if (!/^\d+$/.test(digits)) return false;
+  if (indicativo === "+57") return digits.length === 10;
+  return digits.length >= 10 && digits.length <= 12;
+};
+
+export const phoneErrorMessage = (indicativo: string) =>
+  indicativo === "+57"
+    ? "Teléfono debe tener 10 dígitos"
+    : "Teléfono debe tener entre 10 y 12 dígitos";


### PR DESCRIPTION
- Implement phone validation using `isValidPhone()` that checks against country-specific indicativo
- Strip non-numeric characters from phone input automatically
- Add visual feedback with red border styling for invalid phone numbers
- Display contextual error messages based on the selected country code
- Apply consistent validation across both modal-shipping-info and order-shipment-confirm forms