### PR TITLE
feat: add dropdown menu for order actions with novelty view

### DIFF
--- a/src/modules/commerce/components/orders-view-table/orders-view-table.scss
+++ b/src/modules/commerce/components/orders-view-table/orders-view-table.scss
@@ -42,4 +42,32 @@
     .buttonSeeProject {
         background-color: $dark-gray;
     }
+
+    .dotsBtn {
+        background-color: $background;
+        border: 1px solid transparent;
+        width: 24px;
+        height: 24px;
+        padding: 0;
+        border-radius: 4px;
+        margin-left: 1rem;
+        padding: 0;
+
+        &:hover {
+            border: 1px solid $black;
+            background-color: $background !important;
+        }
+    }
+}
+
+.buttonNoBorder {
+    background-color: $background !important;
+    border: none !important;
+    width: 100%;
+    justify-content: flex-start !important;
+
+    &:hover {
+        outline: 1px solid $black;
+        color: $black !important;
+    }
 }

--- a/src/modules/commerce/components/orders-view-table/orders-view-table.tsx
+++ b/src/modules/commerce/components/orders-view-table/orders-view-table.tsx
@@ -1,9 +1,9 @@
-import { Dispatch, Key, SetStateAction, useState } from "react";
-import { Button, Flex, Table, TableProps, Typography } from "antd";
-import { Eye } from "phosphor-react";
-import { WarningDiamond } from "@phosphor-icons/react";
+import { Dispatch, Key, ReactNode, SetStateAction, useState } from "react";
+import { Button, Dropdown, Table, TableProps, Typography } from "antd";
+import { DotsThreeVertical, Eye, WarningCircle, WarningDiamond } from "@phosphor-icons/react";
 
 import { useAppStore } from "@/lib/store/store";
+import { useModalDetail } from "@/context/ModalContext";
 import { formatDateDMY, formatTimeAgo } from "@/utils/utils";
 
 import OrderTrackingModal from "@/components/molecules/modals/OrderTrackingModal";
@@ -44,6 +44,7 @@ const OrdersViewTable = ({
 }: PropsOrdersViewTable) => {
   const setDraftInfo = useAppStore((state) => state.setDraftInfo);
   const formatMoney = useAppStore((state) => state.formatMoney);
+  const { openModal } = useModalDetail();
 
   const [selectedOrder, setSelectedOrder] = useState<number | null>(null);
   const [currentWarehouseId, setCurrentWarehouseId] = useState<number | null>(null);
@@ -258,25 +259,71 @@ const OrdersViewTable = ({
       key: "buttonOpenModal",
       width: 64,
       dataIndex: "",
-      render: (_, row) => (
-        <Flex gap={8}>
-          <Button
-            disabled={row.order_status === "Pedidos en proceso"}
-            onClick={() => {
-              setSelectedOrder(row.id);
-              setCurrentWarehouseId(row.warehouseid);
-              setIsModalOpen(true);
-            }}
-            className="buttonSeeProject"
-            icon={<WarningDiamond size={"1.3rem"} />}
-          />
-          <Button
-            onClick={() => handleSeeDetail(row)}
-            className="buttonSeeProject"
-            icon={<Eye size={"1.3rem"} />}
-          />
-        </Flex>
-      )
+      render: (_, row) => {
+        const items = [
+          {
+            key: "verBodega",
+            label: (
+              <Button
+                disabled={row.order_status === "Pedidos en proceso"}
+                icon={<WarningDiamond size={20} />}
+                className="buttonNoBorder"
+                onClick={() => {
+                  setSelectedOrder(row.id);
+                  setCurrentWarehouseId(row.warehouseid);
+                  setIsModalOpen(true);
+                }}
+              >
+                Ver bodega
+              </Button>
+            )
+          },
+          {
+            key: "detalle",
+            label: (
+              <Button
+                icon={<Eye size={20} />}
+                className="buttonNoBorder"
+                onClick={() => handleSeeDetail(row)}
+              >
+                Detalle
+              </Button>
+            )
+          }
+        ];
+
+        if (row.incident_id !== null) {
+          items.push({
+            key: "verNovedad",
+            label: (
+              <Button
+                icon={<WarningCircle size={20} />}
+                className="buttonNoBorder"
+                onClick={() => openModal("novelty", { noveltyId: row.incident_id as number })}
+              >
+                Ver novedad
+              </Button>
+            )
+          });
+        }
+
+        const customDropdown = (menu: ReactNode) => (
+          <div className="dropdownApplicationTable">{menu}</div>
+        );
+
+        return (
+          <Dropdown
+            dropdownRender={customDropdown}
+            menu={{ items }}
+            placement="bottomLeft"
+            trigger={["click"]}
+          >
+            <Button className="dotsBtn">
+              <DotsThreeVertical size={16} />
+            </Button>
+          </Dropdown>
+        );
+      }
     }
   ];
 

--- a/src/types/commerce/ICommerce.ts
+++ b/src/types/commerce/ICommerce.ts
@@ -373,6 +373,7 @@ export interface IOrder {
   last_datestamp: string | null;
   files: string | null;
   notification_id: number | null;
+  incident_id: number | null;
 }
 export interface IDraftOrder {
   id: number;


### PR DESCRIPTION
Replace the inline action buttons with a dropdown menu that includes options to view warehouse, order detail, and (if incident exists) novelty details. This improves UI compactness and adds incident access.
This pull request updates the orders view table to improve user experience and add new functionality for handling order incidents. The main changes include adding a dropdown menu for order actions, supporting viewing order incidents, and updating styles to match the new UI elements.

**UI/UX Improvements:**

* Replaced the inline action buttons in the orders table with a dropdown menu (`Dropdown`) triggered by a new three-dots button (`DotsThreeVertical`), consolidating actions like "Ver bodega", "Detalle", and, if applicable, "Ver novedad" for each order. This makes the UI cleaner and more scalable.
* Added new SCSS classes `.dotsBtn` and `.buttonNoBorder` in `orders-view-table.scss` to style the dropdown trigger and menu items, ensuring consistent appearance and better hover feedback for the new UI components.

**Incident Handling:**

* Added support for displaying a "Ver novedad" action in the dropdown if an order has an associated incident (`incident_id`). This action opens the novelty modal via the `openModal` context. [[1]](diffhunk://#diff-5c1ab20cd8055b5308b51684b9a1591b5edfb1744695dab55b2fe8ab099e6c4eL261-R329) [[2]](diffhunk://#diff-5c1ab20cd8055b5308b51684b9a1591b5edfb1744695dab55b2fe8ab099e6c4eR47)
* Extended the `IOrder` interface to include an optional `incident_id` property, enabling the UI to conditionally show incident-related actions.

**Dependency and Import Updates:**

* Updated imports in `orders-view-table.tsx` to include new icons (`DotsThreeVertical`, `WarningCircle`) and the `Dropdown` component from Ant Design, as well as the `useModalDetail` context for modal handling.