### PR TITLE
feat(apply-tab): add balances section to result modal and separate ap…

### DIFF
--- a/src/modules/clients/containers/apply-tab/Modals/ModalResultApply/ModalResultAppy.tsx
+++ b/src/modules/clients/containers/apply-tab/Modals/ModalResultApply/ModalResultAppy.tsx
@@ -11,6 +11,7 @@ const { Panel } = Collapse;
 interface Props {
   invoices?: number;
   desconts?: number;
+  balances?: number;
   payments?: number;
   total?: number;
   defaultPosition?: { x: number; y: number };
@@ -19,6 +20,7 @@ interface Props {
 export const ModalResultAppy = ({
   invoices,
   desconts,
+  balances,
   payments,
   total,
   defaultPosition: defaultPositionProp
@@ -37,9 +39,7 @@ export const ModalResultAppy = ({
 
   const draggleRef = useRef<HTMLDivElement>(null);
   const [bounds, setBounds] = useState({ left: 0, top: 0, bottom: 0, right: 0 });
-  const [defaultPosition, setDefaultPosition] = useState(
-    defaultPositionProp ?? { x: 0, y: -160 }
-  );
+  const [defaultPosition, setDefaultPosition] = useState(defaultPositionProp ?? { x: 0, y: -160 });
 
   const onStart = (_event: DraggableEvent, uiData: DraggableData) => {
     const { clientWidth, clientHeight } = window.document.documentElement;
@@ -83,9 +83,15 @@ export const ModalResultAppy = ({
                 <div>{formatMoney(payments)}</div>
               </Flex>
               <Flex justify="space-between" className="descuentos">
-                <div>Descuentos</div>
+                <div>Notas crédito</div>
                 <div className={desconts === 0 ? "no-value" : ""}>
                   {desconts === 0 ? "-" : formatMoney(desconts)}
+                </div>
+              </Flex>
+              <Flex justify="space-between" className="descuentos">
+                <div>Saldos</div>
+                <div className={balances === 0 ? "no-value" : ""}>
+                  {balances === 0 ? "-" : formatMoney(balances)}
                 </div>
               </Flex>
             </Flex>

--- a/src/modules/clients/containers/apply-tab/Modals/ModalResultApply/modalResultAppy.scss
+++ b/src/modules/clients/containers/apply-tab/Modals/ModalResultApply/modalResultAppy.scss
@@ -59,6 +59,7 @@
     .facturas,
     .pagos,
     .descuentos,
+    .saldos,
     .saldo {
         display: flex;
         justify-content: space-between;

--- a/src/modules/clients/containers/apply-tab/apply-tab.tsx
+++ b/src/modules/clients/containers/apply-tab/apply-tab.tsx
@@ -306,7 +306,7 @@ const ApplyTab: React.FC<IApplyTabProps> = ({
       color: "#000000",
       statusId: 4,
       itemsList: filteredData?.balances,
-      total: applicationData?.summary.total_balance,
+      total: applicationData?.summary.total_application_balance,
       count: filteredData?.balances.length
     };
 
@@ -437,6 +437,7 @@ const ApplyTab: React.FC<IApplyTabProps> = ({
       <ModalResultAppy
         invoices={applicationData?.summary.total_invoices}
         desconts={applicationData?.summary.total_discounts}
+        balances={applicationData?.summary.total_application_balance}
         payments={applicationData?.summary.total_payments}
         total={applicationData?.summary.total_balance}
         defaultPosition={defaultPositionDragModal}

--- a/src/types/applyTabClients/IApplyTabClients.ts
+++ b/src/types/applyTabClients/IApplyTabClients.ts
@@ -44,6 +44,7 @@ export interface IApplyTabClients {
     total_payments: number;
     total_discounts: number;
     total_balance: number;
+    total_application_balance: number;
     url_log: string;
     url_attachment: string | null;
     attachment_name: string | null;


### PR DESCRIPTION
…plication balance

- Added new `total_application_balance` field to track balances separately from total balance
- Introduced "Saldos" display section in ModalResultAppy component
- Renamed "Descuentos" label to "Notas crédito" for clarity
- Updated type definitions and component props to support the new balances feature