### PR TITLE
Support extraFields and modal-managed chat closing

### DIFF
--- a/src/components/molecules/modals/ModalEnterProcess/ModalEnterProcess.tsx
+++ b/src/components/molecules/modals/ModalEnterProcess/ModalEnterProcess.tsx
@@ -15,6 +15,7 @@ import FooterButtons from "@/components/atoms/FooterButtons/FooterButtons";
 import AttachmentList from "@/components/molecules/modals/SendEmailModal/components/AttachmentList";
 import { Header } from "@/components/molecules/modals/SendEmailModal/components/Header";
 import { CustomButton } from "@/components/molecules/modals/SendEmailModal/components/CustomButton";
+import { GenericResponse } from "@/types/global/IGlobal";
 import {
   addCommentHistoricAction,
   getManagementTypes,
@@ -28,11 +29,27 @@ interface Props {
   isOpen: boolean;
   onClose: () => void;
   clientId?: string;
+  initialValues?: {
+    managementTypeId?: number;
+    managementStatusId?: number;
+    contactId?: number;
+  };
+  lockSelects?: boolean;
+  extraFields?: Record<string, string | number | boolean>;
+  onSuccess?: (response: GenericResponse) => void;
 }
 
 type ViewMode = "default" | "minimized" | "maximized";
 
-const ModalEnterProcess: React.FC<Props> = ({ isOpen, onClose, clientId }) => {
+const ModalEnterProcess: React.FC<Props> = ({
+  isOpen,
+  onClose,
+  clientId,
+  initialValues,
+  lockSelects = false,
+  extraFields,
+  onSuccess
+}) => {
   const { ID: projectId } = useAppStore((state) => state.selectedProject);
 
   /* -------------------- Header State -------------------- */
@@ -63,9 +80,9 @@ const ModalEnterProcess: React.FC<Props> = ({ isOpen, onClose, clientId }) => {
     setModalSize({ width: 660, height: 520 });
     setMask(false);
 
-    setManagementType(null);
-    setManagementStatus(null);
-    setContactId(null);
+    setManagementType(initialValues?.managementTypeId ?? null);
+    setManagementStatus(initialValues?.managementStatusId ?? null);
+    setContactId(initialValues?.contactId ?? null);
     setEditorState(EditorState.createEmpty());
     setAttachments([]);
 
@@ -77,10 +94,10 @@ const ModalEnterProcess: React.FC<Props> = ({ isOpen, onClose, clientId }) => {
           getContactsByClient(clientId, projectId)
         ]);
 
-        setManagementTypes(typesRes.data || []);
-        setManagementStatuses(statusRes.data || []);
+        const nextManagementTypes = typesRes.data || [];
+        const nextManagementStatuses = statusRes.data || [];
         // concatenamos nombre, apellido, teléfono y correo
-        const mappedContacts = (contactsRes.data || []).map(
+        const nextContacts = (contactsRes.data || []).map(
           (c: {
             CONTACT_NAME: any;
             CONTACT_LASTNAME: any;
@@ -91,14 +108,33 @@ const ModalEnterProcess: React.FC<Props> = ({ isOpen, onClose, clientId }) => {
             label: `${c.CONTACT_NAME} ${c.CONTACT_LASTNAME} - ${c.CONTACT_PHONE} - ${c.CONTACT_EMAIL}`
           })
         );
-        setContacts(mappedContacts);
+
+        setManagementTypes(nextManagementTypes);
+        setManagementStatuses(nextManagementStatuses);
+        setContacts(nextContacts);
+
+        if (lockSelects) {
+          setManagementType(initialValues?.managementTypeId ?? nextManagementTypes[0]?.id ?? null);
+          setManagementStatus(
+            initialValues?.managementStatusId ?? nextManagementStatuses[0]?.id ?? null
+          );
+          setContactId(initialValues?.contactId ?? nextContacts[0]?.ID ?? null);
+        }
       } catch (error) {
         message.error("Error cargando datos de gestión");
       }
     };
 
     loadData();
-  }, [isOpen, clientId, projectId]);
+  }, [
+    isOpen,
+    clientId,
+    projectId,
+    initialValues?.managementTypeId,
+    initialValues?.managementStatusId,
+    initialValues?.contactId,
+    lockSelects
+  ]);
 
   /* -------------------- Helpers -------------------- */
   const hasContent = () => editorState.getCurrentContent().getPlainText().trim().length > 0;
