### PR TITLE
fix(discounts): add optional chaining to pagination.totalPages and sa…

### DIFF
--- a/src/components/organisms/discounts/discount-package/table/DiscountPackageList.tsx
+++ b/src/components/organisms/discounts/discount-package/table/DiscountPackageList.tsx
@@ -37,7 +37,7 @@ export default function DiscountPackages({
       pagination={{
         pageSize: 25,
         showSizeChanger: false,
-        total: res?.pagination.totalPages || 0,
+        total: res?.pagination?.totalPages || 0,
         onChange: handleChangePage,
         itemRender: TablePaginator,
         current: page

--- a/src/components/organisms/discounts/discount-rules/table/DiscountRulesTable.tsx
+++ b/src/components/organisms/discounts/discount-rules/table/DiscountRulesTable.tsx
@@ -38,7 +38,7 @@ export default function DiscountRulesTable({
       pagination={{
         pageSize: 25,
         showSizeChanger: false,
-        total: res?.pagination.totalPages || 0,
+        total: res?.pagination?.totalPages || 0,
         onChange: handleChangePage,
         itemRender: TablePaginator,
         current: page

--- a/src/components/organisms/discounts/hooks/useDiscount.ts
+++ b/src/components/organisms/discounts/hooks/useDiscount.ts
@@ -65,9 +65,8 @@ export default function useDiscount({ messageApi, tabActive }: Props) {
   );
 
   useEffect(() => {
-    if (res?.data) {
-      setData(res.data.map((item) => ({ ...item, checked: false })));
-    }
+    const items = res?.data;
+    setData(Array.isArray(items) ? items.map((item) => ({ ...item, checked: false })) : []);
   }, [res, tabActive]);
 
   const onChangeSearch = (e: ChangeEvent<HTMLInputElement>) => {


### PR DESCRIPTION
…fe data mapping
This pull request makes minor improvements to the handling of paginated data and data initialization in the discounts feature. The changes ensure safer access to nested properties and more robust handling of potentially undefined or non-array data.

**Pagination property safety:**

* Updated the pagination configuration in both `DiscountPackageList.tsx` and `DiscountRulesTable.tsx` to use optional chaining when accessing `res.pagination.totalPages`, preventing runtime errors if `pagination` is undefined. [[1]](diffhunk://#diff-2e6dc4ae62d2d73eed5e6c392b283bd6bbd14235d14fdbae9115cf03315c3006L40-R40) [[2]](diffhunk://#diff-ae637f52b7e891bee1b363fa6c8662182528feb17c265274b1f9386f82adcfcdL41-R41)

**Data initialization robustness:**

* Modified the data initialization in `useDiscount.ts` to check if `res.data` is an array before mapping, defaulting to an empty array if not, which prevents errors when the data is missing or not in the expected format.