### PR TITLE
Support multiple product discounts in cart item

### DIFF
--- a/src/modules/commerce/components/create-order-cart-item/create-order-cart-item.module.scss
+++ b/src/modules/commerce/components/create-order-cart-item/create-order-cart-item.module.scss
@@ -45,6 +45,11 @@
             font-weight: 800;
         }
 
+        &__qty {
+            font-size: 0.875rem;
+            font-weight: 400;
+        }
+
         .oldPrice {
             font-size: 0.875rem;
             font-weight: 500;

--- a/src/modules/commerce/components/create-order-cart-item/create-order-cart-item.tsx
+++ b/src/modules/commerce/components/create-order-cart-item/create-order-cart-item.tsx
@@ -8,21 +8,17 @@ import { formatNumber } from "@/utils/utils";
 import { useHandleProductsItems } from "../../hooks/create-order/handle-products-items.hook";
 import SimpleTag from "@/components/atoms/SimpleTag/SimpleTag";
 
-import { ISelectedProduct } from "@/types/commerce/ICommerce";
+import { Discount, DiscountItem, ISelectedProduct } from "@/types/commerce/ICommerce";
 
 import styles from "./create-order-cart-item.module.scss";
 import { useAppStore } from "@/lib/store/store";
-interface IproductDiscount {
-  discountPercentage: number;
-  subtotal: number;
-}
 export interface CreateOrderItemProps {
   product: ISelectedProduct;
   categoryName: string;
-  productDiscount?: IproductDiscount;
+  productsDiscount?: DiscountItem[];
 }
 
-const CreateOrderItem: FC<CreateOrderItemProps> = ({ product, categoryName, productDiscount }) => {
+const CreateOrderItem: FC<CreateOrderItemProps> = ({ product, categoryName, productsDiscount }) => {
   const {
     alreadySelectedProduct,
     handleDecrementQuantity,
@@ -30,6 +26,38 @@ const CreateOrderItem: FC<CreateOrderItemProps> = ({ product, categoryName, prod
     handleChangeQuantity
   } = useHandleProductsItems(product, categoryName);
   const { config } = useAppStore((state) => ({ config: state.config }));
+
+  const calculateDiscount: (
+    discount: DiscountItem[]
+  ) => { discountPercentage: number; subtotal: number; qty: number }[] = (
+    discount: DiscountItem[]
+  ) => {
+    const discountData = [];
+    for (const productDiscountItem of discount ?? []) {
+      const productDiscount = productDiscountItem.discount;
+      const discountSource = productDiscount?.primary;
+      const subtotal = config?.include_iva
+        ? discountSource?.new_price_taxes ||
+          discountSource?.new_price ||
+          productDiscountItem.price_taxes ||
+          productDiscountItem.price
+        : discountSource?.new_price || productDiscountItem.price;
+      console.log("discountSource", discountSource);
+      const productDiscountData = productDiscount
+        ? {
+            discountPercentage: discountSource?.discount_applied?.discount,
+            subtotal,
+            qty: productDiscountItem.quantity
+          }
+        : undefined;
+      if (productDiscountData) {
+        discountData.push(productDiscountData);
+      }
+    }
+    return discountData;
+  };
+
+  const discounts = calculateDiscount(productsDiscount || []);
 
   // Determinar el precio a mostrar según la configuración de IVA
   const price = config?.include_iva ? product.price_taxes || product.price : product.price;
@@ -70,15 +98,18 @@ const CreateOrderItem: FC<CreateOrderItemProps> = ({ product, categoryName, prod
       </h4>
 
       <div className={styles.price}>
-        {productDiscount ? (
+        {discounts.length ? (
           <Flex vertical gap={4}>
             <h5 className={styles.oldPrice}>${formatNumber(price ?? 0)}</h5>
-            <Flex gap={8} align="baseline">
-              <h5 className={styles.price__amount}>
-                ${formatNumber(productDiscount.subtotal ?? 0)}
-              </h5>
-              <p className={styles.discountPercentage}>-{productDiscount.discountPercentage}%</p>
-            </Flex>
+            {discounts.map((d, index) => (
+              <Flex key={index} gap={8} align="baseline">
+                <h5 className={styles.price__amount}>
+                  {discounts.length > 1 && <span className={styles.price__qty}>{d.qty} x </span>}$
+                  {formatNumber(d.subtotal ?? 0)}
+                </h5>
+                <p className={styles.discountPercentage}>-{String(d.discountPercentage || 0)}%</p>
+              </Flex>
+            ))}
           </Flex>
         ) : (
           <h5 className={styles.price}>${formatNumber(price ?? 0)}</h5>

--- a/src/modules/commerce/components/create-order-cart/create-order-cart.tsx
+++ b/src/modules/commerce/components/create-order-cart/create-order-cart.tsx
@@ -31,7 +31,7 @@ import { computeComplementRequirements } from "../../utils/complementCalculation
 import { ISelectedCategories } from "../../containers/create-order/create-order";
 
 import { ISelectType } from "@/types/clients/IClients";
-import { ISelectedProduct } from "@/types/commerce/ICommerce";
+import { Discount, DiscountItem, ISelectedProduct } from "@/types/commerce/ICommerce";
 
 import styles from "./create-order-cart.module.scss";
 export interface selectClientForm {
@@ -489,27 +489,15 @@ const CreateOrderCart: FC<CreateOrderCartProps> = ({ onClose }) => {
                 <p>SKUs: {category.products.length}</p>
               </Flex>
               {category.products.map((product) => {
-                const productDiscount = appliedDiscounts?.find(
+                const productsDiscount: DiscountItem[] = appliedDiscounts?.filter(
                   (discount: any) => discount.product_sku === product.SKU
-                )?.discount;
-                const discountSource = productDiscount?.primary ?? productDiscount?.secondary;
-                const subtotal = config?.include_iva
-                  ? discountSource?.new_price_taxes || discountSource?.new_price
-                  : discountSource?.new_price;
-
-                const productDiscountData =
-                  productDiscount && productDiscount.subtotalDiscount > 0
-                    ? {
-                        discountPercentage: discountSource?.discount_applied?.discount,
-                        subtotal
-                      }
-                    : undefined;
+                );
                 return (
                   <CreateOrderItem
                     key={`${product.id}-${product.SKU}`}
                     product={product}
                     categoryName={category.category}
-                    productDiscount={productDiscountData}
+                    productsDiscount={productsDiscount}
                   />
                 );
               })}


### PR DESCRIPTION
Allow multiple discounts per product and display quantities/percentages. CreateOrderItem now accepts productsDiscount (DiscountItem[]) and calculates per-discount subtotal/qty via a new helper, rendering each discounted line with qty and discount percent. CreateOrderCart filters appliedDiscounts by product SKU and passes the DiscountItem[] to the item. Also added a small SCSS rule for the price qty element and updated type imports.