### PR TITLE
feat(balances): shift motive filtering from client-side to server-side

### DIFF
--- a/src/hooks/useBalances.ts
+++ b/src/hooks/useBalances.ts
@@ -10,6 +10,7 @@ export const useBalances = (filters?: IBalancesFilter) => {
   const queries: string[] = [];
   if (filters?.users.length) queries.push(`users=${filters.users.join(",")}`);
   if (filters?.clients.length) queries.push(`clients=${filters.clients.join(",")}`);
+  if (filters?.motive_ids?.length) queries.push(`motive_ids=${filters.motive_ids.join(",")}`);
   if (filters?.from_date) queries.push(`from_date=${filters.from_date}`);
   if (filters?.to_date) queries.push(`to_date=${filters.to_date}`);
   if (filters?.client_uuid) queries.push(`client_uuid=${filters.client_uuid}`);

--- a/src/modules/balances/components/FilterBalances/FilterBalances.tsx
+++ b/src/modules/balances/components/FilterBalances/FilterBalances.tsx
@@ -5,7 +5,7 @@ import { Button } from "@/modules/chat/ui/button";
 import { DateRangeFilter } from "@/components/atoms/DateRangeFilter/DateRangeFilter";
 
 export interface ISaldosFilterValue {
-  motives: string[]; // selected motive names
+  motive_ids: number[]; // selected motive ids
   from_date: string | null;
   to_date: string | null;
 }
@@ -39,11 +39,11 @@ export function FilterBalances({ motives, value, onChange, isLoading }: IFilterB
             <button
               type="button"
               className={`w-full text-left px-3 py-2 text-sm hover:bg-cashport-gray-lighter transition-colors ${
-                value.motives.length === 0
+                value.motive_ids.length === 0
                   ? "bg-cashport-green text-cashport-black font-medium"
                   : "text-cashport-black"
               }`}
-              onClick={() => onChange({ ...value, motives: [] })}
+              onClick={() => onChange({ ...value, motive_ids: [] })}
             >
               Todos los tipos
             </button>
@@ -53,11 +53,11 @@ export function FilterBalances({ motives, value, onChange, isLoading }: IFilterB
                 type="button"
                 key={motive.id}
                 className={`w-full text-left px-3 py-2 text-sm hover:bg-cashport-gray-lighter transition-colors border-t border-gray-100 ${
-                  value.motives.includes(motive.name)
+                  value.motive_ids.includes(motive.id)
                     ? "bg-cashport-green text-cashport-black font-medium"
                     : "text-cashport-black"
                 }`}
-                onClick={() => onChange({ ...value, motives: toggle(value.motives, motive.name) })}
+                onClick={() => onChange({ ...value, motive_ids: toggle(value.motive_ids, motive.id) })}
               >
                 <div className="truncate" title={motive.name}>
                   {motive.name}

--- a/src/modules/balances/containers/ClientBalancesView/ClientBalancesView.tsx
+++ b/src/modules/balances/containers/ClientBalancesView/ClientBalancesView.tsx
@@ -33,7 +33,7 @@ export function ClientBalancesView() {
   const clientId = extractSingleParam(params.clientId) || "";
 
   const [filter, setFilter] = useState<ISaldosFilterValue>({
-    motives: [],
+    motive_ids: [],
     from_date: null,
     to_date: null
   });
@@ -43,7 +43,8 @@ export function ClientBalancesView() {
     clients: [],
     from_date: filter.from_date,
     to_date: filter.to_date,
-    client_uuid: clientId
+    client_uuid: clientId,
+    motive_ids: filter.motive_ids
   });
 
   const { data: motives, isLoading: motivesLoading } = useFinancialDiscountMotives();
@@ -66,11 +67,7 @@ export function ClientBalancesView() {
   const filteredGroups = (balancesData ?? [])
     .map((group) => ({
       ...group,
-      balances: group.balances.filter(
-        (balance) =>
-          matchesSearch(balance, searchTerm) &&
-          (filter.motives.length === 0 || filter.motives.includes(balance.motive_name))
-      )
+      balances: group.balances.filter((balance) => matchesSearch(balance, searchTerm))
     }))
     .filter((group) => group.balances.length > 0);
 

--- a/src/types/financialDiscounts/IFinancialDiscounts.ts
+++ b/src/types/financialDiscounts/IFinancialDiscounts.ts
@@ -118,4 +118,5 @@ export interface IBalancesFilter {
   from_date: string | null;
   to_date: string | null;
   client_uuid?: string;
+  motive_ids?: number[]; // selected motive ids
 }


### PR DESCRIPTION
Changed filter from using motive names (strings) to motive IDs (numbers) and moved filtering logic to the backend query. Updated FilterBalances component, ClientBalancesView container, useBalances hook, and IBalancesFilter type to support the new motive_ids parameter. This improves performance by filtering on the server instead of the client.