### PR TITLE
Fix/86e1trt8h/commerce

### DIFF
--- a/src/components/molecules/modals/MoldalNoveltyDetail/MoldalNoveltyDetail.tsx
+++ b/src/components/molecules/modals/MoldalNoveltyDetail/MoldalNoveltyDetail.tsx
@@ -83,6 +83,11 @@ const MoldalNoveltyDetail: FC<MoldalNoveltyDetailProps> = ({
     return <div></div>;
   }
 
+  const hasInvoiceValues =
+    !!incidentData.invoice_cashport_value ||
+    !!incidentData.invoice_client_value ||
+    !!incidentData.invoice_amount_difference;
+
   return (
     <aside className={`wrapper__new  wrapper__new_hide`}>
       {contextHolder}
@@ -115,7 +120,7 @@ const MoldalNoveltyDetail: FC<MoldalNoveltyDetailProps> = ({
         cliente={incidentData.client}
         aprobadores={[{ nombre: incidentData.approvers_users, estado: "pendiente" }]}
       />
-      <InfoInvoice incidentData={incidentData} />
+      {hasInvoiceValues && <InfoInvoice incidentData={incidentData} />}
       <EvidenceSection
         evidenceComments={incidentData.evidence_comments}
         evidenceFiles={incidentData.evidence_files}

--- a/src/modules/commerce/components/confirmed-order-modalBlocked/confirmed-order-modalBlocked.tsx
+++ b/src/modules/commerce/components/confirmed-order-modalBlocked/confirmed-order-modalBlocked.tsx
@@ -62,7 +62,7 @@ const ConfirmedOrderModalBlocked: FC<IConfirmedOrderModalBlocked> = ({
               handleOk={handleSendToApproval}
               onClose={handleClientPaid}
               titleConfirm="Enviar a aprobación"
-              titleCancel="Es un cliente de contado"
+              titleCancel="Es un pedido de contado"
             />
           </Flex>
         );

--- a/src/modules/commerce/components/create-order-cart/create-order-cart.tsx
+++ b/src/modules/commerce/components/create-order-cart/create-order-cart.tsx
@@ -162,7 +162,7 @@ const CreateOrderCart: FC<CreateOrderCartProps> = ({ onClose }) => {
   }, [selectedCategories]);
 
   const complementMismatch = useMemo(() => {
-    const req = computeComplementRequirements(selectedCategories);
+    const req = computeComplementRequirements(selectedCategories, client?.id);
     if (!req.hasMainProduct) return null;
 
     const allProducts = selectedCategories.flatMap((c) => c.products);
@@ -333,7 +333,7 @@ const CreateOrderCart: FC<CreateOrderCartProps> = ({ onClose }) => {
     if (projectId !== GALDERMA_PROJECT_ID) return;
     if (categories.length === 0) return;
 
-    const req = computeComplementRequirements(selectedCategories);
+    const req = computeComplementRequirements(selectedCategories, client?.id);
 
     const currentSKUs = new Set<string>();
     for (const cat of selectedCategories) {
@@ -468,7 +468,7 @@ const CreateOrderCart: FC<CreateOrderCartProps> = ({ onClose }) => {
     prevAutoAssignedSKUsRef.current = newSnapshot;
 
     if (mutated) setSelectedCategories(next);
-  }, [selectedCategories, categories, projectId]);
+  }, [selectedCategories, categories, projectId, client?.id]);
 
   return (
     <div className={styles.cartContainer}>

--- a/src/modules/commerce/utils/complementCalculation.ts
+++ b/src/modules/commerce/utils/complementCalculation.ts
@@ -39,7 +39,6 @@ export const computeComplementRequirements = (
   });
 
   const canulasFromSculptra = sculptraQty * 2;
-  console.log("Client id:", clientId);
   const isFullCanulaClient = !!clientId && FULL_CANULA_CLIENT_IDS.includes(clientId);
   const canulasFromRestylane = isFullCanulaClient
     ? restylaneTotalQty // 1 cánula per Restylane unit

--- a/src/modules/commerce/utils/complementCalculation.ts
+++ b/src/modules/commerce/utils/complementCalculation.ts
@@ -2,6 +2,7 @@ import { ISelectedCategories } from "../containers/create-order/create-order";
 import {
   EVEN_QUANTITY_GROUP_PRODUCTS,
   EVEN_QUANTITY_PRODUCT,
+  FULL_CANULA_CLIENT_IDS,
   SCULPTRA_MAIN_PRODUCT,
   matchesProductIdentifier
 } from "./constants/evenQuantityProducts";
@@ -15,7 +16,8 @@ export interface ComplementRequirements {
 }
 
 export const computeComplementRequirements = (
-  selectedCategories: ISelectedCategories[]
+  selectedCategories: ISelectedCategories[],
+  clientId?: string
 ): ComplementRequirements => {
   let sculptraQty = 0;
   let restylaneTotalQty = 0;
@@ -37,7 +39,11 @@ export const computeComplementRequirements = (
   });
 
   const canulasFromSculptra = sculptraQty * 2;
-  const canulasFromRestylane = Math.floor(restylaneTotalQty / 2);
+  console.log("Client id:", clientId);
+  const isFullCanulaClient = !!clientId && FULL_CANULA_CLIENT_IDS.includes(clientId);
+  const canulasFromRestylane = isFullCanulaClient
+    ? restylaneTotalQty // 1 cánula per Restylane unit
+    : Math.floor(restylaneTotalQty / 2); // default: 1 cánula per 2 units
 
   return {
     requiredCanulas: canulasFromSculptra + canulasFromRestylane,

--- a/src/modules/commerce/utils/constants/evenQuantityProducts.ts
+++ b/src/modules/commerce/utils/constants/evenQuantityProducts.ts
@@ -49,3 +49,17 @@ export const AGUA_COMPLEMENT: ProductIdentifier = {
   EAN: null,
   description: "AGUA ESTERIL"
 };
+
+// Clients that require 1 cánula per Restylane unit (1:1) instead of the default 1-per-2 ratio.
+// Keyed by client name so it's clear which ID belongs to which client.
+export const FULL_CANULA_CLIENTS = {
+  FLOREZ_GRAJALES_DAVID_STEVEN: "1088021041",
+  CTRO_DERMA_LASER_PIEL_Y_BELLEZA_SAS: "816006442",
+  RADA_CASSAB_MEDICINA_ESTETICA: "830509599",
+  DOCTOR_ESCALANTE_SAS: "901352842",
+  CAROLINA_MARTINEZ_SAS: "901115633",
+  CANTIK_COLOMBIA_SAS: "901578018",
+  INNOVA_LASER_CENTER_SAS: "900523237"
+} as const;
+
+export const FULL_CANULA_CLIENT_IDS: string[] = Object.values(FULL_CANULA_CLIENTS);


### PR DESCRIPTION
This pull request introduces targeted improvements to the order creation and novelty detail modals, as well as enhancements to the complement calculation logic for commerce modules. The main focus is to adjust the calculation of required canulas based on specific client requirements, conditionally render invoice information, and improve user-facing text.

**Complement calculation logic enhancements:**

* Updated `computeComplementRequirements` in `complementCalculation.ts` to accept an optional `clientId` parameter, allowing the function to determine if a client requires a 1:1 ratio of canulas to Restylane units. This logic uses a new `FULL_CANULA_CLIENT_IDS` constant for client lookup. [[1]](diffhunk://#diff-0b573ac582f4221f699064808d1e7aa8f5c7c4254a47f40ba141201d71bd84a0L18-R20) [[2]](diffhunk://#diff-0b573ac582f4221f699064808d1e7aa8f5c7c4254a47f40ba141201d71bd84a0L40-R46) [[3]](diffhunk://#diff-7ca8590710946a1c1904ff71921866dc0855c89d39d5db8b4f76f40b213284d6R52-R65)
* Modified all usages of `computeComplementRequirements` in `create-order-cart.tsx` to pass `client?.id`, ensuring the calculation is client-specific. Also updated dependencies in related React hooks to include `client?.id`. [[1]](diffhunk://#diff-f5ffce025964f652d85862ec7e82ebc762eb60a8ad6510ab281a796e7a64ffefL165-R165) [[2]](diffhunk://#diff-f5ffce025964f652d85862ec7e82ebc762eb60a8ad6510ab281a796e7a64ffefL336-R336) [[3]](diffhunk://#diff-f5ffce025964f652d85862ec7e82ebc762eb60a8ad6510ab281a796e7a64ffefL471-R471)

**UI/UX improvements:**

* In `MoldalNoveltyDetail.tsx`, added a conditional to only render the `InfoInvoice` component if there are invoice values present in the incident data, preventing empty or irrelevant invoice sections from displaying. [[1]](diffhunk://#diff-ed5ba5c4f92204ad9dca317acb3ad38d55f67a93a387e3f1c24529835dff3b40R86-R90) [[2]](diffhunk://#diff-ed5ba5c4f92204ad9dca317acb3ad38d55f67a93a387e3f1c24529835dff3b40L118-R123)
* Updated the cancel button text in `confirmed-order-modalBlocked.tsx` for clarity, changing it from "Es un cliente de contado" to "Es un pedido de contado".