### PR TITLE
Feat/upgrades and changes commerce flow

### DIFF
--- a/src/modules/commerce/components/create-order-cart/create-order-cart.tsx
+++ b/src/modules/commerce/components/create-order-cart/create-order-cart.tsx
@@ -183,13 +183,16 @@ const CreateOrderCart: FC<CreateOrderCartProps> = ({ onClose }) => {
     };
   }, [selectedCategories]);
 
-  const handleContinuePurchase = (options?: { skipOddSBVital?: boolean }) => {
+  const handleContinuePurchase = (options?: {
+    skipOddSBVital?: boolean;
+    skipOddGroup?: boolean;
+  }) => {
     if (projectId === GALDERMA_PROJECT_ID) {
       if (!options?.skipOddSBVital && hasOddSBVital) {
         setShowOddSBVitalModal(true);
         return;
       }
-      if (hasOddRestylaneGroupSum) {
+      if (!options?.skipOddGroup && hasOddRestylaneGroupSum) {
         setShowOddGroupModal(true);
         return;
       }
@@ -236,6 +239,11 @@ const CreateOrderCart: FC<CreateOrderCartProps> = ({ onClose }) => {
   const handleConfirmOddSBVital = () => {
     setShowOddSBVitalModal(false);
     handleContinuePurchase({ skipOddSBVital: true });
+  };
+
+  const handleConfirmOddGroup = () => {
+    setShowOddGroupModal(false);
+    handleContinuePurchase({ skipOddSBVital: true, skipOddGroup: true });
   };
 
   const handleCloseModal = () => {
@@ -680,17 +688,18 @@ const CreateOrderCart: FC<CreateOrderCartProps> = ({ onClose }) => {
       <ModalConfirmAction
         isOpen={showOddGroupModal}
         onClose={handleCloseOddGroupModal}
-        title="No puedes continuar con la compra"
+        onOk={handleConfirmOddGroup}
+        title="¿Está seguro que desea continuar?"
         content={
           <Flex vertical className={styles.confirmationModalContent} gap="0.5rem">
             <p className={styles.confirmationModalContent__totalLabel}>
               La suma total de unidades entre las referencias Restylane (VOLYME, REFYNE, LYFT LIDO,
-              LIDOCAINA, KYSSE, DEFYNE) debe ser un número par.
+              LIDOCAINA, KYSSE, DEFYNE) es impar. Se va a cobrar la unidad impar a precio full
             </p>
           </Flex>
         }
-        cancelText="Entendido"
-        hideOkButton
+        okText="Continuar"
+        cancelText="Cancelar"
       />
 
       <ModalConfirmAction

--- a/src/modules/commerce/containers/orders-view/orders-view.tsx
+++ b/src/modules/commerce/containers/orders-view/orders-view.tsx
@@ -165,7 +165,7 @@ export const OrdersView: FC = () => {
                 label: (
                   <LabelCollapse
                     status={order.status}
-                    quantity={order.count}
+                    quantity={order.pagination.total_count}
                     total={order.total}
                     color={order.color}
                   />


### PR DESCRIPTION
This pull request enhances the user experience and logic in the order cart flow, especially around handling odd-numbered product groupings for a specific project. It introduces improved modal behavior and messaging, and also makes a minor fix in the orders view display.

**Order cart modal improvements:**

* Added an extra option (`skipOddGroup`) to the `handleContinuePurchase` function to allow bypassing the odd Restylane group sum check after user confirmation.
* Introduced a new handler, `handleConfirmOddGroup`, to close the odd group modal and proceed with the purchase, skipping both odd SB Vital and odd group checks.
* Updated the odd group modal to include a confirmation action with clearer messaging, an explicit "Continue" button, and improved instructions for the user.

**Order view display fix:**

* Changed the `quantity` prop in `LabelCollapse` to use `order.pagination.total_count` instead of `order.count` for accurate order quantity display.