### PR TITLE
Feat/86e1ww007/client balances

### DIFF
--- a/src/app/clientes/detail/[clientId]/project/[projectId]/layout.tsx
+++ b/src/app/clientes/detail/[clientId]/project/[projectId]/layout.tsx
@@ -85,7 +85,8 @@ const ClientDetailsLayout: FC<ClientDetailsLayoutProps> = ({ children }) => {
     { key: "pagos", label: "Pagos" },
     { key: "aplicacion", label: "Aplicación" },
     { key: "contactos", label: "Contactos" },
-    { key: "historial", label: "Historial" }
+    { key: "historial", label: "Historial" },
+    { key: "saldos", label: "Saldos" }
   ];
 
   const ClientDetailObject: ClientDetailsContextType = useMemo(

--- a/src/app/clientes/detail/[clientId]/project/[projectId]/saldos/page.tsx
+++ b/src/app/clientes/detail/[clientId]/project/[projectId]/saldos/page.tsx
@@ -1,0 +1,12 @@
+"use client";
+
+import { SaldosProvider } from "@/modules/balances/context/saldos-context";
+import { ClientBalancesView } from "@/modules/balances/containers/ClientBalancesView/ClientBalancesView";
+
+const SaldosPage = () => (
+  <SaldosProvider>
+    <ClientBalancesView />
+  </SaldosProvider>
+);
+
+export default SaldosPage;

--- a/src/hooks/useBalances.ts
+++ b/src/hooks/useBalances.ts
@@ -12,6 +12,7 @@ export const useBalances = (filters?: IBalancesFilter) => {
   if (filters?.clients.length) queries.push(`clients=${filters.clients.join(",")}`);
   if (filters?.from_date) queries.push(`from_date=${filters.from_date}`);
   if (filters?.to_date) queries.push(`to_date=${filters.to_date}`);
+  if (filters?.client_uuid) queries.push(`client_uuid=${filters.client_uuid}`);
 
   const queryString = queries.length > 0 ? `?${queries.join("&")}` : "";
 

--- a/src/modules/balances/components/FilterBalances/FilterBalances.tsx
+++ b/src/modules/balances/components/FilterBalances/FilterBalances.tsx
@@ -1,0 +1,100 @@
+import { Dropdown } from "antd";
+import { Filter, ChevronDown, Tag } from "lucide-react";
+
+import { Button } from "@/modules/chat/ui/button";
+import { DateRangeFilter } from "@/components/atoms/DateRangeFilter/DateRangeFilter";
+
+export interface ISaldosFilterValue {
+  motives: string[]; // selected motive names
+  from_date: string | null;
+  to_date: string | null;
+}
+
+interface SaldosMotive {
+  id: number;
+  name: string;
+}
+
+interface IFilterBalancesProps {
+  motives: SaldosMotive[];
+  value: ISaldosFilterValue;
+  onChange: (next: ISaldosFilterValue) => void;
+  isLoading?: boolean;
+}
+
+const toggle = <T,>(arr: T[], id: T): T[] =>
+  arr.includes(id) ? arr.filter((item) => item !== id) : [...arr, id];
+
+export function FilterBalances({ motives, value, onChange, isLoading }: IFilterBalancesProps) {
+  const menu = (
+    <div className="bg-cashport-white border border-cashport-gray-light rounded-lg shadow-lg w-96">
+      <div className="p-4 space-y-4">
+        {/* Tipo Filter Section */}
+        <div>
+          <label className="text-xs font-semibold text-gray-700 uppercase tracking-wide mb-2 block">
+            <Tag className="h-3 w-3 inline mr-1" />
+            Tipo
+          </label>
+          <div className="max-h-40 overflow-y-auto border border-gray-200 rounded-md">
+            <button
+              type="button"
+              className={`w-full text-left px-3 py-2 text-sm hover:bg-cashport-gray-lighter transition-colors ${
+                value.motives.length === 0
+                  ? "bg-cashport-green text-cashport-black font-medium"
+                  : "text-cashport-black"
+              }`}
+              onClick={() => onChange({ ...value, motives: [] })}
+            >
+              Todos los tipos
+            </button>
+
+            {motives?.map((motive) => (
+              <button
+                type="button"
+                key={motive.id}
+                className={`w-full text-left px-3 py-2 text-sm hover:bg-cashport-gray-lighter transition-colors border-t border-gray-100 ${
+                  value.motives.includes(motive.name)
+                    ? "bg-cashport-green text-cashport-black font-medium"
+                    : "text-cashport-black"
+                }`}
+                onClick={() => onChange({ ...value, motives: toggle(value.motives, motive.name) })}
+              >
+                <div className="truncate" title={motive.name}>
+                  {motive.name}
+                </div>
+              </button>
+            ))}
+          </div>
+        </div>
+
+        {/* Date Range Filter Section */}
+        <DateRangeFilter
+          dateRange={{ start: value.from_date, end: value.to_date }}
+          onDateRangeChange={(start, end) =>
+            onChange({ ...value, from_date: start || null, to_date: end || null })
+          }
+          onClear={() => onChange({ ...value, from_date: null, to_date: null })}
+        />
+      </div>
+    </div>
+  );
+
+  return (
+    <Dropdown
+      dropdownRender={() => menu}
+      trigger={["click"]}
+      placement="bottomLeft"
+      disabled={isLoading}
+    >
+      <Button
+        variant="outline"
+        disabled={isLoading}
+        className="h-12 border-cashport-gray-light text-cashport-black hover:bg-cashport-gray-lighter bg-transparent"
+      >
+        <Filter className="h-4 w-4 mr-2" />
+        Filtros
+        <ChevronDown className="h-4 w-4 ml-2" />
+      </Button>
+    </Dropdown>
+  );
+}

--- a/src/modules/balances/containers/ClientBalancesView/ClientBalancesView.tsx
+++ b/src/modules/balances/containers/ClientBalancesView/ClientBalancesView.tsx
@@ -1,0 +1,152 @@
+"use client";
+
+import { useState } from "react";
+import { useParams } from "next/navigation";
+
+import { Flex, Spin } from "antd";
+import UiSearchInput from "@/components/ui/search-input/search-input";
+import Collapse from "@/components/ui/collapse";
+import LabelCollapse from "@/components/ui/label-collapse";
+import { Sheet, SheetContent } from "@/modules/chat/ui/sheet";
+import { BalanceDetailModal } from "../../components/BalanceDetailModal/BalanceDetailModal";
+import { BalancesTable } from "../../components/BalancesTable/BalancesTable";
+import { FilterBalances, ISaldosFilterValue } from "../../components/FilterBalances/FilterBalances";
+import { useSaldos } from "../../context/saldos-context";
+import { useBalances } from "@/hooks/useBalances";
+import { useFinancialDiscountMotives } from "@/hooks/useFinancialDiscountMotives";
+import { extractSingleParam } from "@/utils/utils";
+import { IBalanceRow } from "@/types/financialDiscounts/IFinancialDiscounts";
+
+const matchesSearch = (balance: IBalanceRow, term: string) => {
+  if (!term) return true;
+  const lowerTerm = term.toLowerCase();
+  return (
+    String(balance.id).toLowerCase().includes(lowerTerm) ||
+    (balance.client_name ?? "").toLowerCase().includes(lowerTerm) ||
+    (balance.kam_name ?? "").toLowerCase().includes(lowerTerm) ||
+    (balance.motive_name ?? "").toLowerCase().includes(lowerTerm)
+  );
+};
+
+export function ClientBalancesView() {
+  const params = useParams();
+  const clientId = extractSingleParam(params.clientId) || "";
+
+  const [filter, setFilter] = useState<ISaldosFilterValue>({
+    motives: [],
+    from_date: null,
+    to_date: null
+  });
+
+  const { data: balancesData, isLoading: balancesLoading } = useBalances({
+    users: [],
+    clients: [],
+    from_date: filter.from_date,
+    to_date: filter.to_date,
+    client_uuid: clientId
+  });
+
+  const { data: motives, isLoading: motivesLoading } = useFinancialDiscountMotives();
+
+  const { state, toggleSaldoSelection, selectAllSaldos, deselectSaldos } = useSaldos();
+
+  const [searchTerm, setSearchTerm] = useState("");
+  const [selectedSaldoForDetail, setSelectedSaldoForDetail] = useState<IBalanceRow | null>(null);
+  const [isDetailSheetOpen, setIsDetailSheetOpen] = useState(false);
+
+  const openDetailSheet = (balance: IBalanceRow) => {
+    setSelectedSaldoForDetail(balance);
+    setIsDetailSheetOpen(true);
+  };
+
+  const closeDetailSheet = () => {
+    setIsDetailSheetOpen(false);
+  };
+
+  const filteredGroups = (balancesData ?? [])
+    .map((group) => ({
+      ...group,
+      balances: group.balances.filter(
+        (balance) =>
+          matchesSearch(balance, searchTerm) &&
+          (filter.motives.length === 0 || filter.motives.includes(balance.motive_name))
+      )
+    }))
+    .filter((group) => group.balances.length > 0);
+
+  return (
+    <>
+      <div className="clientBalancesView">
+        <Flex justify="space-between" className="clientStickyHeader">
+          <Flex gap={"0.5rem"}>
+            <UiSearchInput
+              className="standardSearch"
+              placeholder="Buscar"
+              onChange={(e) => setSearchTerm(e.target.value)}
+            />
+
+            {/* Saldos Filters Dropdown (Tipo + Fechas) */}
+            <FilterBalances
+              motives={motives ?? []}
+              value={filter}
+              onChange={setFilter}
+              isLoading={motivesLoading}
+            />
+          </Flex>
+        </Flex>
+
+        {/* Grouped tables by state */}
+        {balancesLoading ? (
+          <Flex justify="center" align="center" style={{ height: "3rem" }}>
+            <Spin />
+          </Flex>
+        ) : (
+          <Collapse
+            defaultActiveKey={filteredGroups[0]?.balance_status_id}
+            items={filteredGroups.map((group) => ({
+              key: group.balance_status_id,
+              label: (
+                <LabelCollapse
+                  status={group.balance_status}
+                  color={group.color}
+                  quantity={group.balances_count}
+                  total={group.pending_total}
+                />
+              ),
+              children: (
+                <BalancesTable
+                  data={group.balances}
+                  loading={balancesLoading}
+                  selectedSaldoIds={state.selectedSaldoIds}
+                  onToggleSelection={toggleSaldoSelection}
+                  onSelectAll={selectAllSaldos}
+                  onDeselectAll={deselectSaldos}
+                  onOpenDetail={openDetailSheet}
+                />
+              )
+            }))}
+          />
+        )}
+      </div>
+
+      {/* Detail Sheet */}
+      <Sheet
+        open={isDetailSheetOpen}
+        onOpenChange={(open) => {
+          setIsDetailSheetOpen(open);
+          if (!open) setTimeout(() => setSelectedSaldoForDetail(null), 300);
+        }}
+      >
+        <SheetContent side="right" className="w-full sm:max-w-2xl overflow-y-auto p-0" hideClose>
+          {selectedSaldoForDetail && (
+            <BalanceDetailModal
+              saldoData={selectedSaldoForDetail}
+              onBack={closeDetailSheet}
+              isModal
+            />
+          )}
+        </SheetContent>
+      </Sheet>
+    </>
+  );
+}

--- a/src/modules/commerce/components/create-order-checkout/create-order-checkout.tsx
+++ b/src/modules/commerce/components/create-order-checkout/create-order-checkout.tsx
@@ -187,12 +187,27 @@ export default function CheckoutPage() {
       executive_discounts: executiveDiscounts,
       deactivate_cross_selling: !deactivateCrossSelling
     };
+
+    // El range_promotion_id es el id del rango activo
+    // (promotion.active_range.range_id) del que provienen los
+    // bonificados comunes (bonusOptions). Los "other bonified"
+    // (otherBonificated) no pertenecen a un rango, así que nunca
+    // son fuente de este id; solo usamos bonusOptions para detectar
+    // si aplica enviarlo.
+    const hasCommonBonusProducts = (bonus?.bonusOptions ?? []).some((opt) =>
+      opt.cards.some((card) => card.items.length > 0)
+    );
+    const activeRangeId = confirmOrderData?.promotion?.active_range?.range_id;
+
     return {
       order_summary: orderSummary,
       is_electronic_invoicing: isElectronicInvoicing,
       order_split_details: splitDetails,
       promotion_id: bonus?.id || 0,
-      nit_id: channelCode
+      nit_id: channelCode,
+      ...(hasCommonBonusProducts && activeRangeId
+        ? { range_promotion_id: activeRangeId }
+        : {})
     };
   };
 

--- a/src/modules/commerce/components/create-order-checkout/create-order-checkout.tsx
+++ b/src/modules/commerce/components/create-order-checkout/create-order-checkout.tsx
@@ -91,7 +91,8 @@ export default function CheckoutPage() {
         discount_package: selectedDiscount,
         order_summary: products,
         executive_discounts: executiveDiscounts,
-        deactivate_cross_selling: !deactivateCrossSelling
+        deactivate_cross_selling: !deactivateCrossSelling,
+        ...(bonus?.id !== undefined && { promotion_id: bonus.id })
       };
       try {
         const response = await confirmOrder(projectId, client?.id || "", payload);

--- a/src/types/commerce/ICommerce.ts
+++ b/src/types/commerce/ICommerce.ts
@@ -283,6 +283,13 @@ export interface ICreateOrderData {
   order_split_details: IOrderSplitDetail[];
   promotion_id: number;
   nit_id: string;
+  /**
+   * ID del rango activo (`promotion.active_range.range_id`) del que
+   * provienen los productos bonificados comunes (bonusOptions).
+   * No aplica a los "other bonified" (otherBonificated), que no
+   * pertenecen a un rango de la promoción.
+   */
+  range_promotion_id?: number;
 }
 
 export interface ISucessCreateOrder {

--- a/src/types/financialDiscounts/IFinancialDiscounts.ts
+++ b/src/types/financialDiscounts/IFinancialDiscounts.ts
@@ -117,4 +117,5 @@ export interface IBalancesFilter {
   clients: string[]; // selected client_ids
   from_date: string | null;
   to_date: string | null;
+  client_uuid?: string;
 }


### PR DESCRIPTION
This pull request introduces a new "Saldos" (Balances) section to the client project detail view, providing a dedicated interface for viewing and filtering client balances. It also adds support for filtering balances by client UUID and improves order payload handling in the commerce module. The most important changes are grouped below:

### New "Saldos" Section for Client Projects

* Added a new "Saldos" tab to the client project detail navigation in `ClientDetailsLayout`, making balances accessible from the UI. ([src/app/clientes/detail/[clientId]/project/[projectId]/layout.tsxL88-R89](diffhunk://#diff-ccbdb3050e4fa362b0c3a070951a3c339a65081916d49673ea8b6c108b92ceb9L88-R89))
* Created the `SaldosPage` component, which sets up the balances context and renders the new balances view. ([src/app/clientes/detail/[clientId]/project/[projectId]/saldos/page.tsxR1-R12](diffhunk://#diff-a5543ec63f2323b527620459806fc0c1081d7fdfa5d2bb8f3220a183cf55cb52R1-R12))
* Implemented the `ClientBalancesView` container, providing grouped and filterable balances display, search, and detail modal functionality.
* Added the `FilterBalances` component, enabling users to filter balances by motive type and date range.

### Balances Filtering Enhancements

* Extended the balances filter (`IBalancesFilter`) and the `useBalances` hook to support filtering by `client_uuid`, allowing for more precise queries. [[1]](diffhunk://#diff-1fe47dc61214059edb30433b392fb13a96bbf14d997614b80a2c05554c9b3f3cR120) [[2]](diffhunk://#diff-9c5c7da54bf2dfff19092ab5a73e67be93d8cee7ad9498d129a285c69da9bb22R15)

### Commerce Module Improvements

* Updated the order creation payload in the checkout page to include `promotion_id` and, when applicable, `range_promotion_id` for bonus products, ensuring correct backend processing. [[1]](diffhunk://#diff-946724022fb5b4dbf7742f549668679cba81a28440e35673a4b2b0ff7b8eb7bbL94-R95) [[2]](diffhunk://#diff-946724022fb5b4dbf7742f549668679cba81a28440e35673a4b2b0ff7b8eb7bbR191-R211)
* Documented the new `range_promotion_id` field in the `ICreateOrderData` interface for clarity and maintainability.