### PR TITLE
Add Excel log download to Apply Tab

### DIFF
--- a/src/modules/clients/containers/apply-tab/Modals/ModalGenerateActionApplyTab/ModalGenerateActionApplyTab.tsx
+++ b/src/modules/clients/containers/apply-tab/Modals/ModalGenerateActionApplyTab/ModalGenerateActionApplyTab.tsx
@@ -13,6 +13,7 @@ interface Props {
   handleOpenModal: (modalNumber: number) => void;
   selectedRows?: IApplyTabRecord[];
   downloadLog?: () => void;
+  downloadExcelLog?: () => void;
 }
 
 export const ModalGenerateActionApplyTab = ({
@@ -20,7 +21,8 @@ export const ModalGenerateActionApplyTab = ({
   onClose,
   handleOpenModal,
   selectedRows,
-  downloadLog
+  downloadLog,
+  downloadExcelLog
 }: Props) => {
   return (
     <Modal
@@ -55,6 +57,11 @@ export const ModalGenerateActionApplyTab = ({
           onClick={downloadLog}
           icon={<DownloadSimple size={20} />}
           title="Descargar Log"
+        />
+        <ButtonGenerateAction
+          onClick={downloadExcelLog}
+          icon={<DownloadSimple size={20} />}
+          title="Descargar excel log"
         />
         <ButtonGenerateAction
           onClick={() => {

--- a/src/modules/clients/containers/apply-tab/apply-tab.tsx
+++ b/src/modules/clients/containers/apply-tab/apply-tab.tsx
@@ -11,6 +11,7 @@ import { useAppStore } from "@/lib/store/store";
 import { extractSingleParam } from "@/utils/utils";
 import {
   addItemsToTable,
+  getApplicationsExcelLog,
   markPaymentsAsUnidentified,
   removeItemsFromTable,
   removeMultipleRows,
@@ -358,6 +359,21 @@ const ApplyTab: React.FC<IApplyTabProps> = ({
     }
   };
 
+  const handleDownloadExcelLog = async () => {
+    try {
+      const data = await getApplicationsExcelLog(projectId, clientId);
+
+      if (data?.excel_url) {
+        window.open(data.excel_url, "_blank");
+        setIsModalOpen({ selected: 0 });
+      } else {
+        showMessage("error", "No se pudo obtener el excel log");
+      }
+    } catch (error) {
+      showMessage("error", "Error al descargar el excel log");
+    }
+  };
+
   const deselectAllRows = () => {
     setSelectedRowKeys({
       invoices: [],
@@ -652,6 +668,7 @@ const ApplyTab: React.FC<IApplyTabProps> = ({
         handleOpenModal={handleOpenModal}
         selectedRows={selectedRows}
         downloadLog={handleDownloadLog}
+        downloadExcelLog={handleDownloadExcelLog}
       />
 
       <ModalConfirmAction

--- a/src/services/applyTabClients/applyTabClients.ts
+++ b/src/services/applyTabClients/applyTabClients.ts
@@ -394,3 +394,16 @@ export const updatePrompt = async (id: number, prompt: string, updatedBy: string
     throw error;
   }
 };
+
+export const getApplicationsExcelLog = async (project_id: number, clientUUID: string) => {
+  try {
+    const response: GenericResponse<{ excel_url: string; file_name: string }> = await API.get(
+      `${config.API_HOST}/paymentApplication/applications/excel?project_id=${project_id}&clientUUID=${clientUUID}`
+    );
+
+    return response.data;
+  } catch (error) {
+    console.error("error getApplicationsExcelLog", error);
+    throw error;
+  }
+};


### PR DESCRIPTION
Expose an endpoint and UI flow to download an Excel log for applications. Added getApplicationsExcelLog service to call the API, a handleDownloadExcelLog handler in apply-tab to open the returned excel_url, and wired it into ModalGenerateActionApplyTab via a new downloadExcelLog prop and button. Includes basic error handling and user feedback when the download fails.