### PR TITLE
feat(banks): update payment status requirement from Identificado to C…

### DIFF
--- a/src/modules/banks/components/modal-actions-wallet-payments/modal-actions-wallet-payments.tsx
+++ b/src/modules/banks/components/modal-actions-wallet-payments/modal-actions-wallet-payments.tsx
@@ -15,6 +15,7 @@ import { ISingleBank } from "@/types/banks/IBanks";
 import "./modal-actions-wallet-payments.scss";
 
 const IDENTIFICADO_STATUS_ID = 1;
+const CARGADO_ERP_STATUS_ID = 20;
 
 interface Props {
   isOpen: boolean;
@@ -41,9 +42,7 @@ const ModalActionsWalletPayments = ({ isOpen, onClose, selectedRows, onSuccess }
       window.open(res.url, "_blank");
       message.success("Plano descargado correctamente");
       onClose();
-      const allIdentificado = selectedRows.every(
-        (row) => row.id_status === IDENTIFICADO_STATUS_ID
-      );
+      const allIdentificado = selectedRows.every((row) => row.id_status === IDENTIFICADO_STATUS_ID);
       if (allIdentificado) {
         setIsConfirmOpen(true);
       }
@@ -92,8 +91,8 @@ const ModalActionsWalletPayments = ({ isOpen, onClose, selectedRows, onSuccess }
       return;
     }
 
-    if (selectedRows[0].id_status !== IDENTIFICADO_STATUS_ID) {
-      message.warning("El pago seleccionado debe estar en estado Identificado");
+    if (selectedRows[0].id_status !== CARGADO_ERP_STATUS_ID) {
+      message.warning("El pago seleccionado debe estar en estado Cargado al ERP");
       return;
     }
 


### PR DESCRIPTION
…argado ERP

Change the modal payment validation logic to require payments to be in 'Cargado al ERP' status instead of 'Identificado' status before allowing further processing. Also added the new CARGADO_ERP_STATUS_ID constant (20) to support this updated workflow.