### PR TITLE
Staging

### DIFF
--- a/src/modules/commerce/components/create-order-checkout/modal-shipping-info/modal-shipping-info.tsx
+++ b/src/modules/commerce/components/create-order-checkout/modal-shipping-info/modal-shipping-info.tsx
@@ -480,12 +480,13 @@ export default function ModalShippingInfo({
               <label className="text-[10px] font-semibold text-[#666666]">Observaciones</label>
               <textarea
                 placeholder="Instrucciones especiales para esta entrega"
-                maxLength={128}
+                maxLength={35}
                 value={draft.observaciones}
                 onChange={(e) => setDraft((d) => ({ ...d, observaciones: e.target.value }))}
                 rows={3}
                 className="w-full px-2.5 py-2 text-xs bg-[#F7F7F7] border border-[#DDDDDD] rounded-lg outline-none focus:border-[#141414] transition-colors text-[#141414] placeholder:text-[#999999] resize-none"
               />
+              <p className="text-[10px] text-[#999999]">Máximo 35 caracteres</p>
             </div>
           </div>
         </div>

--- a/src/modules/commerce/components/create-order-checkout/order-shipment-confirm/order-shipment-confirm.tsx
+++ b/src/modules/commerce/components/create-order-checkout/order-shipment-confirm/order-shipment-confirm.tsx
@@ -589,13 +589,13 @@ export default function OrderShipmentConfirm({
                 <label className="text-xs font-semibold text-[#666666]">Observaciones</label>
                 <textarea
                   placeholder="Ingresar un comentario"
-                  maxLength={64}
+                  maxLength={35}
                   value={singleForm.observaciones}
                   onChange={(e) => setSingleForm((f) => ({ ...f, observaciones: e.target.value }))}
                   rows={3}
                   className="w-full px-3 py-2.5 text-sm bg-[#F7F7F7] border border-[#DDDDDD] rounded-lg outline-none focus:border-[#141414] transition-colors text-[#141414] placeholder:text-[#999999] resize-none"
                 />
-                <p className="text-[10px] text-[#999999]">Máximo 64 caracteres</p>
+                <p className="text-[10px] text-[#999999]">Máximo 35 caracteres</p>
               </div>
             </div>
           )}

--- a/src/modules/commerce/components/create-order-discounts-modal/create-order-discounts-modal.module.scss
+++ b/src/modules/commerce/components/create-order-discounts-modal/create-order-discounts-modal.module.scss
@@ -1,18 +1,12 @@
 @import "@/styles/variables.scss";
 
-.discountsModal {
+.discountsModalContent {
     background-color: $white;
     display: flex;
     flex-direction: column;
     gap: 1rem;
     border-radius: 10px;
     padding: 1.375rem 1.5rem;
-    z-index: 3;
-    box-shadow: 0px 0px 0px 2000px rgba(0, 0, 0, 0.5);
-    position: absolute;
-    bottom: 1rem;
-    left: 1rem;
-    right: 1rem;
     overflow-y: hidden;
     max-height: 600px;
 
@@ -80,4 +74,14 @@
             }
         }
     }
+}
+
+// Non-floating variant: overlay + absolute positioning on top of the shared content styles.
+.discountsModal {
+    z-index: 3;
+    box-shadow: 0px 0px 0px 2000px rgba(0, 0, 0, 0.5);
+    position: absolute;
+    bottom: 1rem;
+    left: 1rem;
+    right: 1rem;
 }

--- a/src/modules/commerce/components/create-order-discounts-modal/create-order-discounts-modal.tsx
+++ b/src/modules/commerce/components/create-order-discounts-modal/create-order-discounts-modal.tsx
@@ -1,5 +1,5 @@
 import { Dispatch, FC, SetStateAction, useContext, useEffect, useState } from "react";
-import { Spin } from "antd";
+import { Modal, Spin } from "antd";
 import { WarningDiamond, X } from "@phosphor-icons/react";
 
 import PrincipalButton from "@/components/atoms/buttons/principalButton/PrincipalButton";