@@ -118,18 +154,26 @@ const ModalEnterProcess: React.FC<Props> = ({ isOpen, onClose, clientId }) => {
 
     setLoading(true);
     try {
-      await addCommentHistoricAction(
+      const response = await addCommentHistoricAction(
         clientId,
         projectId,
         editorState.getCurrentContent().getPlainText(),
         managementType,
         managementStatus,
         contactId ?? undefined,
-        attachments[0] ?? undefined
+        attachments[0] ?? undefined,
+        extraFields
       );
 
-      message.success("Gestión registrada correctamente");
-      onClose();
+      const isSuccess = response.success ?? response.data === true;
+      if (isSuccess) {
+        message.success("Gestión registrada correctamente");
+        onSuccess?.(response);
+        onClose();
+        return;
+      }
+
+      message.error("Error al registrar la gestión");
     } catch (error) {
       message.error("Error al registrar la gestión");
     } finally {
@@ -177,6 +221,7 @@ const ModalEnterProcess: React.FC<Props> = ({ isOpen, onClose, clientId }) => {
               placeholder="Tipo de gestión"
               value={managementType}
               onChange={setManagementType}
+              disabled={lockSelects}
               style={{ width: "100%" }}
               options={managementTypes.map((t) => ({
                 value: t.id, // <- usar id en minúscula
@@ -200,6 +245,7 @@ const ModalEnterProcess: React.FC<Props> = ({ isOpen, onClose, clientId }) => {
               value={contactId}
               onChange={setContactId}
               allowClear
+              disabled={lockSelects}
               style={{ width: "100%" }}
               options={contacts.map((c) => {
                 const mainText = `${c.CONTACT_NAME} ${c.CONTACT_LASTNAME} - ${c.CONTACT_PHONE}`;

--- a/src/hooks/useChatTickets.ts
+++ b/src/hooks/useChatTickets.ts
@@ -8,13 +8,21 @@ interface UseChatTicketsParams {
   page?: number;
   search?: string;
   isRead?: boolean;
+  justOpen?: boolean;
 }
 
-const useChatTickets = ({ limit = 200, page = 1, search, isRead }: UseChatTicketsParams = {}) => {
+const useChatTickets = ({ limit = 200, page = 1, search, isRead, justOpen }: UseChatTicketsParams = {}) => {
   const params = [`limit=${limit}`, `page=${page}`];
 
   if (search) {
     params.push(`searchQuery=${search}`);
+  }
+  if (typeof justOpen === "boolean") {
+    if (justOpen) {
+      params.push(`is_active=1`);
+    } else {
+      params.push(`is_active=0`);
+    }
   }
   if (typeof isRead === "boolean") {
     if (isRead) {

--- a/src/modules/chat/components/all-chats/AllChats.tsx
+++ b/src/modules/chat/components/all-chats/AllChats.tsx
@@ -55,7 +55,8 @@ export default function AllChats({
   } = useChatTickets({
     page,
     search: debouncedQuery,
-    isRead: activeTab === "abiertos" ? true : activeTab === "no-leidos" ? false : undefined
+    isRead: activeTab === "abiertos" ? true : activeTab === "no-leidos" ? false : undefined,
+    justOpen: activeTab === "abiertos" ? true : undefined
   });
 
   const { isConnected, subscribeToTicketUpdates } = useSocket();
@@ -263,7 +264,7 @@ export default function AllChats({
             conversations.map((c) => {
               const isActive = c.id === activeConversation?.id;
               const isSelected = selectedIds.includes(c.id);
-              console.log(c)
+              console.log(c);
               return (
                 <li
                   key={c.id}
@@ -281,7 +282,9 @@ export default function AllChats({
                   />
                   <div className="ml-6 min-w-0 flex-1">
                     <div className="flex w-full items-baseline gap-2">
-                      <p className={`min-w-0 flex-1 truncate text-sm font-semibold ${c.status === "CLOSED" ? "text-[#72737f]" : ""}`}>
+                      <p
+                        className={`min-w-0 flex-1 truncate text-sm font-semibold ${c.status === "CLOSED" ? "text-[#72737f]" : ""}`}
+                      >
                         {c.status === "CLOSED"
                           ? `${c.client_name || ""} - Cerrado ⚠️ `
                           : `${c.client_name || ""}`}

--- a/src/modules/chat/containers/chat-details.tsx
+++ b/src/modules/chat/containers/chat-details.tsx
@@ -7,7 +7,7 @@ import { Flex, message, Spin } from "antd";
 import { CaretDoubleRight, Copy } from "@phosphor-icons/react";
 
 import { deleteContact } from "@/services/contacts/contacts";
-import { closeWhatsAppTicket, sendTemplate } from "@/services/chat/chat";
+import { sendTemplate } from "@/services/chat/chat";
 
 import useClientSegmentationDetail from "@/hooks/useClientSegmentationDetail";
 import { cn } from "@/utils/utils";
@@ -25,11 +25,12 @@ import ChatActions from "@/modules/chat/components/chat-actions";
 import AddClientModal from "../components/contacts-tab-modal";
 import TemplateDialog from "../components/template-dialog/template-dialog";
 import ModalGeneratePaymentLink from "../components/modalGeneratePaymentLink/ModalGeneratePaymentLink";
-import { ModalConfirmAction } from "@/components/molecules/modals/ModalConfirmAction/ModalConfirmAction";
+import ModalEnterProcess from "@/components/molecules/modals/ModalEnterProcess/ModalEnterProcess";
 
 import { IAddClientForm } from "@/types/chat/IChat";
 
 import type { Conversation } from "@/modules/chat/lib/mock-data";
+import { ModalConfirmAction } from "@/components/molecules/modals/ModalConfirmAction/ModalConfirmAction";
 
 type Props = {
   conversation: Conversation;
@@ -101,20 +102,6 @@ export default function ChatDetails({
       mutateTickets();
     } catch (error) {
       message.error("Error al inactivar el contacto");
-    } finally {
-      setIsActionLoading(false);
-    }
-  };
-
-  const handleCloseChat = async () => {
-    setIsActionLoading(true);
-    try {
-      await closeWhatsAppTicket(conversation.id);
-      message.success("Chat cerrado exitosamente");
-      handleCloseModals();
-      mutateTickets();
-    } catch {
-      message.error("Error al cerrar el chat");
     } finally {
       setIsActionLoading(false);
     }
@@ -320,13 +307,22 @@ export default function ChatDetails({
           okLoading={isActionLoading}
         />
 
-        <ModalConfirmAction
+        <ModalEnterProcess
           isOpen={isModalOpen.selected === 3}
-          onClose={() => handleCloseModals()}
-          onOk={handleCloseChat}
-          title="¿Está seguro de cerrar este chat?"
-          okText="Cerrar chat"
-          okLoading={isActionLoading}
+          onClose={handleCloseModals}
+          clientId={clientDetails?.client.uuid || ""}
+          initialValues={{
+            contactId: clientDetails?.client.contact_id,
+            managementTypeId: 4, // Gestión de cierre de chat
+          }}
+          lockSelects
+          extraFields={{
+            ticketId: conversation.id,
+            close_ticket: true
+          }}
+          onSuccess={() => {
+            mutateTickets();
+          }}
         />
       </div>
 

--- a/src/services/accountingAdjustment/accountingAdjustment.ts
+++ b/src/services/accountingAdjustment/accountingAdjustment.ts
@@ -362,7 +362,8 @@ export const addCommentHistoricAction = async (
   management_type_id: number,
   management_status_id: number,
   contact_id?: number,
-  file?: File
+  file?: File,
+  extraFields?: Record<string, string | number | boolean>
 ): Promise<GenericResponse> => {
   const formData = new FormData();
 
@@ -377,6 +378,12 @@ export const addCommentHistoricAction = async (
   if (file) {
     const correctedFile = getCorrectMimeType(file);
     formData.append("file", correctedFile);
+  }
+
+  if (extraFields) {
+    Object.entries(extraFields).forEach(([key, value]) => {
+      formData.append(key, String(value));
+    });
   }
 
   try {


### PR DESCRIPTION
Enhance ModalEnterProcess to accept initialValues, lockSelects, extraFields and onSuccess; import GenericResponse and use initial values when opening the modal, optionally lock selects, and pass extraFields to the submission call. Update addCommentHistoricAction signature to accept extraFields and append them to FormData. Adjust submit handling to inspect the API response, call onSuccess and show success/error messages. Add justOpen param to useChatTickets to toggle is_active in query and pass it from AllChats when the "abiertos" tab is active. Replace the previous direct chat-close flow in chat-details with a ModalEnterProcess instance (pre-filling managementTypeId and extraFields to trigger ticket close) and remove the old close flow. Minor UI/formatting tweaks and small logging fix.