### PR TITLE
Add item_uuid propagation and short UUID util

### DIFF
--- a/src/modules/commerce/components/create-order-checkout/create-order-checkout.tsx
+++ b/src/modules/commerce/components/create-order-checkout/create-order-checkout.tsx
@@ -25,6 +25,7 @@ import { ModalConfirmAction } from "@/components/molecules/modals/ModalConfirmAc
 import WompiModal from "@/components/organisms/paymentWeb/PaymentWebView";
 import ModalAttachEvidence from "@/components/molecules/modals/ModalEvidence/ModalAttachEvidence";
 import { GenericResponse } from "@/types/global/IGlobal";
+import { generateShortUuid } from "@/utils/utils";
 
 import ProductsDetailsAndDiscounts from "./products-details-and-discounts";
 import OrderShipmentConfirm from "./order-shipment-confirm/order-shipment-confirm";
@@ -90,6 +91,11 @@ export default function CheckoutPage() {
       try {
         const response = await confirmOrder(projectId, client?.id || "", payload);
         if (response.status === 200) {
+          response?.data?.discounts?.discountItems?.forEach((item) => {
+            if (!item.item_uuid) {
+              item.item_uuid = generateShortUuid();
+            }
+          });
           setConfirmOrderData(response.data);
         }
       } catch (error) {
@@ -126,8 +132,45 @@ export default function CheckoutPage() {
       .reduce((s, e) => s + (e.otherBonusCantidades[sku] ?? 0), 0);
 
   const buildOrderPayload = (isElectronicInvoicing: number): ICreateOrderData => {
+    // 1) Genera un uuid corto por cada línea de order_summary.products.
+    const summaryProducts = (confirmOrderData?.products ?? []).map((p) => ({
+      ...p,
+      item_uuid: generateShortUuid()
+    }));
+
+    // 2) Mapa de lookup por (sku + product_id + quantity) para mapear el mismo
+    //    uuid a los productos correspondientes en cada split.
+    const uuidByKey = new Map<string, string>();
+    summaryProducts.forEach((p) => {
+      const key = `${p.product_sku}::${p.product_id}::${p.quantity}`;
+      if (p.item_uuid) uuidByKey.set(key, p.item_uuid);
+    });
+
+    // 3) Inyecta el mismo uuid en order_summary.discounts.discountItems
+    //    (mismo source que order_split_details[*].products).
+    const summaryDiscountItems = (confirmOrderData?.discounts?.discountItems ?? []).map((p) => {
+      const key = `${p.product_sku}::${p.product_id}::${p.quantity}`;
+      const item_uuid = uuidByKey.get(key) ?? p.item_uuid ?? generateShortUuid();
+      return { ...p, item_uuid };
+    });
+
+    // 4) Clona order_split_details inyectando item_uuid en cada producto del split.
+    const splitDetails = order_split_details.map((split) => ({
+      ...split,
+      products: split.products.map((p) => {
+        const key = `${p.product_sku}::${p.product_id}::${p.quantity}`;
+        const item_uuid = uuidByKey.get(key) ?? p.item_uuid ?? generateShortUuid();
+        return { ...p, item_uuid };
+      })
+    }));
+
     const orderSummary: IOrderSummaryPayload = {
       ...confirmOrderData,
+      products: summaryProducts,
+      discounts: {
+        ...confirmOrderData.discounts,
+        discountItems: summaryDiscountItems
+      },
       discount_package: selectedDiscount as IDiscountPackageAvailable,
       executive_discounts: executiveDiscounts,
       deactivate_cross_selling: !deactivateCrossSelling
@@ -135,7 +178,7 @@ export default function CheckoutPage() {
     return {
       order_summary: orderSummary,
       is_electronic_invoicing: isElectronicInvoicing,
-      order_split_details,
+      order_split_details: splitDetails,
       promotion_id: bonus?.id || 0,
       nit_id: channelCode
     };

--- a/src/modules/commerce/components/create-order-checkout/modal-shipping-info/modal-shipping-info.tsx
+++ b/src/modules/commerce/components/create-order-checkout/modal-shipping-info/modal-shipping-info.tsx
@@ -78,7 +78,7 @@ export default function ModalShippingInfo({
 
   const splitTotal = useMemo(() => {
     return discountItems.reduce((sum, item) => {
-      const qty = draft.cantidades[item.product_sku] ?? 0;
+      const qty = draft.cantidades[item.item_uuid || item.product_sku] ?? 0;
       const unitPrice = item.discount?.primary?.new_price ?? item.price;
       return sum + unitPrice * qty;
     }, 0);
@@ -89,7 +89,7 @@ export default function ModalShippingInfo({
   const splitProductDescriptions = useMemo(() => {
     const descs: string[] = [];
     for (const i of discountItems) {
-      if ((draft.cantidades[i.product_sku] ?? 0) > 0) descs.push(i.description ?? "");
+      if ((draft.cantidades[i.item_uuid || i.product_sku] ?? 0) > 0) descs.push(i.description ?? "");
     }
     for (const b of bonusItems) {
       if ((draft.bonusCantidades[b.product_sku] ?? 0) > 0) descs.push(b.description ?? "");
@@ -326,9 +326,9 @@ export default function ModalShippingInfo({
                 <span className="text-[10px] text-[#999999] font-semibold text-center">Cant.</span>
               </div>
               {discountItems.map((item, iIdx) => {
-                const asignado = draft.cantidades[item.product_sku] ?? 0;
+                const asignado = draft.cantidades[item.item_uuid || item.product_sku] ?? 0;
                 const asignadoOtros = cantidadesAsignadasExcluyendo(
-                  item.product_sku,
+                  item.item_uuid || item.product_sku,
                   mode === "new" ? null : mode
                 );
                 const disponible = item.quantity - asignadoOtros;
@@ -336,7 +336,7 @@ export default function ModalShippingInfo({
                 const isLastRow = iIdx === discountItems.length - 1 && !hasBonus;
                 return (
                   <div
-                    key={item.product_sku}
+                    key={`${item.product_sku}::${iIdx}`}
                     className={`grid grid-cols-[1fr_56px_72px] items-center px-3 py-2.5 ${!isLastRow ? "border-b border-[#EEEEEE]" : ""}`}
                   >
                     <p className="text-xs text-[#141414] leading-tight pr-2">{item.description}</p>
@@ -358,7 +358,7 @@ export default function ModalShippingInfo({
                         );
                         setDraft((d) => ({
                           ...d,
-                          cantidades: { ...d.cantidades, [item.product_sku]: v }
+                          cantidades: { ...d.cantidades, [item.item_uuid || item.product_sku]: v }
                         }));
                       }}
                       className="w-full text-center text-sm font-semibold border border-[#DDDDDD] rounded-lg px-2 py-1.5 outline-none focus:border-[#141414] transition-colors bg-white text-[#141414]"

--- a/src/modules/commerce/components/create-order-checkout/order-shipment-confirm/order-shipment-confirm.tsx
+++ b/src/modules/commerce/components/create-order-checkout/order-shipment-confirm/order-shipment-confirm.tsx
@@ -241,7 +241,7 @@ export default function OrderShipmentConfirm({
     indicativo: "+57",
     telefono: "",
     observaciones: "",
-    cantidades: Object.fromEntries(discountItems.map((i) => [i.product_sku, 0])),
+    cantidades: Object.fromEntries(discountItems.map((i) => [i.item_uuid || i.product_sku, 0])),
     bonusCantidades: Object.fromEntries(bonusItems.map((i) => [i.product_sku, 0])),
     otherBonusCantidades: Object.fromEntries(otherBonusItems.map((i) => [i.product_sku, 0]))
   });
@@ -328,7 +328,7 @@ export default function OrderShipmentConfirm({
   const otherBonusAsignadas = (sku: string) =>
     entregas.reduce((s, e) => s + (e.otherBonusCantidades[sku] ?? 0), 0);
   const hayDesbalance =
-    discountItems.some((i) => cantidadesAsignadas(i.product_sku) !== i.quantity) ||
+    discountItems.some((i) => cantidadesAsignadas(i.item_uuid || i.product_sku) !== i.quantity) ||
     bonusItems.some((i) => bonusAsignadas(i.product_sku) !== i.quantity) ||
     otherBonusItems.some((i) => otherBonusAsignadas(i.product_sku) !== i.quantity);
 
@@ -339,12 +339,10 @@ export default function OrderShipmentConfirm({
     isValidEmail(singleForm.email) &&
     isValidPhone(singleForm.telefono, singleForm.indicativo);
 
-  const isSingleEmailInvalid =
-    singleForm.email.trim() !== "" && !isValidEmail(singleForm.email);
+  const isSingleEmailInvalid = singleForm.email.trim() !== "" && !isValidEmail(singleForm.email);
 
   const isSinglePhoneInvalid =
-    singleForm.telefono.trim() !== "" &&
-    !isValidPhone(singleForm.telefono, singleForm.indicativo);
+    singleForm.telefono.trim() !== "" && !isValidPhone(singleForm.telefono, singleForm.indicativo);
 
   // Sync order_split_details on context
   useEffect(() => {
@@ -372,7 +370,10 @@ export default function OrderShipmentConfirm({
 
     const buildProductsForSplit = (cantidades: Record<string, number>): DiscountItem[] =>
       discountItems
-        .map((item) => ({ ...item, quantity: cantidades[item.product_sku] ?? 0 }))
+        .map((item) => ({
+          ...item,
+          quantity: cantidades[item?.item_uuid || item.product_sku] ?? 0
+        }))
         .filter((item) => item.quantity > 0);
 
     const buildBonusForSplit = (
@@ -630,10 +631,13 @@ export default function OrderShipmentConfirm({
                     </button>
                   </div>
                   <div className="divide-y divide-[#F7F7F7]">
-                    {discountItems.map((item) => {
-                      const asignado = entrega.cantidades[item.product_sku] ?? 0;
+                    {discountItems.map((item, idx) => {
+                      const asignado = entrega.cantidades[item.item_uuid || item.product_sku] ?? 0;
                       return (
-                        <div key={item.product_sku} className="flex items-center gap-2 px-3 py-2">
+                        <div
+                          key={`${item.product_sku}::${idx}`}
+                          className="flex items-center gap-2 px-3 py-2"
+                        >
                           <p className="flex-1 text-[11px] text-[#666666] line-clamp-1">
                             {item.description}
                           </p>

--- a/src/modules/commerce/components/create-order-checkout/products-details-and-discounts/products-details-and-discounts.tsx
+++ b/src/modules/commerce/components/create-order-checkout/products-details-and-discounts/products-details-and-discounts.tsx
@@ -256,7 +256,7 @@ export default function ProductsDetailsAndDiscounts({
               {discountItems.map((item, idx) => {
                 const precioFinal = item.discount?.primary?.new_price ?? item.price;
                 const totalLinea = precioFinal * item.quantity;
-                const restante = item.quantity - cantidadesAsignadas(item.product_sku);
+                const restante = item.quantity - cantidadesAsignadas(item.item_uuid || item.product_sku);
                 const maxPercentage = item.discount?.primary?.discount_applied?.max_discount ?? 0;
                 const executiveEntry = executiveDiscounts.find(
                   (e) => e.product_sku === item.product_sku
@@ -265,7 +265,7 @@ export default function ProductsDetailsAndDiscounts({
 
                 return (
                   <div
-                    key={item.product_sku}
+                    key={`${item.product_sku}-${idx}`}
                     className={`grid ${cols} items-center px-4 py-4 ${
                       idx < discountItems.length - 1 ? "border-b border-[#F4F4F4]" : ""
                     }`}
@@ -334,7 +334,7 @@ export default function ProductsDetailsAndDiscounts({
 
                   {bonificados.map((b, idx) => (
                     <div
-                      key={b.key}
+                      key={`${b.key}-${idx}`}
                       className={`grid ${cols} items-center px-4 py-3.5 bg-[#FDFFF5] ${
                         idx < bonificados.length - 1 ? "border-b border-[#F0F9D8]" : ""
                       }`}

--- a/src/modules/commerce/containers/confirmed-order/confirmed-order.tsx
+++ b/src/modules/commerce/containers/confirmed-order/confirmed-order.tsx
@@ -3,7 +3,7 @@ import { Flex, Spin, Typography } from "antd";
 import { useParams, useRouter, useSearchParams } from "next/navigation";
 import { CheckCircle } from "phosphor-react";
 
-import { extractSingleParam, formatNumber } from "@/utils/utils";
+import { extractSingleParam, formatNumber, generateShortUuid } from "@/utils/utils";
 import { getSingleOrder } from "@/services/commerce/commerce";
 import { useAppStore } from "@/lib/store/store";
 
@@ -40,7 +40,12 @@ export const ConfirmedOrderView: FC = () => {
       const response = await getSingleOrder(projectId, parseInt(orderIdParam));
       setOrder(response?.data[0]);
       if (response.data[0].detail?.discounts?.discountItems?.length > 0)
-        setAppliedDiscounts(response.data[0].detail?.discounts?.discountItems);
+        setAppliedDiscounts(
+          response.data[0].detail?.discounts?.discountItems?.map((item) => ({
+            ...item,
+            item_uuid: item.item_uuid ?? generateShortUuid()
+          }))
+        );
       setLoading(false);
     };
     fetchOrder();
@@ -123,8 +128,10 @@ export const ConfirmedOrderView: FC = () => {
                         </Flex>
                         <div className={styles.products}>
                           {category.products.map((product) => {
-                            const productDiscount = appliedDiscounts?.find(
-                              (discount: any) => discount.product_sku === product.product_sku
+                            const productDiscount = appliedDiscounts?.find((discount: any) =>
+                              product.item_uuid
+                                ? discount.item_uuid === product.item_uuid
+                                : discount.product_sku === product.product_sku
                             )?.discount;
                             const productDiscountData =
                               productDiscount && productDiscount.subtotalDiscount > 0

--- a/src/modules/commerce/utils/constants/evenQuantityProducts.ts
+++ b/src/modules/commerce/utils/constants/evenQuantityProducts.ts
@@ -15,7 +15,7 @@ export const EVEN_QUANTITY_GROUP_PRODUCTS: ProductIdentifier[] = [
   { SKU: "011594", EAN: null, description: "RESTYLANE REFYNE 1ml New" },
   { SKU: "012130", EAN: null, description: "REST LYFT LIDO 1ml" },
   { SKU: "012126", EAN: null, description: "RESTYLANE LIDOCAINA 1ml" },
-  { SKU: "011596", EAN: null, description: "RESTYLANE KYSSE 1ml" },
+  { SKU: "012135", EAN: null, description: "RESTYLANE KYSSE 1ml" },
   { SKU: "012134", EAN: null, description: "RESTYLANE DEFYNE 1ml" }
 ];
 

--- a/src/types/commerce/ICommerce.ts
+++ b/src/types/commerce/ICommerce.ts
@@ -85,6 +85,7 @@ export interface IConfirmOrderData {
 export interface IProductInDetail {
   id: number;
   product_sku: string;
+  item_uuid?: string;
   product_name: string;
   quantity: number;
   price: number;
@@ -134,6 +135,12 @@ export interface DiscountItem {
   product_id: number;
   description: string;
   discount: Discount;
+  /**
+   * UUID corto generado en el front que correlaciona este producto
+   * con su línea origen en `order_summary.products`. Permite al backend
+   * mapear de dónde viene cada producto en cada split.
+   */
+  item_uuid?: string;
 }
 export interface DiscountOrder {
   discountId: number;

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -506,3 +506,15 @@ export const formatEmailBodyHtml = (body: string): string => {
     .replace(/>/g, "&gt;")
     .replace(/\n/g, "<br/>");
 };
+
+/**
+ * Genera un UUID corto (8 caracteres hex) a partir de `crypto.randomUUID()`.
+ * Suficiente para correlacionar items dentro de un mismo request de orden.
+ */
+export function generateShortUuid(): string {
+  if (typeof crypto !== "undefined" && typeof crypto.randomUUID === "function") {
+    return crypto.randomUUID().replace(/-/g, "").slice(0, 8);
+  }
+  // Fallback para entornos sin crypto.randomUUID
+  return Math.random().toString(16).slice(2, 10).padEnd(8, "0");
+}


### PR DESCRIPTION
Introduce item_uuid correlation across order data and a short UUID generator.

- Add generateShortUuid util (8-hex chars) with crypto.randomUUID fallback.
- Extend ICommerce types to include optional item_uuid on products/discount items.
- On order confirmation, generate item_uuid for discountItems when missing.
- Build order payload by injecting consistent item_uuid values into order_summary.products, order_summary.discounts.discountItems, and order_split_details.products using a lookup by (sku::product_id::quantity) so splits share the same UUIDs.
- Updated UI components (ModalShippingInfo, OrderShipmentConfirm, ProductsDetailsAndDiscounts, ConfirmedOrderView) to use item_uuid when reading/writing quantities and when matching discounts; also adjusted list keys to include index for uniqueness.
- Fix SKU in EVEN_QUANTITY_GROUP_PRODUCTS constant (replace 011596 with 012135).

These changes ensure front-end generates and propagates stable short identifiers to correlate product lines across summary, discounts and split details so the backend can map split origins reliably.