### PR TITLE
(dataQuality): add alerts column to countries clients table

### DIFF
--- a/src/modules/dataQuality/components/countries-clients-table/CountriesClientsTable.tsx
+++ b/src/modules/dataQuality/components/countries-clients-table/CountriesClientsTable.tsx
@@ -96,6 +96,28 @@ export default function CountriesClientsTable({
       showSorterTooltip: false
     },
     {
+      title: "Alertas",
+      dataIndex: "alerts",
+      key: "alerts",
+      align: "center",
+      render: (alerts: number) => {
+        const count = alerts ?? 0;
+        return (
+          <span
+            className={
+              count > 0
+                ? "inline-flex items-center justify-center min-w-6 h-6 px-2 rounded-full text-xs font-semibold bg-red-100 text-red-600"
+                : "text-xs text-gray-400"
+            }
+          >
+            {count > 0 ? count : "-"}
+          </span>
+        );
+      },
+      sorter: (a, b) => (a.alerts ?? 0) - (b.alerts ?? 0),
+      showSorterTooltip: false
+    },
+    {
       title: "Estado",
       key: "status",
       dataIndex: "status",

--- a/src/types/dataQuality/IDataQuality.ts
+++ b/src/types/dataQuality/IDataQuality.ts
@@ -73,6 +73,7 @@ export interface IClientData {
   country_name: string;
   periodicity: string | null;
   status: string;
+  alerts: number;
 }
 
 // Client List Response


### PR DESCRIPTION
Display notification count with red badge styling for items with alerts, and gray dash for zero alerts. Includes sorting functionality.