### PR TITLE
Add chat status and mark closed conversations

### DIFF
--- a/src/modules/chat/components/all-chats/AllChats.tsx
+++ b/src/modules/chat/components/all-chats/AllChats.tsx
@@ -95,10 +95,7 @@ export default function AllChats({
         { revalidate: false }
       );
 
-      if (
-        activeConversation?.id !== data.ticketId &&
-        data.message.direction === "INBOUND"
-      ) {
+      if (activeConversation?.id !== data.ticketId && data.message.direction === "INBOUND") {
         setUnreadTickets((prev) => new Set(prev).add(data.ticketId));
       }
     });
@@ -266,6 +263,7 @@ export default function AllChats({
             conversations.map((c) => {
               const isActive = c.id === activeConversation?.id;
               const isSelected = selectedIds.includes(c.id);
+              console.log(c)
               return (
                 <li
                   key={c.id}
@@ -283,8 +281,10 @@ export default function AllChats({
                   />
                   <div className="ml-6 min-w-0 flex-1">
                     <div className="flex w-full items-baseline gap-2">
-                      <p className="min-w-0 flex-1 truncate text-sm font-semibold">
-                        {c.client_name}
+                      <p className={`min-w-0 flex-1 truncate text-sm font-semibold ${c.status === "CLOSED" ? "text-[#72737f]" : ""}`}>
+                        {c.status === "CLOSED"
+                          ? `${c.client_name || ""} - Cerrado ⚠️ `
+                          : `${c.client_name || ""}`}
                       </p>
                       <span className="shrink-0 w-12 md:w-14 text-right text-xs text-muted-foreground tabular-nums whitespace-nowrap">
                         {formatChatDate(c.lastMessageAt)}

--- a/src/modules/chat/lib/mock-data.ts
+++ b/src/modules/chat/lib/mock-data.ts
@@ -42,6 +42,7 @@ export type Conversation = {
   lastMessageAt: string;
   timeline: TimelineItem[];
   countMessages: number;
+  status: "OPEN" | "CLOSED";
 };
 
 export function formatRelativeTime(iso: string) {

--- a/src/modules/chat/lib/ticketToConversation.ts
+++ b/src/modules/chat/lib/ticketToConversation.ts
@@ -25,6 +25,7 @@ export function ticketToConversation(ticket: ITicket, unreadTicketsSet: Set<stri
     updatedAt: ticket.updatedAt,
     tags: ticket.tags ? [ticket.tags] : [],
     timeline: [],
+    status: ticket.status,
     metrics: { totalVencido: 0, ultimoPago: "" },
     hasUnreadUpdate:
       (ticket.lastViewedAt === null && ticket.lastMessage?.direction === "INBOUND") ||

--- a/src/types/chat/IChat.ts
+++ b/src/types/chat/IChat.ts
@@ -22,7 +22,7 @@ export interface ITicket {
   customerId: string;
   clientName: string;
   assignedTo: string | null;
-  status: string;
+  status: "OPEN" | "CLOSED";
   priority: string;
   subject: string;
   tags: string | null;


### PR DESCRIPTION
Expose ticket status through the chat types and UI: ITicket.status now uses a union ("OPEN" | "CLOSED"), Conversation includes a status field, and ticketToConversation maps ticket.status into the conversation. The AllChats UI now visually indicates CLOSED conversations with a muted text style and appends " - Cerrado ⚠️" to the client name. Also minor cleanup of a conditional formatting and a temporary console.log was added in the conversation rendering.