### PR TITLE
Refactor/split ajusted statet in apply tab4 saldos

### DIFF
--- a/src/modules/clients/containers/apply-tab/Modals/ModalListAdjustments/ModalListAdjustments.tsx
+++ b/src/modules/clients/containers/apply-tab/Modals/ModalListAdjustments/ModalListAdjustments.tsx
@@ -192,7 +192,7 @@ const ModalListAdjustments: React.FC<ModalListAdjustmentsProps> = ({
                 {paginatedRows?.map((row) => {
                   const isGlobal = modalAdjustmentsState.adjustmentType === "global";
                   const title = isGlobal
-                    ? `Nota crédito ${(row as IApplicationBalance).id}`
+                    ? row.comments
                     : `Nota crédito ${(row as IFinancialDiscount).erp_id}`;
                   const subtitle = isGlobal
                     ? formatDate((row as IApplicationBalance).created_at)

--- a/src/modules/clients/containers/apply-tab/Modals/ModalListAdjustments/ModalListAdjustments.tsx
+++ b/src/modules/clients/containers/apply-tab/Modals/ModalListAdjustments/ModalListAdjustments.tsx
@@ -65,22 +65,30 @@ const ModalListAdjustments: React.FC<ModalListAdjustmentsProps> = ({
   const [isApplyingSpecificAdjustment, setIsApplyingSpecificAdjustment] = useState(false);
 
   useEffect(() => {
+    if (!visible) return;
+    let ignore = false;
+
     const fetchData = async () => {
       setLoadingData(true);
-      if (modalAdjustmentsState.adjustmentType === "global") {
-        const response = await getApplicationBalances(projectId, clientId);
-        setAdjustments(response?.flatMap((group) => group.balances) ?? []);
-      } else {
-        const response = await getApplicationAdjustments(projectId, clientId);
-        setAdjustments(response.map((item) => item.financial_discounts).flat());
+      try {
+        if (modalAdjustmentsState.adjustmentType === "global") {
+          const response = await getApplicationBalances(projectId, clientId);
+          if (!ignore) setAdjustments(response?.flatMap((group) => group.balances) ?? []);
+        } else {
+          const response = await getApplicationAdjustments(projectId, clientId);
+          if (!ignore) setAdjustments(response.map((item) => item.financial_discounts).flat());
+        }
+      } catch (error) {
+        console.error("error fetchData", error);
+      } finally {
+        if (!ignore) setLoadingData(false);
       }
-      setLoadingData(false);
     };
-    try {
-      fetchData();
-    } catch (error) {
-      console.error("error fetchData", error);
-    }
+
+    fetchData();
+    return () => {
+      ignore = true;
+    };
   }, [projectId, clientId, visible, modalAdjustmentsState.adjustmentType]);
 
   useEffect(() => {

--- a/src/modules/clients/containers/apply-tab/Modals/ModalSelectAjustements/ModalSelectAjustements.tsx
+++ b/src/modules/clients/containers/apply-tab/Modals/ModalSelectAjustements/ModalSelectAjustements.tsx
@@ -38,7 +38,7 @@ export const ModalSelectAjustements: React.FC<ModalSelectAjustementsProps> = ({
           icon={<NewspaperClipping size={20} />}
           title="Por factura"
           onClick={() => {
-            setModalAction(2, "byInvoice");
+            setModalAction(4, "byInvoice");
           }}
         />
       </div>

--- a/src/modules/clients/containers/apply-tab/apply-tab.tsx
+++ b/src/modules/clients/containers/apply-tab/apply-tab.tsx
@@ -652,7 +652,7 @@ const ApplyTab: React.FC<IApplyTabProps> = ({
             mutate();
           } else {
             setModalAdjustmentsState((prev) => {
-              return { ...prev, isOpen: true, modal: 2 };
+              return { ...prev, isOpen: true, modal: 1 };
             });
           }
         }}

--- a/src/types/applyTabClients/IApplyTabClients.ts
+++ b/src/types/applyTabClients/IApplyTabClients.ts
@@ -97,6 +97,7 @@ export interface IApplicationBalance {
   is_deleted: number;
   financial_record_id: number | null;
   created_at: string;
+  comments: string | null;
 }
 
 export interface IApplicationBalanceStatusGroup {


### PR DESCRIPTION
This pull request introduces several improvements and bug fixes to the adjustments modals in the Apply Tab, focusing on safer data fetching, UI consistency, and data structure updates. The main changes include making the data fetching in `ModalListAdjustments` more robust, updating the display logic for adjustment titles, correcting modal action handling, and extending the `IApplicationBalance` type.

**Improvements to data fetching and UI behavior:**

- Improved the `useEffect` in `ModalListAdjustments` to safely handle asynchronous data fetching by using an `ignore` flag to prevent state updates on unmounted components, and ensuring loading state is correctly managed.

**UI/UX adjustments and modal logic:**

- Changed the title displayed for global adjustments in `ModalListAdjustments` to show the `comments` field instead of a generic credit note label.
- Fixed the modal action index for "Por factura" selection in `ModalSelectAjustements` to use the correct value, ensuring the intended modal is shown.
- Updated the modal index when opening the adjustments modal from the main Apply Tab to maintain consistency in modal navigation.

**Type and data structure updates:**

- Added a `comments` field to the `IApplicationBalance` interface to support displaying comments in the UI.