### PR TITLE
Staging

### DIFF
--- a/src/modules/banks/components/modal-actions-wallet-payments/modal-actions-wallet-payments.tsx
+++ b/src/modules/banks/components/modal-actions-wallet-payments/modal-actions-wallet-payments.tsx
@@ -15,6 +15,7 @@ import { ISingleBank } from "@/types/banks/IBanks";
 import "./modal-actions-wallet-payments.scss";
 
 const IDENTIFICADO_STATUS_ID = 1;
+const CARGADO_ERP_STATUS_ID = 20;
 
 interface Props {
   isOpen: boolean;
@@ -41,9 +42,7 @@ const ModalActionsWalletPayments = ({ isOpen, onClose, selectedRows, onSuccess }
       window.open(res.url, "_blank");
       message.success("Plano descargado correctamente");
       onClose();
-      const allIdentificado = selectedRows.every(
-        (row) => row.id_status === IDENTIFICADO_STATUS_ID
-      );
+      const allIdentificado = selectedRows.every((row) => row.id_status === IDENTIFICADO_STATUS_ID);
       if (allIdentificado) {
         setIsConfirmOpen(true);
       }
@@ -92,8 +91,8 @@ const ModalActionsWalletPayments = ({ isOpen, onClose, selectedRows, onSuccess }
       return;
     }
 
-    if (selectedRows[0].id_status !== IDENTIFICADO_STATUS_ID) {
-      message.warning("El pago seleccionado debe estar en estado Identificado");
+    if (selectedRows[0].id_status !== CARGADO_ERP_STATUS_ID) {
+      message.warning("El pago seleccionado debe estar en estado Cargado al ERP");
       return;
     }
 


### PR DESCRIPTION
This pull request updates the status handling logic in the `ModalActionsWalletPayments` component to align with new business requirements. The main change is the introduction and usage of a new status constant for "Cargado al ERP", replacing the previous "Identificado" status in relevant checks and messages.

**Status handling updates:**

* Added a new constant `CARGADO_ERP_STATUS_ID` with a value of 20 to represent the "Cargado al ERP" status.
* Updated the validation logic to check for `CARGADO_ERP_STATUS_ID` instead of `IDENTIFICADO_STATUS_ID`, and changed the warning message to indicate the payment must be in "Cargado al ERP" status.

**Code cleanup:**

* Minor formatting change to the `allIdentificado` variable assignment for improved readability.