### PR TITLE
Add promotion selector to ModalBonus modal

### DIFF
--- a/src/modules/commerce/components/create-order-cart/create-order-cart.tsx
+++ b/src/modules/commerce/components/create-order-cart/create-order-cart.tsx
@@ -521,9 +521,7 @@ const CreateOrderCart: FC<CreateOrderCartProps> = ({ onClose }) => {
 
       {selectedCategories.length > 0 && (
         <div className={styles.cartContainer__footer}>
-          {((promotions.length > 0 &&
-            (confirmOrderData.promotion?.active_range?.gift_options?.length ?? 0) > 0) ||
-            (confirmOrderData?.other_bonificated_products?.length ?? 0) > 0) && (
+          {
             <button
               onClick={() => {
                 setIsBonusModalOpen(true);
@@ -542,7 +540,7 @@ const CreateOrderCart: FC<CreateOrderCartProps> = ({ onClose }) => {
               </span>
               <Eye size={14} className="text-[#999999]" />
             </button>
-          )}
+          }
           {!checkingOut && (
             <>
               <button
@@ -618,7 +616,13 @@ const CreateOrderCart: FC<CreateOrderCartProps> = ({ onClose }) => {
         <CreateOrderDiscountsModal setOpenDiscountsModal={setOpenDiscountsModal} />
       )}
 
-      <ModalBonus isOpen={isBonusModalOpen} onClose={() => setIsBonusModalOpen(false)} />
+      <ModalBonus
+        isOpen={isBonusModalOpen}
+        onClose={() => setIsBonusModalOpen(false)}
+        promotions={promotions}
+        selectedPromotionId={promotionId ?? null}
+        onSelectPromotion={setPromotionId}
+      />
 
       <ModalConfirmAction
         isOpen={showConfirmModal}

--- a/src/modules/commerce/components/modal-bonus/modal-bonus.module.scss
+++ b/src/modules/commerce/components/modal-bonus/modal-bonus.module.scss
@@ -5,6 +5,92 @@
     padding-bottom: 0.25rem;
 }
 
+/* Title row with optional back button */
+.titleRow {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+}
+
+.backButton {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 28px;
+    height: 28px;
+    padding: 0;
+    background: transparent;
+    border: none;
+    border-radius: 6px;
+    color: #141414;
+    cursor: pointer;
+    transition: background 0.15s;
+
+    &:hover {
+        background: #f5f5f5;
+    }
+}
+
+/* Select screen */
+.selectContent {
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+    padding: 0.25rem 0 0.5rem;
+}
+
+.selectLabel {
+    font-size: 12px;
+    color: #666666;
+    margin: 0;
+}
+
+.promotionsList {
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+}
+
+.promotionCard {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    width: 100%;
+    padding: 0.75rem 1rem;
+    background: #ffffff;
+    border: 1px solid #eeeeee;
+    border-radius: 8px;
+    cursor: pointer;
+    transition: background 0.15s, border-color 0.15s;
+    text-align: left;
+    font-size: 13px;
+    font-weight: 500;
+    color: #141414;
+
+    &:hover {
+        background: #fafafa;
+        border-color: #cccccc;
+    }
+}
+
+.promotionCardActive {
+    @extend .promotionCard;
+    background: #f5f5f5;
+    border-color: #141414;
+}
+
+.promotionCardLeft {
+    display: flex;
+    align-items: center;
+    gap: 0.625rem;
+}
+
+.promotionCheck {
+    color: #141414;
+    font-size: 14px;
+    font-weight: 700;
+}
+
 .section {
     display: flex;
     flex-direction: column;

--- a/src/modules/commerce/components/modal-bonus/modal-bonus.tsx
+++ b/src/modules/commerce/components/modal-bonus/modal-bonus.tsx
@@ -1,8 +1,10 @@
 "use client";
-import { useContext, useState } from "react";
+import { useContext, useEffect, useState } from "react";
 import { Modal, Typography } from "antd";
+import { ArrowLeft, Gift } from "@phosphor-icons/react";
 
 import { IBonus, IGiftOption } from "@/types/commerce/ICommerce";
+import { IPromotion } from "@/services/promotion/promotion";
 import { OrderViewContext } from "@/modules/commerce/contexts/orderViewContext";
 
 import styles from "./modal-bonus.module.scss";
@@ -12,9 +14,18 @@ const { Title } = Typography;
 interface Props {
   isOpen: boolean;
   onClose: () => void;
+  promotions: IPromotion[];
+  selectedPromotionId: number | null;
+  onSelectPromotion: (id: number) => void;
 }
 
-const ModalBonus = ({ isOpen, onClose }: Props) => {
+const ModalBonus = ({
+  isOpen,
+  onClose,
+  promotions,
+  selectedPromotionId,
+  onSelectPromotion
+}: Props) => {
   const { confirmOrderData, setBonus } = useContext(OrderViewContext);
 
   const promotion = confirmOrderData?.promotion;
@@ -23,11 +34,18 @@ const ModalBonus = ({ isOpen, onClose }: Props) => {
 
   const tabOptions = giftOptions;
 
+  const [currentScreen, setCurrentScreen] = useState<"select" | "detail">("select");
   const [activeTab, setActiveTab] = useState(0);
   const [poolQty, setPoolQty] = useState<Record<number, Record<number, number>>>({});
   const [otherQty, setOtherQty] = useState<Record<number, number>>(() =>
     Object.fromEntries(otherBonificated.map((p) => [p.product_id, p.qty]))
   );
+
+  useEffect(() => {
+    if (isOpen) {
+      setCurrentScreen(promotions.length > 0 ? "select" : "detail");
+    }
+  }, [isOpen, promotions.length]);
 
   const getPoolGroupTotal = (groupId: number) => {
     const group = poolQty[groupId] ?? {};
@@ -109,6 +127,221 @@ const ModalBonus = ({ isOpen, onClose }: Props) => {
     onClose();
   };
 
+  const handleSelectPromotion = (id: number) => {
+    onSelectPromotion(id);
+    setCurrentScreen("detail");
+  };
+
+  const renderSelectScreen = () => (
+    <div className={styles.selectContent}>
+      <p className={styles.selectLabel}>Elige la promoción a aplicar</p>
+      <div className={styles.promotionsList}>
+        {promotions.map((promo) => {
+          const isActive = selectedPromotionId === promo.id;
+          return (
+            <button
+              key={promo.id}
+              onClick={() => handleSelectPromotion(promo.id)}
+              className={isActive ? styles.promotionCardActive : styles.promotionCard}
+            >
+              <div className={styles.promotionCardLeft}>
+                <Gift size={16} weight={isActive ? "fill" : "regular"} />
+                <span>{promo.name}</span>
+              </div>
+              {isActive && <span className={styles.promotionCheck}>✓</span>}
+            </button>
+          );
+        })}
+      </div>
+    </div>
+  );
+
+  const renderDetailScreen = () => (
+    <>
+      {!promotion && otherBonificated.length === 0 ? (
+        <p style={{ color: "#999", fontSize: 13, textAlign: "center", padding: "1rem 0" }}>
+          No hay bonificados disponibles
+        </p>
+      ) : (
+        <>
+          {promotion && tabOptions.length > 0 && (
+            <div className={styles.section}>
+              <p className={styles.sectionLabel}>Bonificados promoción</p>
+
+              {tabOptions.length > 1 && (
+                <div className={styles.tabRow}>
+                  {tabOptions.map((opt, idx) => (
+                    <button
+                      key={opt.gift_group_id}
+                      onClick={() => setActiveTab(idx)}
+                      className={activeTab === idx ? styles.tabActive : styles.tab}
+                    >
+                      Opción {opt.option_number}
+                    </button>
+                  ))}
+                </div>
+              )}
+
+              <div className={styles.grupos}>
+                {tabOptions[activeTab]?.items
+                  .filter((g) => !g.fixed)
+                  .map((group) => {
+                    const groupTotal = getPoolGroupTotal(group.gift_item_group_id);
+                    return (
+                      <div key={group.gift_item_group_id} className={styles.poolTable}>
+                        <div className={styles.poolHeader}>
+                          <span>Elige {group.max_selection_qty} und.</span>
+                          <span className={styles.poolCount}>
+                            {groupTotal}/{group.max_selection_qty}
+                          </span>
+                        </div>
+                        <table className={styles.table}>
+                          <tbody>
+                            {group.items.map((item, idx) => {
+                              const qty =
+                                poolQty[group.gift_item_group_id]?.[item.product_id] ?? 0;
+                              return (
+                                <tr
+                                  key={item.product_id}
+                                  className={idx < group.items.length - 1 ? styles.rowBorder : ""}
+                                >
+                                  <td className={styles.cellName}>{item.description}</td>
+                                  <td className={styles.cellControl}>
+                                    <div className={styles.counter}>
+                                      <button
+                                        onClick={() =>
+                                          updatePool(
+                                            group.gift_item_group_id,
+                                            item.product_id,
+                                            -1,
+                                            group.max_selection_qty
+                                          )
+                                        }
+                                        disabled={qty <= 0}
+                                        className={styles.counterBtn}
+                                      >
+                                        -
+                                      </button>
+                                      <span className={styles.counterVal}>{qty}</span>
+                                      <button
+                                        onClick={() =>
+                                          updatePool(
+                                            group.gift_item_group_id,
+                                            item.product_id,
+                                            1,
+                                            group.max_selection_qty
+                                          )
+                                        }
+                                        disabled={groupTotal >= group.max_selection_qty}
+                                        className={styles.counterBtn}
+                                      >
+                                        +
+                                      </button>
+                                    </div>
+                                  </td>
+                                </tr>
+                              );
+                            })}
+                          </tbody>
+                        </table>
+                      </div>
+                    );
+                  })}
+
+                {tabOptions[activeTab]?.items
+                  .filter((g) => g.fixed)
+                  .map((group) => (
+                    <div key={group.gift_item_group_id} className={styles.fixedTable}>
+                      <div className={styles.fixedHeader}>
+                        <span>Incluido</span>
+                      </div>
+                      <table className={styles.table}>
+                        <tbody>
+                          {group.items.map((item, idx) => (
+                            <tr
+                              key={item.product_id}
+                              className={
+                                idx < group.items.length - 1 ? styles.rowBorderGreen : ""
+                              }
+                            >
+                              <td className={styles.cellName}>{item.description}</td>
+                              <td className={styles.cellBadge}>
+                                <span className={styles.fixedBadge}>{item.qty}</span>
+                              </td>
+                            </tr>
+                          ))}
+                        </tbody>
+                      </table>
+                    </div>
+                  ))}
+              </div>
+            </div>
+          )}
+
+          {otherBonificated.length > 0 && (
+            <div className={styles.section}>
+              <p className={styles.sectionLabel}>Otros bonificados</p>
+              <div className={styles.genericTable}>
+                <table className={styles.table}>
+                  <tbody>
+                    {otherBonificated.map((item, idx, arr) => {
+                      const qty = otherQty[item.product_id] ?? 0;
+                      return (
+                        <tr
+                          key={item.product_id}
+                          className={idx < arr.length - 1 ? styles.rowBorder : ""}
+                        >
+                          <td className={styles.cellName}>
+                            {item.description}
+                            <span className={styles.saldoHint}>
+                              ({qty}/{item.max_selection_qty})
+                            </span>
+                          </td>
+                          <td className={styles.cellControl}>
+                            <div className={styles.counter}>
+                              <button
+                                onClick={() =>
+                                  updateOther(item.product_id, -1, item.max_selection_qty)
+                                }
+                                disabled={qty <= 0}
+                                className={styles.counterBtn}
+                              >
+                                -
+                              </button>
+                              <span className={styles.counterVal}>{qty}</span>
+                              <button
+                                onClick={() =>
+                                  updateOther(item.product_id, 1, item.max_selection_qty)
+                                }
+                                disabled={qty >= item.max_selection_qty}
+                                className={styles.counterBtn}
+                              >
+                                +
+                              </button>
+                            </div>
+                          </td>
+                        </tr>
+                      );
+                    })}
+                  </tbody>
+                </table>
+              </div>
+            </div>
+          )}
+        </>
+      )}
+
+      <div className={styles.footer}>
+        <p className={styles.footerTotal}>
+          Total: <strong>{totalBonificados()}</strong>
+        </p>
+        <button onClick={handleConfirm} className={styles.confirmBtn}>
+          Confirmar
+        </button>
+      </div>
+    </>
+  );
+
   return (
     <Modal
       className="modalBonus"
@@ -116,191 +349,26 @@ const ModalBonus = ({ isOpen, onClose }: Props) => {
       open={isOpen}
       onCancel={onClose}
       footer={null}
-      title={<Title level={4}>Bonificados</Title>}
+      title={
+        <div className={styles.titleRow}>
+          {currentScreen === "detail" && promotions.length > 0 && (
+            <button
+              onClick={() => setCurrentScreen("select")}
+              className={styles.backButton}
+              aria-label="Volver a la lista de promociones"
+            >
+              <ArrowLeft size={16} weight="bold" />
+            </button>
+          )}
+          <Title level={4} style={{ margin: 0 }}>
+            Bonificados
+          </Title>
+        </div>
+      }
       destroyOnClose
     >
       <div className={styles.content}>
-        {!promotion && otherBonificated.length === 0 ? (
-          <p style={{ color: "#999", fontSize: 13, textAlign: "center", padding: "1rem 0" }}>
-            No hay bonificados disponibles
-          </p>
-        ) : (
-          <>
-            {promotion && tabOptions.length > 0 && (
-              <div className={styles.section}>
-                <p className={styles.sectionLabel}>Bonificados promoción</p>
-
-                {tabOptions.length > 1 && (
-                  <div className={styles.tabRow}>
-                    {tabOptions.map((opt, idx) => (
-                      <button
-                        key={opt.gift_group_id}
-                        onClick={() => setActiveTab(idx)}
-                        className={activeTab === idx ? styles.tabActive : styles.tab}
-                      >
-                        Opción {opt.option_number}
-                      </button>
-                    ))}
-                  </div>
-                )}
-
-                <div className={styles.grupos}>
-                  {tabOptions[activeTab]?.items
-                    .filter((g) => !g.fixed)
-                    .map((group) => {
-                      const groupTotal = getPoolGroupTotal(group.gift_item_group_id);
-                      return (
-                        <div key={group.gift_item_group_id} className={styles.poolTable}>
-                          <div className={styles.poolHeader}>
-                            <span>Elige {group.max_selection_qty} und.</span>
-                            <span className={styles.poolCount}>
-                              {groupTotal}/{group.max_selection_qty}
-                            </span>
-                          </div>
-                          <table className={styles.table}>
-                            <tbody>
-                              {group.items.map((item, idx) => {
-                                const qty =
-                                  poolQty[group.gift_item_group_id]?.[item.product_id] ?? 0;
-                                return (
-                                  <tr
-                                    key={item.product_id}
-                                    className={idx < group.items.length - 1 ? styles.rowBorder : ""}
-                                  >
-                                    <td className={styles.cellName}>{item.description}</td>
-                                    <td className={styles.cellControl}>
-                                      <div className={styles.counter}>
-                                        <button
-                                          onClick={() =>
-                                            updatePool(
-                                              group.gift_item_group_id,
-                                              item.product_id,
-                                              -1,
-                                              group.max_selection_qty
-                                            )
-                                          }
-                                          disabled={qty <= 0}
-                                          className={styles.counterBtn}
-                                        >
-                                          -
-                                        </button>
-                                        <span className={styles.counterVal}>{qty}</span>
-                                        <button
-                                          onClick={() =>
-                                            updatePool(
-                                              group.gift_item_group_id,
-                                              item.product_id,
-                                              1,
-                                              group.max_selection_qty
-                                            )
-                                          }
-                                          disabled={groupTotal >= group.max_selection_qty}
-                                          className={styles.counterBtn}
-                                        >
-                                          +
-                                        </button>
-                                      </div>
-                                    </td>
-                                  </tr>
-                                );
-                              })}
-                            </tbody>
-                          </table>
-                        </div>
-                      );
-                    })}
-
-                  {tabOptions[activeTab]?.items
-                    .filter((g) => g.fixed)
-                    .map((group) => (
-                      <div key={group.gift_item_group_id} className={styles.fixedTable}>
-                        <div className={styles.fixedHeader}>
-                          <span>Incluido</span>
-                        </div>
-                        <table className={styles.table}>
-                          <tbody>
-                            {group.items.map((item, idx) => (
-                              <tr
-                                key={item.product_id}
-                                className={
-                                  idx < group.items.length - 1 ? styles.rowBorderGreen : ""
-                                }
-                              >
-                                <td className={styles.cellName}>{item.description}</td>
-                                <td className={styles.cellBadge}>
-                                  <span className={styles.fixedBadge}>{item.qty}</span>
-                                </td>
-                              </tr>
-                            ))}
-                          </tbody>
-                        </table>
-                      </div>
-                    ))}
-                </div>
-              </div>
-            )}
-
-            {otherBonificated.length > 0 && (
-              <div className={styles.section}>
-                <p className={styles.sectionLabel}>Otros bonificados</p>
-                <div className={styles.genericTable}>
-                  <table className={styles.table}>
-                    <tbody>
-                      {otherBonificated.map((item, idx, arr) => {
-                        const qty = otherQty[item.product_id] ?? 0;
-                        return (
-                          <tr
-                            key={item.product_id}
-                            className={idx < arr.length - 1 ? styles.rowBorder : ""}
-                          >
-                            <td className={styles.cellName}>
-                              {item.description}
-                              <span className={styles.saldoHint}>
-                                ({qty}/{item.max_selection_qty})
-                              </span>
-                            </td>
-                            <td className={styles.cellControl}>
-                              <div className={styles.counter}>
-                                <button
-                                  onClick={() =>
-                                    updateOther(item.product_id, -1, item.max_selection_qty)
-                                  }
-                                  disabled={qty <= 0}
-                                  className={styles.counterBtn}
-                                >
-                                  -
-                                </button>
-                                <span className={styles.counterVal}>{qty}</span>
-                                <button
-                                  onClick={() =>
-                                    updateOther(item.product_id, 1, item.max_selection_qty)
-                                  }
-                                  disabled={qty >= item.max_selection_qty}
-                                  className={styles.counterBtn}
-                                >
-                                  +
-                                </button>
-                              </div>
-                            </td>
-                          </tr>
-                        );
-                      })}
-                    </tbody>
-                  </table>
-                </div>
-              </div>
-            )}
-          </>
-        )}
-
-        <div className={styles.footer}>
-          <p className={styles.footerTotal}>
-            Total: <strong>{totalBonificados()}</strong>
-          </p>
-          <button onClick={handleConfirm} className={styles.confirmBtn}>
-            Confirmar
-          </button>
-        </div>
+        {currentScreen === "select" ? renderSelectScreen() : renderDetailScreen()}
       </div>
     </Modal>
   );


### PR DESCRIPTION
Introduce a promotion selection flow for the bonus modal and wire it from the cart. CreateOrderCart now always renders the bonus preview button (when categories are present) and passes promotions, selectedPromotionId and onSelectPromotion to ModalBonus. ModalBonus was refactored to support two screens (select/detail): a new select screen lists available promotions as selectable cards, and the detail screen retains the existing bonus selection UI. Added currentScreen state, a useEffect to initialize the screen on open, a back button in the modal header, and a handler to switch to detail when a promotion is chosen. New SCSS rules were added for the selector UI and button styles.