### PR TITLE
feat(balances): add send to other balances functionality and API endp…

### DIFF
--- a/src/modules/balances/components/BalanceRowActions/BalanceRowActions.tsx
+++ b/src/modules/balances/components/BalanceRowActions/BalanceRowActions.tsx
@@ -11,6 +11,7 @@ interface BalanceRowActionsProps {
   context?: BalanceTableContext;
   onCargarSoporte: (record: IBalanceRow) => void;
   onEnviarAprobacion: (record: IBalanceRow) => void;
+  onSendOtherBalances: (record: IBalanceRow) => void;
   onDecision: (record: IBalanceRow, action: BalanceDecisionAction) => void;
 }
 
@@ -19,6 +20,7 @@ export function BalanceRowActions({
   context = "balances",
   onCargarSoporte,
   onEnviarAprobacion,
+  onSendOtherBalances,
   onDecision
 }: BalanceRowActionsProps) {
   const statusCode = (record.status_code ?? "").toLowerCase();
@@ -45,8 +47,7 @@ export function BalanceRowActions({
           {
             key: "enviar-otros-saldos",
             label: "Enviar a otros saldos",
-            // eslint-disable-next-line no-console
-            onClick: () => console.log("Enviar a otros saldos", { record })
+            onClick: () => onSendOtherBalances(record)
           },
           {
             key: "cargar-soporte",

--- a/src/modules/balances/components/BalancesTable/BalancesTable.tsx
+++ b/src/modules/balances/components/BalancesTable/BalancesTable.tsx
@@ -1,12 +1,14 @@
 "use client";
 
 import { useState } from "react";
-import { Button, Flex, Table, TableProps } from "antd";
+import { Button, Flex, message, Table, TableProps } from "antd";
 import { Eye } from "@phosphor-icons/react";
 import "./BalancesTable.scss";
 import useScreenHeight from "@/components/hooks/useScreenHeight";
 import useScreenWidth from "@/components/hooks/useScreenWidth";
 import { IBalanceRow } from "@/types/financialDiscounts/IFinancialDiscounts";
+import { sendToOtherBalances } from "@/services/balances/balances";
+import { useMessageApi } from "@/context/MessageContext";
 import { BalanceRowActions, BalanceTableContext } from "../BalanceRowActions/BalanceRowActions";
 import { ModalUploadBalanceFile } from "../ModalUploadBalanceFile/ModalUploadBalanceFile";
 import { ModalSendBalanceToApproval } from "../ModalSendBalanceToApproval/ModalSendBalanceToApproval";
@@ -56,6 +58,7 @@ export function BalancesTable({
 }: BalancesTableProps) {
   const height = useScreenHeight();
   const width = useScreenWidth();
+  const { showMessage } = useMessageApi();
 
   const [activeRecord, setActiveRecord] = useState<IBalanceRow | null>(null);
   const [openModal, setOpenModal] = useState<"upload" | "approval" | "decision" | null>(null);
@@ -73,6 +76,21 @@ export function BalancesTable({
   const handleEnviarAprobacion = (record: IBalanceRow) => {
     setActiveRecord(record);
     setOpenModal("approval");
+  };
+
+  const handleSendOtherBalances = async (record: IBalanceRow) => {
+    const hideLoading = message.loading("Enviando a otros saldos...", 0);
+    try {
+      await sendToOtherBalances(record.id);
+      showMessage("success", "Saldo enviado a otros saldos correctamente");
+      onUploaded?.();
+    } catch (error) {
+      const errorMessage =
+        error instanceof Error ? error.message : "Ocurrió un error al enviar a otros saldos";
+      showMessage("error", errorMessage);
+    } finally {
+      hideLoading();
+    }
   };
 
   const handleDecision = (record: IBalanceRow, action: BalanceDecisionAction) => {
@@ -178,6 +196,7 @@ export function BalancesTable({
             context={context}
             onCargarSoporte={handleCargarSoporte}
             onEnviarAprobacion={handleEnviarAprobacion}
+            onSendOtherBalances={handleSendOtherBalances}
             onDecision={handleDecision}
           />
           <Button

--- a/src/services/balances/balances.ts
+++ b/src/services/balances/balances.ts
@@ -31,3 +31,14 @@ export const uploadBalanceFile = async (
     throw error;
   }
 };
+
+export const sendToOtherBalances = async (balanceId: number) => {
+  try {
+    const response: GenericResponse<any> = await API.patch(
+      `${config.API_HOST}/financial-discount/balance/${balanceId}/classify-other`
+    );
+    return response;
+  } catch (error) {
+    throw error;
+  }
+};


### PR DESCRIPTION
…oint

Adds a new action to send balances to "other balances" category via a new API endpoint. Implements handleSendOtherBalances in BalancesTable with loading state and success/error feedback, and passes the callback to BalanceRowActions.