### PR TITLE
Add regenerate Excel/PDF for history rows

### DIFF
--- a/src/modules/clients/components/history-tab/history-tab-table/history-tab-table.tsx
+++ b/src/modules/clients/components/history-tab/history-tab-table/history-tab-table.tsx
@@ -18,12 +18,18 @@ interface PropsHistoryTable {
   setSelectedRows: Dispatch<SetStateAction<IHistoryRow[] | undefined>>;
   // eslint-disable-next-line no-unused-vars
   handleOpenDetail: (row: IHistoryRow, url: string | null) => void;
+  // eslint-disable-next-line no-unused-vars
+  handleRegenerateExcel: (row: IHistoryRow) => Promise<void>;
+  // eslint-disable-next-line no-unused-vars
+  handleRegeneratePDF: (row: IHistoryRow) => Promise<void>;
 }
 
 const HistoryTable = ({
   dataAllRecords: data,
   setSelectedRows,
-  handleOpenDetail
+  handleOpenDetail,
+  handleRegenerateExcel,
+  handleRegeneratePDF
 }: PropsHistoryTable) => {
   const [page, setPage] = useState(1);
   const height = useScreenHeight();
@@ -86,7 +92,7 @@ const HistoryTable = ({
                 icon={<FileXls size={20} />}
                 className="buttonNoBorder"
                 onClick={() => {
-                  handleOpenDetail(row, row.payment_identification_excel_url);
+                  handleRegenerateExcel(row);
                 }}
               >
                 Descargar plano
@@ -100,7 +106,7 @@ const HistoryTable = ({
                 icon={<FileText size={20} />}
                 className="buttonNoBorder"
                 onClick={() => {
-                  handleOpenDetail(row, row.payment_identification_url);
+                  handleRegeneratePDF(row);
                 }}
               >
                 Ver pdf

--- a/src/modules/clients/containers/history-tab/history-tab.tsx
+++ b/src/modules/clients/containers/history-tab/history-tab.tsx
@@ -6,6 +6,7 @@ import { DotsThree } from "phosphor-react";
 import { extractSingleParam } from "@/utils/utils";
 import { useClientHistory } from "@/hooks/useClientHistory";
 import { useMessageApi } from "@/context/MessageContext";
+import { reprocessExcel, reprocessPDF } from "@/services/paymentApplications/paymentApplications";
 
 import UiSearchInput from "@/components/ui/search-input";
 import HistoryTable from "../../components/history-tab/history-tab-table";
@@ -44,6 +45,76 @@ const HistoryTab = () => {
     setOpenModal({ selected: 3 });
   };
 
+  const isPaymentApplicationEvent = (row: IHistoryRow) => {
+    const eventNormalized = (row.event || "").toLowerCase();
+    return eventNormalized === "aplicación de pago" || eventNormalized === "legalización de saldo";
+  };
+
+  const getApplicationIdFromRow = (row: IHistoryRow) => {
+    const directApplicationId = row.id_payment_application;
+    if (typeof directApplicationId === "number" && directApplicationId > 0) {
+      return directApplicationId;
+    }
+
+    return null;
+  };
+
+  const handleRegenerateExcel = async (row: IHistoryRow) => {
+    if (!isPaymentApplicationEvent(row)) {
+      return showMessage(
+        "info",
+        "Esta opción solo aplica para eventos de Aplicación de pago o Legalización de saldo"
+      );
+    }
+
+    const applicationId = getApplicationIdFromRow(row);
+
+    if (!applicationId) {
+      return showMessage("info", "No se encontró el id de aplicación de pago en este registro");
+    }
+
+    try {
+      const data = await reprocessExcel(applicationId);
+      window.open(data.excel_url, "_blank");
+    } catch (error) {
+      if (row.payment_identification_excel_url) {
+        window.open(row.payment_identification_excel_url, "_blank");
+        return;
+      }
+
+      const message = error instanceof Error ? error.message : "No se pudo generar el plano";
+      showMessage("error", message);
+    }
+  };
+
+  const handleRegeneratePDF = async (row: IHistoryRow) => {
+    if (!isPaymentApplicationEvent(row)) {
+      return showMessage(
+        "info",
+        "Esta opción solo aplica para eventos de Aplicación de pago o Legalización de saldo"
+      );
+    }
+
+    const applicationId = getApplicationIdFromRow(row);
+
+    if (!applicationId) {
+      return showMessage("info", "No se encontró el id de aplicación de pago en este registro");
+    }
+
+    try {
+      const data = await reprocessPDF(applicationId);
+      window.open(data.pdf_url, "_blank");
+    } catch (error) {
+      if (row.payment_identification_url) {
+        window.open(row.payment_identification_url, "_blank");
+        return;
+      }
+
+      const message = error instanceof Error ? error.message : "No se pudo generar el PDF";
+      showMessage("error", message);
+    }
+  };
+
   return (
     <>
       {isLoading ? (
@@ -69,6 +140,8 @@ const HistoryTab = () => {
             dataAllRecords={data}
             setSelectedRows={setSelectedRows}
             handleOpenDetail={handleOpenDetail}
+            handleRegenerateExcel={handleRegenerateExcel}
+            handleRegeneratePDF={handleRegeneratePDF}
           />
 
           <ModalActionsHistoryTab

--- a/src/types/clientHistory/IClientHistory.ts
+++ b/src/types/clientHistory/IClientHistory.ts
@@ -1,5 +1,8 @@
 export interface IHistoryRow {
   id: number;
+  id_payment_application?: number | null;
+  id_aplication_payment?: number | null;
+  id_application_payment?: number | null;
   event: string;
   description: string;
   project_id: number;


### PR DESCRIPTION
Introduce regenerate actions for payment application history entries. history-tab now imports reprocessExcel/reprocessPDF and implements handleRegenerateExcel/handleRegeneratePDF which validate the event type and application id, call the reprocess services, open the returned URL in a new tab, and fall back to existing stored URLs on error while showing user messages. history-tab-table props and click handlers were updated to call these new functions instead of opening details. Also extend IHistoryRow with optional application id fields (id_payment_application, id_aplication_payment, id_application_payment) to support lookup of the payment application id.