### PR TITLE
Refactor/split ajusted statet in apply tab4 saldos

### DIFF
--- a/src/modules/clients/containers/accounting-adjustments-tab/accounting-adjustments-tab.tsx
+++ b/src/modules/clients/containers/accounting-adjustments-tab/accounting-adjustments-tab.tsx
@@ -112,7 +112,7 @@ const AccountingAdjustmentsTab = () => {
       await addItemsToTable(
         Number(projectId) || 0,
         clientId,
-        "discounts",
+        "credit_notes",
         selectedRows?.map((adjustment) => adjustment.id) || []
       );
       setIsModalOpen({ selected: 0 });

--- a/src/modules/clients/containers/apply-tab/Modals/ModalAddToTables/ModalAddToTables.tsx
+++ b/src/modules/clients/containers/apply-tab/Modals/ModalAddToTables/ModalAddToTables.tsx
@@ -7,6 +7,7 @@ import { useAppStore } from "@/lib/store/store";
 import { extractSingleParam, formatDate } from "@/utils/utils";
 import {
   getApplicationAdjustments,
+  getApplicationBalances,
   getApplicationInvoices,
   getApplicationPayments
 } from "@/services/applyTabClients/applyTabClients";
@@ -20,14 +21,17 @@ import CheckboxColoredValues from "@/components/ui/checkbox-colored-values/check
 import { IClientPayment } from "@/types/clientPayments/IClientPayments";
 import { IApplicationInvoice } from "@/types/invoices/IInvoices";
 import { IFinancialDiscount } from "@/hooks/useAcountingAdjustment";
+import { IApplicationBalance } from "@/types/applyTabClients/IApplyTabClients";
 
 import "./modalAddToTables.scss";
+
+type AddableRow = IApplicationInvoice | IClientPayment | IFinancialDiscount | IApplicationBalance;
 
 interface ModalAddToTablesProps {
   onCancel: () => void;
   // eslint-disable-next-line no-unused-vars
   onAdd: (
-    adding_type: "invoices" | "payments" | "credit_notes",
+    adding_type: "invoices" | "payments" | "credit_notes" | "balances",
     selectedIds: number[]
   ) => Promise<void>;
   isModalAddToTableOpen: IModalAddToTableOpen;
@@ -45,13 +49,10 @@ const ModalAddToTables: React.FC<ModalAddToTablesProps> = ({
   const [allInvoices, setAllInvoices] = useState<IApplicationInvoice[]>();
   const [allPayments, setAllPayments] = useState<IClientPayment[]>();
   const [allCreditNotes, setAllCreditNotes] = useState<IFinancialDiscount[]>();
+  const [allBalances, setAllBalances] = useState<IApplicationBalance[]>();
 
-  const [rows, setRows] = useState<(IApplicationInvoice | IClientPayment | IFinancialDiscount)[]>(
-    []
-  );
-  const [selectedRows, setSelectedRows] = useState<
-    (IApplicationInvoice | IClientPayment | IFinancialDiscount)[]
-  >([]);
+  const [rows, setRows] = useState<AddableRow[]>([]);
+  const [selectedRows, setSelectedRows] = useState<AddableRow[]>([]);
   const [searchQuery, setSearchQuery] = useState<string>("");
   const [currentPage, setCurrentPage] = useState(1);
   const [loadingData, setLoadingData] = useState(true);
@@ -77,6 +78,12 @@ const ModalAddToTables: React.FC<ModalAddToTablesProps> = ({
         const fetchedAdjustments = res?.flatMap((group) => group.financial_discounts) ?? [];
         setAllCreditNotes(fetchedAdjustments);
         setLoadingData(false);
+      } else if (isModalAddToTableOpen.adding === "balances") {
+        setLoadingData(true);
+        const res = await getApplicationBalances(projectId, clientId);
+        const fetchedBalances = res?.flatMap((group) => group.balances) ?? [];
+        setAllBalances(fetchedBalances);
+        setLoadingData(false);
       }
     };
 
@@ -90,8 +97,10 @@ const ModalAddToTables: React.FC<ModalAddToTablesProps> = ({
       setRows(allPayments);
     } else if (isModalAddToTableOpen.adding === "credit_notes" && allCreditNotes) {
       setRows(allCreditNotes);
+    } else if (isModalAddToTableOpen.adding === "balances" && allBalances) {
+      setRows(allBalances);
     }
-  }, [isModalAddToTableOpen.adding, allInvoices, allPayments, allCreditNotes]);
+  }, [isModalAddToTableOpen.adding, allInvoices, allPayments, allCreditNotes, allBalances]);
 
   useEffect(() => {
     return () => {
@@ -113,7 +122,7 @@ const ModalAddToTables: React.FC<ModalAddToTablesProps> = ({
     setCurrentPage(page);
   };
 
-  const getRowSearchKey = (row: IApplicationInvoice | IClientPayment | IFinancialDiscount) =>
+  const getRowSearchKey = (row: AddableRow) =>
     isModalAddToTableOpen.adding === "invoices"
       ? (row as IApplicationInvoice).id_erp
       : isModalAddToTableOpen.adding === "credit_notes"
@@ -200,10 +209,7 @@ const ModalAddToTables: React.FC<ModalAddToTablesProps> = ({
     }
   };
 
-  const handleSelectOne = (
-    checked: boolean,
-    row: IClientPayment | IApplicationInvoice | IFinancialDiscount
-  ) => {
+  const handleSelectOne = (checked: boolean, row: AddableRow) => {
     setSelectedRows((prevSelectedRows) =>
       checked
         ? [...prevSelectedRows, row]
@@ -224,7 +230,9 @@ const ModalAddToTables: React.FC<ModalAddToTablesProps> = ({
       ? "facturas"
       : isModalAddToTableOpen.adding === "credit_notes"
         ? "notas créditos"
-        : "pagos";
+        : isModalAddToTableOpen.adding === "balances"
+          ? "saldos"
+          : "pagos";
 
   const isAllChecked =
     paginatedRows.length > 0 &&
@@ -276,7 +284,9 @@ const ModalAddToTables: React.FC<ModalAddToTablesProps> = ({
                 ? "Facturas no encontradas"
                 : isModalAddToTableOpen.adding === "credit_notes"
                   ? "Notas crédito no encontradas"
-                  : "Pagos no encontrados"}
+                  : isModalAddToTableOpen.adding === "balances"
+                    ? "Saldos no encontrados"
+                    : "Pagos no encontrados"}
             </div>
             <div
               className="excel-button-container"
@@ -337,14 +347,18 @@ const ModalAddToTables: React.FC<ModalAddToTablesProps> = ({
                           ? `Factura ${(row as IApplicationInvoice).id_erp}`
                           : isModalAddToTableOpen.adding === "credit_notes"
                             ? `Nota crédito ${(row as IFinancialDiscount).erp_id}`
-                            : `Pago ${(row as IClientPayment).id}`}
+                            : isModalAddToTableOpen.adding === "balances"
+                              ? `Saldo ${(row as IApplicationBalance).id}`
+                              : `Pago ${(row as IClientPayment).id}`}
                       </h4>
                       <p className="invoices-list__date">
                         {isModalAddToTableOpen.adding === "invoices"
                           ? formatDate((row as IApplicationInvoice).financial_record_date)
                           : isModalAddToTableOpen.adding === "credit_notes"
                             ? formatDate((row as IFinancialDiscount).date_of_issue)
-                            : formatDate((row as IClientPayment).payment_date)}
+                            : isModalAddToTableOpen.adding === "balances"
+                              ? formatDate((row as IApplicationBalance).created_at)
+                              : formatDate((row as IClientPayment).payment_date)}
                       </p>
                     </div>
                     <h3 className="invoices-list__amount">{formatMoney(row.current_value)}</h3>

--- a/src/modules/clients/containers/apply-tab/Modals/ModalListAdjustments/ModalListAdjustments.tsx
+++ b/src/modules/clients/containers/apply-tab/Modals/ModalListAdjustments/ModalListAdjustments.tsx
@@ -18,7 +18,7 @@ import SecondaryButton from "@/components/atoms/buttons/secondaryButton/Secondar
 import CheckboxColoredValues from "@/components/ui/checkbox-colored-values/checkbox-colored-values";
 import ModalApplySpecificAdjustment from "../ModalApplySpecificAdjustment/ModalApplySpecificAdjustment";
 
-import { IModalAdjustmentsState } from "../../apply-tab";
+import { IAddingType, IModalAdjustmentsState } from "../../apply-tab";
 import { IApplyTabRecord, IApplicationBalance } from "@/types/applyTabClients/IApplyTabClients";
 
 import "./modalListAdjustments.scss";
@@ -31,7 +31,7 @@ interface ModalListAdjustmentsProps {
   setModalAction: (modalAction: number) => void;
   addGlobalAdjustment: (
     // eslint-disable-next-line no-unused-vars
-    adding_type: "invoices" | "payments" | "credit_notes",
+    adding_type: IAddingType,
     // eslint-disable-next-line no-unused-vars
     selectedIds: number[]
   ) => Promise<void>;
@@ -115,7 +115,7 @@ const ModalListAdjustments: React.FC<ModalListAdjustmentsProps> = ({
     setLoading(true);
     if (modalAdjustmentsState.adjustmentType === "global") {
       await addGlobalAdjustment(
-        "credit_notes",
+        "balances",
         selectedRows.map((row) => row.id)
       );
     } else if (modalAdjustmentsState.adjustmentType === "byInvoice") {

--- a/src/modules/clients/containers/apply-tab/Modals/ModalListAdjustments/ModalListAdjustments.tsx
+++ b/src/modules/clients/containers/apply-tab/Modals/ModalListAdjustments/ModalListAdjustments.tsx
@@ -31,7 +31,7 @@ interface ModalListAdjustmentsProps {
   setModalAction: (modalAction: number) => void;
   addGlobalAdjustment: (
     // eslint-disable-next-line no-unused-vars
-    adding_type: "invoices" | "payments" | "discounts",
+    adding_type: "invoices" | "payments" | "credit_notes",
     // eslint-disable-next-line no-unused-vars
     selectedIds: number[]
   ) => Promise<void>;
@@ -115,7 +115,7 @@ const ModalListAdjustments: React.FC<ModalListAdjustmentsProps> = ({
     setLoading(true);
     if (modalAdjustmentsState.adjustmentType === "global") {
       await addGlobalAdjustment(
-        "discounts",
+        "credit_notes",
         selectedRows.map((row) => row.id)
       );
     } else if (modalAdjustmentsState.adjustmentType === "byInvoice") {

--- a/src/modules/clients/containers/apply-tab/apply-tab.tsx
+++ b/src/modules/clients/containers/apply-tab/apply-tab.tsx
@@ -51,7 +51,7 @@ interface ISelectedRowKeys {
 
 export interface IModalAddToTableOpen {
   isOpen: boolean;
-  adding?: "invoices" | "payments" | "credit_notes";
+  adding?: "invoices" | "payments" | "credit_notes" | "balances";
 }
 
 export interface IModalAdjustmentsState {
@@ -118,7 +118,7 @@ const ApplyTab: React.FC<IApplyTabProps> = ({
     isValidating,
     setPreventRevalidation
   } = useApplicationTable();
-  const showModal = (adding_type: "invoices" | "payments" | "credit_notes") => {
+  const showModal = (adding_type: "invoices" | "payments" | "credit_notes" | "balances") => {
     setIsModalAddToTableOpen({
       isOpen: true,
       adding: adding_type
@@ -138,7 +138,7 @@ const ApplyTab: React.FC<IApplyTabProps> = ({
   };
 
   const handleAdd = async (
-    adding_type: "invoices" | "payments" | "discounts" | "credit_notes",
+    adding_type: "invoices" | "payments" | "credit_notes" | "balances",
     selectedIds: number[]
   ) => {
     // Handle adding selected
@@ -146,17 +146,16 @@ const ApplyTab: React.FC<IApplyTabProps> = ({
       await addItemsToTable(projectId, clientId, adding_type, selectedIds);
 
       showMessage("success", "Se han agregado los elementos correctamente");
-      if (adding_type !== "discounts") {
-        setIsModalAddToTableOpen({
-          isOpen: false
-        });
-      } else {
-        setModalAdjustmentsState({
-          isOpen: false,
-          modal: 0,
-          adjustmentType: undefined
-        });
-      }
+      // handleAdd is shared by ModalAddToTables and ModalListAdjustments; only one is open
+      // at a time, so close both regardless of adding_type.
+      setIsModalAddToTableOpen({
+        isOpen: false
+      });
+      setModalAdjustmentsState({
+        isOpen: false,
+        modal: 0,
+        adjustmentType: undefined
+      });
 
       mutate();
     } catch (error) {
@@ -516,11 +515,7 @@ const ApplyTab: React.FC<IApplyTabProps> = ({
                           showModal("credit_notes");
                         }
                         if (section.statusName === "saldos") {
-                          setModalAdjustmentsState(
-                            modalAdjustmentsState.isOpen
-                              ? { isOpen: false, modal: 1 }
-                              : { isOpen: true, modal: 1 }
-                          );
+                          showModal("balances");
                         }
                       }}
                     >

--- a/src/modules/clients/containers/apply-tab/apply-tab.tsx
+++ b/src/modules/clients/containers/apply-tab/apply-tab.tsx
@@ -41,7 +41,9 @@ import { IApplyTabRecord } from "@/types/applyTabClients/IApplyTabClients";
 
 import "./apply-tab.scss";
 import { CLIENTUUID_DEMO } from "@/utils/constants/globalConstants";
+import { type } from "node:os";
 
+export type IAddingType = "invoices" | "payments" | "credit_notes" | "balances";
 interface ISelectedRowKeys {
   invoices: React.Key[];
   payments: React.Key[];
@@ -137,10 +139,8 @@ const ApplyTab: React.FC<IApplyTabProps> = ({
     });
   };
 
-  const handleAdd = async (
-    adding_type: "invoices" | "payments" | "credit_notes" | "balances",
-    selectedIds: number[]
-  ) => {
+  const handleAdd = async (adding_type: IAddingType, selectedIds: number[]) => {
+    console.log("handleAdd called with:", { adding_type, selectedIds });
     // Handle adding selected
     try {
       await addItemsToTable(projectId, clientId, adding_type, selectedIds);
@@ -515,7 +515,11 @@ const ApplyTab: React.FC<IApplyTabProps> = ({
                           showModal("credit_notes");
                         }
                         if (section.statusName === "saldos") {
-                          showModal("balances");
+                          setModalAdjustmentsState(
+                            modalAdjustmentsState.isOpen
+                              ? { isOpen: false, modal: 1 }
+                              : { isOpen: true, modal: 1 }
+                          );
                         }
                       }}
                     >

--- a/src/services/applyTabClients/applyTabClients.ts
+++ b/src/services/applyTabClients/applyTabClients.ts
@@ -7,11 +7,12 @@ import { StatusGroup } from "@/hooks/useAcountingAdjustment";
 import { IApplicationBalanceStatusGroup } from "@/types/applyTabClients/IApplyTabClients";
 import { CLIENTUUID_DEMO, PROJECTID_DEMO } from "@/utils/constants/globalConstants";
 import { getCorrectMimeType } from "@/utils/files/getCorrectMimeType";
+import { balanceLegalization } from "../accountingAdjustment/accountingAdjustment";
 
 export const addItemsToTable = async (
   project_id: number,
   client_id: string,
-  adding_type: "invoices" | "payments" | "discounts" | "credit_notes",
+  adding_type: "invoices" | "payments" | "credit_notes" | "balances",
   selected_items_ids: number[]
 ) => {
   const modelData = {
@@ -19,9 +20,8 @@ export const addItemsToTable = async (
     clientUUID: client_id,
     ...(adding_type === "invoices" && { invoice_ids: selected_items_ids }),
     ...(adding_type === "payments" && { payment_ids: selected_items_ids }),
-    ...((adding_type === "discounts" || adding_type === "credit_notes") && {
-      discount_ids: selected_items_ids
-    })
+    ...(adding_type === "credit_notes" && { discount_ids: selected_items_ids }),
+    ...(adding_type === "balances" && { balance_ids: selected_items_ids })
   };
   try {
     const response: GenericResponse<{ applications: number[] }> = await instance.post(


### PR DESCRIPTION
This pull request extends the "Apply Tab" feature to support handling and adding "balances" (saldos) alongside invoices, payments, and credit notes. The changes are focused on introducing the new "balances" type throughout the relevant modals, types, and service methods, ensuring users can select, view, and add balances in the same way as other financial records.

**Key changes include:**

**Support for "balances" in UI and logic:**

* Added "balances" as a valid `adding_type` throughout the UI, including in type definitions (`IAddingType`), modal props, and state management, so users can now select and add balances in the Apply Tab modals. [[1]](diffhunk://#diff-783ab654e6b1029e83918ef67351ca29faaefef8709bda898a5ab3aee63eef72L54-R56) [[2]](diffhunk://#diff-783ab654e6b1029e83918ef67351ca29faaefef8709bda898a5ab3aee63eef72L121-R123) [[3]](diffhunk://#diff-783ab654e6b1029e83918ef67351ca29faaefef8709bda898a5ab3aee63eef72L140-L159) [[4]](diffhunk://#diff-e98b7d0469816dd27289bcde870eb0e31caed8416fbaf58a5187467370ecf4e2L34-R34) [[5]](diffhunk://#diff-9a14f0834273e85272b5ccee87fc7b9549f5bb1a7e4ac8007003b7da33ff7bc7R24-R34) [[6]](diffhunk://#diff-9a14f0834273e85272b5ccee87fc7b9549f5bb1a7e4ac8007003b7da33ff7bc7R52-R55) [[7]](diffhunk://#diff-9a14f0834273e85272b5ccee87fc7b9549f5bb1a7e4ac8007003b7da33ff7bc7R81-R86) [[8]](diffhunk://#diff-9a14f0834273e85272b5ccee87fc7b9549f5bb1a7e4ac8007003b7da33ff7bc7R100-R103) [[9]](diffhunk://#diff-9a14f0834273e85272b5ccee87fc7b9549f5bb1a7e4ac8007003b7da33ff7bc7L116-R125) [[10]](diffhunk://#diff-9a14f0834273e85272b5ccee87fc7b9549f5bb1a7e4ac8007003b7da33ff7bc7L203-R212)

* Updated UI strings and rendering logic to correctly display balances in lists, selection controls, and empty states, ensuring a consistent user experience for the new record type. [[1]](diffhunk://#diff-9a14f0834273e85272b5ccee87fc7b9549f5bb1a7e4ac8007003b7da33ff7bc7R233-R234) [[2]](diffhunk://#diff-9a14f0834273e85272b5ccee87fc7b9549f5bb1a7e4ac8007003b7da33ff7bc7R287-R288) [[3]](diffhunk://#diff-9a14f0834273e85272b5ccee87fc7b9549f5bb1a7e4ac8007003b7da33ff7bc7R350-R360)

**Backend and service integration:**

* Modified the `addItemsToTable` service method to support adding balances by including the `balance_ids` field in the request payload when the "balances" type is selected.

* Updated the logic in `accounting-adjustments-tab.tsx` and `ModalListAdjustments.tsx` to use "credit_notes" and "balances" as the correct types when adding items, aligning the frontend with backend expectations. [[1]](diffhunk://#diff-630ea3023eeabaf97263a144a91461c4235cbd3e49829c4b0b2166ce0177e384L115-R115) [[2]](diffhunk://#diff-e98b7d0469816dd27289bcde870eb0e31caed8416fbaf58a5187467370ecf4e2L118-R118)

These changes collectively allow users to manage balances in the same workflow as other financial adjustments, improving the flexibility and completeness of the Apply Tab feature.