### PR TITLE
Add billing/sales Excel downloads and Firebase fix

### DIFF
--- a/firebase.ts
+++ b/firebase.ts
@@ -8,8 +8,8 @@ import {
   FIREBASE_PROJECT_ID,
   FIREBASE_STORAGE_BUCKET
 } from "@/utils/constants/globalConstants";
-import { initializeApp } from "firebase/app";
-import { getAuth, ParsedToken, signInWithCustomToken } from "firebase/auth";
+import { initializeApp } from "@firebase/app";
+import { getAuth, ParsedToken, signInWithCustomToken } from "@firebase/auth";
 import "firebase/auth";
 import "firebase/functions";
 import "firebase/firestore";

--- a/firebase.ts
+++ b/firebase.ts
@@ -8,8 +8,8 @@ import {
   FIREBASE_PROJECT_ID,
   FIREBASE_STORAGE_BUCKET
 } from "@/utils/constants/globalConstants";
-import { initializeApp } from "@firebase/app";
-import { getAuth, ParsedToken, signInWithCustomToken } from "@firebase/auth";
+import { initializeApp } from "firebase/app";
+import { getAuth, ParsedToken, signInWithCustomToken } from "firebase/auth";
 import "firebase/auth";
 import "firebase/functions";
 import "firebase/firestore";

--- a/src/modules/commerce/components/orders-generate-action-modal/orders-generate-action-modal.tsx
+++ b/src/modules/commerce/components/orders-generate-action-modal/orders-generate-action-modal.tsx
@@ -14,6 +14,8 @@ import { createAndDownloadTxt } from "@/utils/utils";
 import {
   changeOrderState,
   changeStatusOrder,
+  downloadBillingReportExcel,
+  downloadSalesDetailExcel,
   dowloadOrderCSV,
   downloadPartialOrderCSV
 } from "@/services/commerce/commerce";
@@ -50,6 +52,8 @@ export const OrdersGenerateActionModal = ({
 
   const [isErrorModalOpen, setIsErrorModalOpen] = useState(false);
   const [errorMessage, setErrorMessage] = useState("");
+  const [isBillingReportLoading, setIsBillingReportLoading] = useState(false);
+  const [isSalesDetailLoading, setIsSalesDetailLoading] = useState(false);
 
   const validateOrdersSelected = (): boolean => {
     if (ordersId.length === 0) {
@@ -94,6 +98,57 @@ export const OrdersGenerateActionModal = ({
       onClose();
     } catch (error) {
       console.error(error);
+    }
+  };
+
+  const downloadFileFromUrl = (url: string, filename: string) => {
+    const link = document.createElement("a");
+    link.href = url;
+    link.download = filename;
+    document.body.appendChild(link);
+    link.click();
+    link.remove();
+  };
+
+  const handleDownloadBillingReport = async () => {
+    setIsBillingReportLoading(true);
+    const hide = message.open({
+      type: "loading",
+      content: "Descargando informe de facturación...",
+      duration: 0
+    });
+    try {
+      const res = await downloadBillingReportExcel(projectId);
+      downloadFileFromUrl(res.url, res.filename);
+      showMessage("success", "Descarga exitosa");
+      onClose();
+    } catch (error) {
+      showMessage("error", error instanceof Error ? error.message : "Error al descargar el archivo");
+      console.error(error);
+    } finally {
+      hide();
+      setIsBillingReportLoading(false);
+    }
+  };
+
+  const handleDownloadSalesDetail = async () => {
+    setIsSalesDetailLoading(true);
+    const hide = message.open({
+      type: "loading",
+      content: "Descargando informe de ventas...",
+      duration: 0
+    });
+    try {
+      const res = await downloadSalesDetailExcel(projectId);
+      downloadFileFromUrl(res.url, res.filename);
+      showMessage("success", "Descarga exitosa");
+      onClose();
+    } catch (error) {
+      showMessage("error", error instanceof Error ? error.message : "Error al descargar el archivo");
+      console.error(error);
+    } finally {
+      hide();
+      setIsSalesDetailLoading(false);
     }
   };
 
@@ -177,6 +232,18 @@ export const OrdersGenerateActionModal = ({
             onClick={handleDownloadCSV}
             icon={<DownloadSimple size={16} />}
             title="Descargar CSV"
+          />
+          <ButtonGenerateAction
+            onClick={handleDownloadBillingReport}
+            icon={<DownloadSimple size={16} />}
+            title="Descargar informe de facturación"
+            disabled={isBillingReportLoading}
+          />
+          <ButtonGenerateAction
+            onClick={handleDownloadSalesDetail}
+            icon={<DownloadSimple size={16} />}
+            title="Descargar informe de ventas"
+            disabled={isSalesDetailLoading}
           />
           <ButtonGenerateAction
             onClick={handleDownloadPartialCsvShowQuestion}

--- a/src/services/commerce/commerce.ts
+++ b/src/services/commerce/commerce.ts
@@ -278,6 +278,34 @@ export const downloadPartialOrderCSV = async (orderId: number, sendToBackorder: 
     throw new Error("Error desconocido al descargar el CSV parcial");
   }
 };
+
+export const downloadBillingReportExcel = async (
+  projectId: number
+): Promise<{ url: string; filename: string }> => {
+  try {
+    const response: GenericResponse<{ url: string; filename: string }> = await API.get(
+      `/marketplace/projects/${projectId}/billing-report/excel`
+    );
+    return response.data;
+  } catch (error) {
+    console.error("Error fetching billing report excel:", error);
+    throw error;
+  }
+};
+
+export const downloadSalesDetailExcel = async (
+  projectId: number
+): Promise<{ url: string; filename: string }> => {
+  try {
+    const response: GenericResponse<{ url: string; filename: string }> = await API.get(
+      `/marketplace/projects/${projectId}/sales-detail/excel`
+    );
+    return response.data;
+  } catch (error) {
+    console.error("Error fetching sales detail excel:", error);
+    throw error;
+  }
+};
 export const getInventoriesWarehouse = async (projectId: number, orderIds: number[]) => {
   try {
     const form = {


### PR DESCRIPTION
Switch Firebase imports to the @firebase scoped packages. Add two new commerce service APIs (downloadBillingReportExcel, downloadSalesDetailExcel) that return presigned URLs and filenames. In OrdersGenerateActionModal add handlers, loading states, a download helper, and UI buttons to trigger billing report and sales detail downloads with loading/success/error messaging and proper cleanup.