### PR TITLE
Feat/add reaction to messages bubble message component

### DIFF
--- a/src/modules/chat/components/bubble-message/BubbleMessage.tsx
+++ b/src/modules/chat/components/bubble-message/BubbleMessage.tsx
@@ -270,7 +270,7 @@ export default function BubbleMessage({
         padding="p-3"
       >
         <div
-          className="text-sm text-white whitespace-pre-wrap"
+          className="text-sm text-white whitespace-pre-wrap break-words"
           dangerouslySetInnerHTML={{ __html: formatWhatsAppText(bodyText) }}
         />
         {buttonText && (
@@ -291,7 +291,7 @@ export default function BubbleMessage({
   // Default: TEXT
   return (
     <BubbleWrapper mine={mine} customerName={customerName}>
-      <span className="whitespace-pre-wrap">{m.content}</span>
+      <span className="whitespace-pre-wrap break-words">{m.content}</span>
       {footer}
     </BubbleWrapper>
   );

--- a/src/modules/chat/components/bubble-message/BubbleMessage.tsx
+++ b/src/modules/chat/components/bubble-message/BubbleMessage.tsx
@@ -16,8 +16,29 @@ interface BubbleMessageProps {
   message: IMessage;
   customerName: string;
   templateMap: Map<string, IWhatsAppTemplate>;
+  messagesByWaId: Map<string, IMessage>;
   onPreviewImage: (url: string) => void;
   onScrollToBottom: () => void;
+}
+
+function quotedPreviewFor(referenced: IMessage | undefined): string {
+  if (!referenced) return "mensaje no disponible";
+  switch (referenced.type) {
+    case "IMAGE":
+      return "imagen";
+    case "STICKER":
+      return "sticker";
+    case "AUDIO":
+      return "audio";
+    case "DOCUMENT":
+      return referenced.content || "documento";
+    case "CONTACTS":
+      return "contacto";
+    case "TEMPLATE":
+      return "plantilla";
+    default:
+      return referenced.content || "mensaje";
+  }
 }
 
 function ReadStatus({ mine, status }: { mine: boolean; status: string }) {
@@ -96,11 +117,34 @@ export default function BubbleMessage({
   message: m,
   customerName,
   templateMap,
+  messagesByWaId,
   onPreviewImage,
   onScrollToBottom
 }: BubbleMessageProps) {
   const mine = m.direction === "OUTBOUND";
   const footer = <Footer timestamp={m.timestamp} mine={mine} status={m.status} />;
+
+  const aditionals = m.metadata?.aditionals;
+  if (aditionals?.type === "reaction" && aditionals?.reaction?.emoji) {
+    const referenced = messagesByWaId.get(aditionals.reaction.message_id);
+    const quoted = quotedPreviewFor(referenced);
+    const truncated = quoted.length > 80 ? `${quoted.slice(0, 80)}…` : quoted;
+    const quoteIsMissing = !referenced;
+
+    return (
+      <BubbleWrapper mine={mine} customerName={customerName} padding="px-3 py-2">
+        <div className="text-xs opacity-80">
+          Reaccionó <span className="text-base align-middle">{aditionals.reaction.emoji}</span> a:
+        </div>
+        <div
+          className={`mt-1 border-l-2 pl-2 text-xs ${mine ? "border-white/40" : "border-black/30"} opacity-80 ${quoteIsMissing ? "italic" : ""}`}
+        >
+          «{truncated}»
+        </div>
+        {footer}
+      </BubbleWrapper>
+    );
+  }
 
   if (m.type === "CONTACTS") {
     const contacts: TypeContactMessage[] = m.metadata?.contacts || [];

--- a/src/modules/chat/containers/chat-thread.tsx
+++ b/src/modules/chat/containers/chat-thread.tsx
@@ -58,6 +58,15 @@ export default function ChatThread({
     return map;
   }, [ticketMessages]);
 
+  const messagesByWaId = useMemo(() => {
+    const map = new Map<string, IMessage>();
+    for (const m of ticketMessages) {
+      const waId = m.metadata?.whatsapp_message_id;
+      if (waId) map.set(waId, m);
+    }
+    return map;
+  }, [ticketMessages]);
+
   const viewportRef = useRef<HTMLDivElement | null>(null);
   const [waTemplates, setWaTemplates] = useState<IWhatsAppTemplate[]>([]);
 
@@ -253,6 +262,7 @@ export default function ChatThread({
                   message={m}
                   customerName={conversation.customer}
                   templateMap={templateMap}
+                  messagesByWaId={messagesByWaId}
                   onPreviewImage={setPreviewImage}
                   onScrollToBottom={scrollToBottom}
                 />


### PR DESCRIPTION
This pull request adds support for displaying WhatsApp message reactions in the chat UI and improves message rendering for better readability. The main changes include handling reaction messages, adding message lookup by WhatsApp ID, and enhancing text wrapping for message content.

**WhatsApp Reaction Support**

* Added logic in `BubbleMessage.tsx` to detect reaction messages and display a preview of the referenced message, including the emoji used and a truncated version of the quoted message. If the referenced message is unavailable, a fallback message is shown. (`[[1]](diffhunk://#diff-7b2346a87129be3dc5d72019ef885309e9995afa4ce76902f501540e06f5434dR19-R43)`, `[[2]](diffhunk://#diff-7b2346a87129be3dc5d72019ef885309e9995afa4ce76902f501540e06f5434dR120-R148)`)
* Introduced the `quotedPreviewFor` helper function to generate readable previews of referenced messages based on their type. (`[src/modules/chat/components/bubble-message/BubbleMessage.tsxR19-R43](diffhunk://#diff-7b2346a87129be3dc5d72019ef885309e9995afa4ce76902f501540e06f5434dR19-R43)`)

**Message Lookup Enhancement**

* In `chat-thread.tsx`, added a `messagesByWaId` map to efficiently look up messages by their WhatsApp message ID, enabling accurate reaction referencing. This map is passed down to `BubbleMessage`. (`[[1]](diffhunk://#diff-bccbb7fd917767b9b9e81f2c695d389b488155b4f34a1212bd95b207e200c1c5R61-R69)`, `[[2]](diffhunk://#diff-bccbb7fd917767b9b9e81f2c695d389b488155b4f34a1212bd95b207e200c1c5R265)`)

**UI Improvements**

* Updated message rendering to include the `break-words` CSS class, ensuring long words or URLs wrap correctly in both regular and template message bubbles. (`[[1]](diffhunk://#diff-7b2346a87129be3dc5d72019ef885309e9995afa4ce76902f501540e06f5434dL229-R273)`, `[[2]](diffhunk://#diff-7b2346a87129be3dc5d72019ef885309e9995afa4ce76902f501540e06f5434dL250-R294)`)