### PR TITLE
fix(applyTab): refine clientUUID prop usage and improve error handling

### DIFF
--- a/src/modules/clients/containers/apply-tab/apply-tab.tsx
+++ b/src/modules/clients/containers/apply-tab/apply-tab.tsx
@@ -75,7 +75,7 @@ const ApplyTab: React.FC<IApplyTabProps> = ({
   className,
   defaultPositionDragModal,
   isInApplyModule = false,
-  clientUUID,
+  clientUUID
 }) => {
   const { ID: projectId } = useAppStore((state) => state.selectedProject);
   const params = useParams();
@@ -124,10 +124,10 @@ const ApplyTab: React.FC<IApplyTabProps> = ({
   };
 
   useEffect(() => {
-    if (applicationData?.summary.url_attachment) {
-      setUseDefaultFileInEvidence(true);
+    if (isModalOpen.selected === 1) {
+      setUseDefaultFileInEvidence(Boolean(applicationData?.summary?.url_attachment));
     }
-  }, [applicationData?.summary, isModalOpen.selected]);
+  }, [isModalOpen.selected]);
 
   const handleCancel = () => {
     setIsModalAddToTableOpen({
@@ -232,7 +232,9 @@ const ApplyTab: React.FC<IApplyTabProps> = ({
       mutate();
       setIsModalOpen({ selected: 0 });
     } catch (error) {
-      showMessage("error", "Ha ocurrido un error al guardar la aplicación");
+      const errormessage =
+        error instanceof Error ? error.message : "Ha ocurrido un error al guardar la aplicación";
+      showMessage("error", errormessage);
     }
     setLoadingSave(false);
     setPreventRevalidation(false);
@@ -384,7 +386,6 @@ const ApplyTab: React.FC<IApplyTabProps> = ({
     }
     setLoadingRequest(false);
   };
-
 
   const isConfirmDisabled = useMemo(() => {
     if (useDefaultFileInEvidence) {


### PR DESCRIPTION
This pull request includes several improvements and fixes to the `ApplyTab` component in `apply-tab.tsx`, focusing on better error handling, logic refinement for modal behavior, and minor code cleanup. The most significant changes are grouped below:

**Logic and Behavior Improvements:**

* Updated the effect that sets `useDefaultFileInEvidence` to only trigger when the modal is open and to use a boolean conversion for clarity and correctness. This ensures the default file is only set when appropriate.

**Error Handling Enhancements:**

* Improved error messaging in the save handler by displaying the actual error message if available, rather than always showing a generic message.

**Code Cleanup:**

* Removed an unnecessary trailing comma from the props list for consistency.
* Removed an extra blank line for code style consistency.