### PR TITLE
Fix/colors data exploration card

### DIFF
--- a/src/modules/dataQuality/components/Dashboard/DataExplorationCard/DataExplorationCard.tsx
+++ b/src/modules/dataQuality/components/Dashboard/DataExplorationCard/DataExplorationCard.tsx
@@ -84,6 +84,20 @@ export function DataExplorationCard() {
     return { rows: computedRows, lastDataDayIdx };
   }, [data, dayNumbers]);
 
+  const todayDayCutoff = useMemo(() => {
+    const [year, month] = selectedMonth.split("-").map(Number);
+    const today = new Date();
+    const currentYear = today.getFullYear();
+    const currentMonth = today.getMonth() + 1;
+    if (year < currentYear || (year === currentYear && month < currentMonth)) {
+      return Infinity;
+    }
+    if (year > currentYear || (year === currentYear && month > currentMonth)) {
+      return 0;
+    }
+    return today.getDate();
+  }, [selectedMonth]);
+
   return (
     <Card
       className="bg-white overflow-hidden border-0 shadow-none"
@@ -131,7 +145,7 @@ export function DataExplorationCard() {
             </div>
             <div className="flex items-center gap-1.5">
               <div
-                className="w-3 h-3 rounded border border-dashed"
+                className="w-3 h-3 rounded border"
                 style={{ backgroundColor: "#F9FAFB", borderColor: "#E5E7EB" }}
               />
               <span>Esperado</span>
@@ -263,39 +277,40 @@ export function DataExplorationCard() {
                     </td>
                     */}
                     {row.days.map((dayTotals, dayIdx) => {
+                      const dayNumber = dayIdx + 1;
+                      const isFutureDay = dayNumber > todayDayCutoff;
+                      const isWithinReportedRange = dayIdx < lastDataDayIdx;
+
                       if (dayTotals === null) {
-                        const isMissing = dayIdx < lastDataDayIdx;
+                        const showAsExpected = isFutureDay || isWithinReportedRange;
                         return (
                           <td
                             key={dayIdx}
                             className="text-center py-1 font-medium tabular-nums"
                             style={
-                              isMissing
-                                ? { backgroundColor: "#FEE2E2", color: "#991B1B" }
+                              showAsExpected
+                                ? { backgroundColor: "#F9FAFB", color: "#9CA3AF" }
                                 : { backgroundColor: "#ffffff", color: "#9CA3AF" }
                             }
                           >
-                            {isMissing ? "-" : ""}
+                            {showAsExpected ? "⋯" : ""}
                           </td>
                         );
                       }
 
-                      const hasNovedades = dayTotals.novedades > 0;
-                      const bgColor = hasNovedades ? "#FEF3C7" : "#D1FAE5";
-                      const textColor = hasNovedades ? "#92400E" : "#065F46";
-                      const novedadesDayPct =
-                        dayTotals.total_registros > 0
-                          ? Math.round((dayTotals.novedades / dayTotals.total_registros) * 100)
-                          : 0;
+                      if (dayTotals.novedades > 0) {
+                        const novedadesDayPct =
+                          dayTotals.total_registros > 0
+                            ? Math.round((dayTotals.novedades / dayTotals.total_registros) * 100)
+                            : 0;
 
-                      const cellContent = (
-                        <td
-                          key={dayIdx}
-                          className="text-center py-1 font-medium tabular-nums relative"
-                          style={{ backgroundColor: bgColor, color: textColor }}
-                        >
-                          {dayTotals.total_registros}
-                          {hasNovedades && (
+                        const cellContent = (
+                          <td
+                            key={dayIdx}
+                            className="text-center py-1 font-medium tabular-nums relative"
+                            style={{ backgroundColor: "#FEF3C7", color: "#92400E" }}
+                          >
+                            {dayTotals.total_registros}
                             <div
                               className="absolute top-0 right-0 w-0 h-0"
                               style={{
@@ -303,11 +318,9 @@ export function DataExplorationCard() {
                                 borderTop: "6px solid #F59E0B"
                               }}
                             />
-                          )}
-                        </td>
-                      );
+                          </td>
+                        );
 
-                      if (hasNovedades) {
                         return (
                           <TooltipProvider key={dayIdx} delayDuration={100}>
                             <Tooltip>
@@ -329,7 +342,42 @@ export function DataExplorationCard() {
                         );
                       }
 
-                      return cellContent;
+                      if (dayTotals.total_registros === 0) {
+                        if (isFutureDay) {
+                          return (
+                            <td
+                              key={dayIdx}
+                              className="text-center py-1 font-medium tabular-nums"
+                              style={{ backgroundColor: "#F9FAFB", color: "#9CA3AF" }}
+                            >
+                              ⋯
+                            </td>
+                          );
+                        }
+                        return (
+                          <td
+                            key={dayIdx}
+                            className="text-center py-1 font-medium tabular-nums"
+                            style={
+                              isWithinReportedRange
+                                ? { backgroundColor: "#FEE2E2", color: "#991B1B" }
+                                : { backgroundColor: "#ffffff", color: "#9CA3AF" }
+                            }
+                          >
+                            {isWithinReportedRange ? "-" : ""}
+                          </td>
+                        );
+                      }
+
+                      return (
+                        <td
+                          key={dayIdx}
+                          className="text-center py-1 font-medium tabular-nums"
+                          style={{ backgroundColor: "#D1FAE5", color: "#065F46" }}
+                        >
+                          {dayTotals.total_registros}
+                        </td>
+                      );
                     })}
                     <td
                       className="text-right px-2 py-1 font-semibold tabular-nums"


### PR DESCRIPTION
This pull request updates the `DataExplorationCard` component to improve how missing and future data days are displayed, clarifies the expected data state, and refines the visual cues for different cell statuses. The changes enhance the clarity and accuracy of the dashboard's data representation.

**Improvements to handling missing and future data:**

* Introduced a new `todayDayCutoff` calculation to determine which days are in the future based on the selected month and today's date. This allows the UI to distinguish between missing data for past days and unreported future days.
* Updated table cell rendering logic to show a "⋯" symbol for future days and to use clearer color coding for missing, expected, and reported data. Future days and expected (but not yet reported) days now have a distinct appearance, while missing data for past days is highlighted differently. [[1]](diffhunk://#diff-73b2bc634df1efe64e5aa28d1cc30c94a71f078c94ec6046e86066b2403c8252R280-R301) [[2]](diffhunk://#diff-73b2bc634df1efe64e5aa28d1cc30c94a71f078c94ec6046e86066b2403c8252L332-R380)

**Visual and styling updates:**

* Changed the legend's "Esperado" indicator to use a solid border instead of a dashed one for improved consistency.
* Refined the display of days with `novedades` (issues) by always using a specific background and text color, and by consistently showing a triangle indicator in the cell when applicable.