### PR TITLE
Render ticket separators in chat thread

### DIFF
--- a/src/hooks/useTicketMessages.ts
+++ b/src/hooks/useTicketMessages.ts
@@ -10,11 +10,11 @@ interface UseTicketMessagesParams {
 
 const useTicketMessages = ({ ticketId, limit = 20, page }: UseTicketMessagesParams) => {
   const params = new URLSearchParams();
-  params.append('limit', limit.toString());
+  params.append("limit", limit.toString());
   if (page !== undefined) {
-    params.append('page', page.toString());
+    params.append("page", page.toString());
   }
-  
+
   const { data, isLoading, error, mutate } = useSWR<IChatData>(
     `/whatsapp-messages/ticket/${ticketId}?${params.toString()}`,
     () => getOneTicket(ticketId, limit, page)

--- a/src/modules/chat/containers/chat-thread.tsx
+++ b/src/modules/chat/containers/chat-thread.tsx
@@ -58,6 +58,29 @@ export default function ChatThread({
     return map;
   }, [ticketMessages]);
 
+  const ticketSeparatorByMessageId = useMemo(() => {
+    const map = new Map<string, string>();
+    let lastTicketId: string | null = null;
+
+    for (const m of ticketMessages) {
+      const ticketId = m.ticket?.id || conversation.id;
+      if (!ticketId || ticketId === lastTicketId) continue;
+
+      const closedBy = m.ticket?.closedBy?.name;
+      const closedAt = m.ticket?.closedAt ? dayjs(m.ticket.closedAt).format("DD/MM/YYYY") : null;
+      const isClosed = m.ticket?.status === "CLOSED";
+
+      const label = isClosed
+        ? `Ticket "${m.ticket?.subject || ""}" - Cerrado${closedBy ? ` por ${closedBy}` : ""}${closedAt ? ` ${closedAt}` : ""}`
+        : `Ticket "${m.ticket?.subject || ""}" - Abierto`;
+
+      map.set(m.id, label);
+      lastTicketId = ticketId;
+    }
+
+    return map;
+  }, [ticketMessages, conversation.id]);
+
   const messagesByWaId = useMemo(() => {
     const map = new Map<string, IMessage>();
     for (const m of ticketMessages) {
@@ -257,15 +280,23 @@ export default function ChatThread({
             <div key={`group-${day}`} className="space-y-6">
               <DateSeparator date={messages[0].timestamp} />
               {messages.map((m) => (
-                <BubbleMessage
-                  key={m.id}
-                  message={m}
-                  customerName={conversation.customer}
-                  templateMap={templateMap}
-                  messagesByWaId={messagesByWaId}
-                  onPreviewImage={setPreviewImage}
-                  onScrollToBottom={scrollToBottom}
-                />
+                <div key={m.id} className="space-y-3">
+                  {ticketSeparatorByMessageId.has(m.id) ? (
+                    <div className="my-2 flex items-center gap-3 text-[13px] text-[#62687A]">
+                      <div className="h-px flex-1 bg-[#D6D8DE]" />
+                      <span className="whitespace-nowrap">{ticketSeparatorByMessageId.get(m.id)}</span>
+                      <div className="h-px flex-1 bg-[#D6D8DE]" />
+                    </div>
+                  ) : null}
+                  <BubbleMessage
+                    message={m}
+                    customerName={conversation.customer}
+                    templateMap={templateMap}
+                    messagesByWaId={messagesByWaId}
+                    onPreviewImage={setPreviewImage}
+                    onScrollToBottom={scrollToBottom}
+                  />
+                </div>
               ))}
             </div>
           ))}

--- a/src/types/chat/IChat.ts
+++ b/src/types/chat/IChat.ts
@@ -50,6 +50,17 @@ export interface IMessage {
   templateName?: string;
   templateData?: any;
   metadata: any;
+  ticket?: {
+    id: string;
+    subject: string;
+    status: "CLOSED" | "OPEN";
+    closedAt: string | null;
+    closedBy?: {
+      id: string;
+      name: string;
+      email: string;
+    };
+  };
 }
 
 interface IPagination {


### PR DESCRIPTION
Show ticket boundary labels in the chat message list and include ticket metadata in message types. Adds a memoized ticketSeparatorByMessageId map used to render a separator (with ticket subject, status and closed info) before the first message of each ticket; wraps BubbleMessage so separators appear inline. Also extends IMessage with a ticket object (id, subject, status, closedAt, closedBy) and includes a small formatting cleanup in useTicketMessages.