### PR TITLE
fix: handle client documents display and add audit file name in Balan…

### DIFF
--- a/src/modules/balances/components/BalanceDetailModal/BalanceDetailModal.tsx
+++ b/src/modules/balances/components/BalanceDetailModal/BalanceDetailModal.tsx
@@ -82,7 +82,9 @@ export function BalanceDetailModal({
             <div>
               <p className="text-xs text-gray-400">Documento cliente</p>
               <p className="text-sm font-semibold text-cashport-black">
-                {saldoData.client_documents && saldoData.client_documents[0].document}
+                {saldoData.client_documents &&
+                  saldoData.client_documents?.length > 0 &&
+                  saldoData.client_documents[0].document}
               </p>
             </div>
             <div>
@@ -125,7 +127,7 @@ export function BalanceDetailModal({
                 className="inline-flex items-center gap-2 px-3 py-2 rounded-lg border border-gray-200 bg-white cursor-pointer text-sm text-cashport-black hover:bg-[#f7f7f7] transition-colors"
               >
                 <Paperclip size={20} />
-                <span>Auditoría</span>
+                <span>{saldoData.audit_file_name}</span>
               </button>
             </div>
           )}

--- a/src/types/financialDiscounts/IFinancialDiscounts.ts
+++ b/src/types/financialDiscounts/IFinancialDiscounts.ts
@@ -88,6 +88,7 @@ export interface IBalanceRow {
   created_at: string;
   financial_record_date: string;
   audit_file_url: string | null;
+  audit_file_name: string | null;
   client_documents: IClientDocument[] | null;
 }
 


### PR DESCRIPTION
…ceDetailModal
This pull request makes small improvements to the `BalanceDetailModal` component and related types to enhance data handling and display. The main changes ensure safer rendering of client document data and display the correct audit file name in the UI.

Improvements to data handling and display:

* Added a check to ensure `client_documents` exists and has at least one item before accessing the document property in `BalanceDetailModal`, preventing potential runtime errors.
* Updated the audit file display in the modal to show the actual `audit_file_name` from `saldoData` instead of the static label "Auditoría".

Type updates:

* Added the `audit_file_name` property to the `IBalanceRow` interface to support the new display logic.