### PR TITLE
fix: update label and display client document in BalanceDetailModal

### DIFF
--- a/src/modules/balances/components/BalanceDetailModal/BalanceDetailModal.tsx
+++ b/src/modules/balances/components/BalanceDetailModal/BalanceDetailModal.tsx
@@ -80,9 +80,9 @@ export function BalanceDetailModal({
               <p className="text-sm font-semibold text-cashport-black">{saldoData.kam_name}</p>
             </div>
             <div>
-              <p className="text-xs text-gray-400">Fecha registro</p>
+              <p className="text-xs text-gray-400">Documento cliente</p>
               <p className="text-sm font-semibold text-cashport-black">
-                {formatDate(saldoData.created_at)}
+                {saldoData.client_documents && saldoData.client_documents[0].document}
               </p>
             </div>
             <div>


### PR DESCRIPTION
This pull request makes a minor update to the `BalanceDetailModal` component to improve the information displayed to the user. Specifically, it replaces the "Fecha registro" (Registration Date) field with "Documento cliente" (Client Document) and shows the first client document instead of the creation date.

- Changed the label from "Fecha registro" to "Documento cliente" and updated the displayed value to show the first client document from `saldoData.client_documents` instead of the registration date in `BalanceDetailModal.tsx`.