@@ -12,10 +12,14 @@ import styles from "./create-order-discounts-modal.module.scss";
 
 export interface CreateOrderDiscountsModalProps {
   setOpenDiscountsModal: Dispatch<SetStateAction<boolean>>;
+  floating?: boolean;
+  open?: boolean;
 }
 
 const CreateOrderDiscountsModal: FC<CreateOrderDiscountsModalProps> = ({
-  setOpenDiscountsModal
+  setOpenDiscountsModal,
+  floating = false,
+  open = false
 }) => {
   const [radioValue, setRadioValue] = useState<IDiscountPackageAvailable>();
   const { selectedDiscount, setSelectedDiscount, discounts, discountsLoading } =
@@ -49,8 +53,8 @@ const CreateOrderDiscountsModal: FC<CreateOrderDiscountsModalProps> = ({
     padding: "1rem"
   };
 
-  return (
-    <div className={styles.discountsModal}>
+  const content = (
+    <>
       <div className={styles.header}>
         <h3>Descuentos</h3>
         <button onClick={() => setOpenDiscountsModal(false)} className={styles.buttonClose}>
@@ -92,7 +96,27 @@ const CreateOrderDiscountsModal: FC<CreateOrderDiscountsModalProps> = ({
       <PrincipalButton disabled={false} onClick={handleApplyDiscounts}>
         Aplicar
       </PrincipalButton>
-    </div>
+    </>
+  );
+
+  if (floating) {
+    return (
+      <Modal
+        open={open}
+        onCancel={() => setOpenDiscountsModal(false)}
+        footer={null}
+        closable={false}
+        centered
+        width={520}
+        className="createOrderDiscountsModalFloating"
+      >
+        <div className={styles.discountsModalContent}>{content}</div>
+      </Modal>
+    );
+  }
+
+  return (
+    <div className={`${styles.discountsModalContent} ${styles.discountsModal}`}>{content}</div>
   );
 };
 

--- a/src/modules/commerce/components/create-order-search-client/cartera-card/cartera-card.tsx
+++ b/src/modules/commerce/components/create-order-search-client/cartera-card/cartera-card.tsx
@@ -34,15 +34,15 @@ function CarteraCard({ cartera, cupo }: ICarteraCardProps) {
       <div className="px-5 py-4 flex flex-col gap-3">
         <div className="flex items-center justify-between">
           <div>
-            <p className="text-[11px] text-[#999999] mb-0.5">Cupo total</p>
-            <p className="text-sm font-bold text-[#141414]">
-              {formatMoney(noQuota ? 0 : cupo.totalQuota, { hideDecimals: true })}
-            </p>
-          </div>
-          <div className="text-right">
             <p className="text-[11px] text-[#999999] mb-0.5">Cupo disponible</p>
             <p className="text-sm font-bold text-[#141414]">
               {formatMoney(noQuota ? 0 : cupo.availableQuota, { hideDecimals: true })}
+            </p>
+          </div>
+          <div className="text-right">
+            <p className="text-[11px] text-[#999999] mb-0.5">Cupo total</p>
+            <p className="text-sm font-bold text-[#141414]">
+              {formatMoney(noQuota ? 0 : cupo.totalQuota, { hideDecimals: true })}
             </p>
           </div>
         </div>

--- a/src/modules/commerce/containers/create-order/create-order.tsx
+++ b/src/modules/commerce/containers/create-order/create-order.tsx
@@ -9,6 +9,7 @@ import SearchClient from "../../components/create-order-search-client/create-ord
 import CreateOrderMarket from "../../components/create-order-market";
 import CreateOrderCart from "../../components/create-order-cart";
 import CreateOrderCheckout from "../../components/create-order-checkout";
+import CreateOrderDiscountsModal from "../../components/create-order-discounts-modal/create-order-discounts-modal";
 
 import {
   IBonus,
@@ -79,6 +80,7 @@ export const CreateOrderView: FC = () => {
   );
   const [discounts, setDiscounts] = useState<IDiscountPackageAvailable[]>([]);
   const [discountsLoading, setDiscountsLoading] = useState(false);
+  const [openDiscountsModal, setOpenDiscountsModal] = useState(false);
   const [executiveDiscounts, setExecutiveDiscounts] = useState<IExecutiveDiscount[]>([]);
   const [deactivateCrossSelling, setDeactivateCrossSelling] = useState(true);
   const [orderSplitDetails, setOrderSplitDetails] = useState<IOrderSplitDetail[]>([]);
@@ -106,6 +108,10 @@ export const CreateOrderView: FC = () => {
           setDiscounts(response.data);
           // Seleccionar el primer descuento por defecto
           setSelectedDiscount(response.data[0]);
+          // Si hay mas de un descuento, abrir el modal para que el usuario elija
+          if (response.data.length > 1) {
+            setOpenDiscountsModal(true);
+          }
         }
       } catch (error) {
         console.error("Error fetching discounts:", error);
@@ -262,6 +268,11 @@ export const CreateOrderView: FC = () => {
           </div>
         )}
       </div>
+      <CreateOrderDiscountsModal
+        floating
+        open={openDiscountsModal}
+        setOpenDiscountsModal={setOpenDiscountsModal}
+      />
     </OrderViewContext.Provider>
   );
 };


### PR DESCRIPTION
This pull request introduces several improvements and refinements to the order creation flow, focusing on the discounts modal, user input constraints, and UI clarity. The most significant changes include refactoring the discounts modal to support a floating variant using Ant Design's `Modal`, enforcing a shorter character limit for "Observaciones" fields, and clarifying quota labels in the client card component.

**Discounts Modal Enhancements:**

- Refactored the discounts modal to support both floating (modal) and non-floating variants, utilizing Ant Design's `Modal` component when `floating` is true. The modal can now be conditionally displayed based on the number of available discounts. [[1]](diffhunk://#diff-b5800f93dab201c6fffa8b1e4a3245449fa225e38ea74fdc66576f51c2f2c8beL2-R2) [[2]](diffhunk://#diff-b5800f93dab201c6fffa8b1e4a3245449fa225e38ea74fdc66576f51c2f2c8beR15-R22) [[3]](diffhunk://#diff-b5800f93dab201c6fffa8b1e4a3245449fa225e38ea74fdc66576f51c2f2c8beL52-R57) [[4]](diffhunk://#diff-b5800f93dab201c6fffa8b1e4a3245449fa225e38ea74fdc66576f51c2f2c8beL95-R119) [[5]](diffhunk://#diff-68e2136af859399549bd1836fa204041ca4ace9fa42a8726f239748624768f4bR12) [[6]](diffhunk://#diff-68e2136af859399549bd1836fa204041ca4ace9fa42a8726f239748624768f4bR83) [[7]](diffhunk://#diff-68e2136af859399549bd1836fa204041ca4ace9fa42a8726f239748624768f4bR111-R114) [[8]](diffhunk://#diff-68e2136af859399549bd1836fa204041ca4ace9fa42a8726f239748624768f4bR271-R275)

- Updated the SCSS for the discounts modal to separate shared content styles from overlay/floating styles, improving maintainability and clarity. [[1]](diffhunk://#diff-074a26b2398cd9c73286470f292e6a6c4133bd88cb9ff15867ceda9096a74576L3-L15) [[2]](diffhunk://#diff-074a26b2398cd9c73286470f292e6a6c4133bd88cb9ff15867ceda9096a74576R78-R87)

**User Input Constraints and UI Feedback:**

- Reduced the maximum length for "Observaciones" (comments) fields in both the shipping info and shipment confirmation components to 35 characters, and updated the UI text to reflect the new limit. [[1]](diffhunk://#diff-2e1f1a59b8dddb69323f5ee3f61a1d246defd5d9f86c4f374ae07dd17f276762L483-R489) [[2]](diffhunk://#diff-b4b4f1944cce9e8aa8c492a8f2f229c936efa65b0f39a3a91defef11e8fe7911L592-R598)

**UI Labeling Improvements:**

- Swapped the labels and values for "Cupo total" and "Cupo disponible" in the client card component to more accurately reflect the available and total quota, improving clarity for users.