### PR TITLE
refactor(balances): move search filtering to server-side with debounc…

### DIFF
--- a/src/hooks/useBalances.ts
+++ b/src/hooks/useBalances.ts
@@ -14,6 +14,7 @@ export const useBalances = (filters?: IBalancesFilter) => {
   if (filters?.from_date) queries.push(`from_date=${filters.from_date}`);
   if (filters?.to_date) queries.push(`to_date=${filters.to_date}`);
   if (filters?.client_uuid) queries.push(`client_uuid=${filters.client_uuid}`);
+  if (filters?.search) queries.push(`search=${encodeURIComponent(filters.search)}`);
 
   const queryString = queries.length > 0 ? `?${queries.join("&")}` : "";
 

--- a/src/modules/balances/containers/BalancesView/BalancesView.tsx
+++ b/src/modules/balances/containers/BalancesView/BalancesView.tsx
@@ -16,20 +16,10 @@ import { BalancesTable } from "../../components/BalancesTable/BalancesTable";
 import { GroupedFilters } from "../../components/GroupedFilters/GroupedFilters";
 import { useSaldos } from "../../context/saldos-context";
 import { useBalances } from "@/hooks/useBalances";
+import { useDebounce } from "@/hooks/useDeabouce";
 import { getBalancesFilter } from "@/services/accountingAdjustment/accountingAdjustment";
 import { useAppStore } from "@/lib/store/store";
 import { IBalanceRow, IBalancesFilter } from "@/types/financialDiscounts/IFinancialDiscounts";
-
-const matchesSearch = (balance: IBalanceRow, term: string) => {
-  if (!term) return true;
-  const lowerTerm = term.toLowerCase();
-  return (
-    String(balance.id).toLowerCase().includes(lowerTerm) ||
-    (balance.client_name ?? "").toLowerCase().includes(lowerTerm) ||
-    (balance.kam_name ?? "").toLowerCase().includes(lowerTerm) ||
-    (balance.motive_name ?? "").toLowerCase().includes(lowerTerm)
-  );
-};
 
 export function BalancesView() {
   const { ID } = useAppStore((projects) => projects.selectedProject);
@@ -41,11 +31,14 @@ export function BalancesView() {
     to_date: null
   });
 
+  const [searchTerm, setSearchTerm] = useState("");
+  const debouncedSearch = useDebounce(searchTerm, 500);
+
   const {
     data: balancesData,
     isLoading: balancesLoading,
     mutate: mutateBalances
-  } = useBalances(balancesFilter);
+  } = useBalances({ ...balancesFilter, search: debouncedSearch });
 
   const { data: balancesFilters, isLoading: filtersLoading } = useSWR(
     ID ? ["balances-filters", ID] : null,
@@ -54,7 +47,6 @@ export function BalancesView() {
 
   const { state, setFilter, toggleSaldoSelection, selectAllSaldos, deselectSaldos } = useSaldos();
 
-  const [searchTerm, setSearchTerm] = useState("");
   const [selectedSaldoForDetail, setSelectedSaldoForDetail] = useState<IBalanceRow | null>(null);
   const [isDetailSheetOpen, setIsDetailSheetOpen] = useState(false);
 
@@ -67,12 +59,7 @@ export function BalancesView() {
     setIsDetailSheetOpen(false);
   };
 
-  const filteredGroups = (balancesData ?? [])
-    .map((group) => ({
-      ...group,
-      balances: group.balances.filter((balance) => matchesSearch(balance, searchTerm))
-    }))
-    .filter((group) => group.balances.length > 0);
+  const filteredGroups = balancesData ?? [];
 
   const handleStateFilter = (stateName: string) => {
     if (state.filterState === stateName) {

--- a/src/modules/balances/containers/ClientBalancesView/ClientBalancesView.tsx
+++ b/src/modules/balances/containers/ClientBalancesView/ClientBalancesView.tsx
@@ -13,20 +13,10 @@ import { BalancesTable } from "../../components/BalancesTable/BalancesTable";
 import { FilterBalances, ISaldosFilterValue } from "../../components/FilterBalances/FilterBalances";
 import { useSaldos } from "../../context/saldos-context";
 import { useBalances } from "@/hooks/useBalances";
+import { useDebounce } from "@/hooks/useDeabouce";
 import { useFinancialDiscountMotives } from "@/hooks/useFinancialDiscountMotives";
 import { extractSingleParam } from "@/utils/utils";
 import { IBalanceRow } from "@/types/financialDiscounts/IFinancialDiscounts";
-
-const matchesSearch = (balance: IBalanceRow, term: string) => {
-  if (!term) return true;
-  const lowerTerm = term.toLowerCase();
-  return (
-    String(balance.id).toLowerCase().includes(lowerTerm) ||
-    (balance.client_name ?? "").toLowerCase().includes(lowerTerm) ||
-    (balance.kam_name ?? "").toLowerCase().includes(lowerTerm) ||
-    (balance.motive_name ?? "").toLowerCase().includes(lowerTerm)
-  );
-};
 
 export function ClientBalancesView() {
   const params = useParams();
@@ -38,6 +28,9 @@ export function ClientBalancesView() {
     to_date: null
   });
 
+  const [searchTerm, setSearchTerm] = useState("");
+  const debouncedSearch = useDebounce(searchTerm, 500);
+
   const {
     data: balancesData,
     isLoading: balancesLoading,
@@ -48,14 +41,14 @@ export function ClientBalancesView() {
     from_date: filter.from_date,
     to_date: filter.to_date,
     client_uuid: clientId,
-    motive_ids: filter.motive_ids
+    motive_ids: filter.motive_ids,
+    search: debouncedSearch
   });
 
   const { data: motives, isLoading: motivesLoading } = useFinancialDiscountMotives();
 
   const { state, toggleSaldoSelection, selectAllSaldos, deselectSaldos } = useSaldos();
 
-  const [searchTerm, setSearchTerm] = useState("");
   const [selectedSaldoForDetail, setSelectedSaldoForDetail] = useState<IBalanceRow | null>(null);
   const [isDetailSheetOpen, setIsDetailSheetOpen] = useState(false);
 
@@ -68,12 +61,7 @@ export function ClientBalancesView() {
     setIsDetailSheetOpen(false);
   };
 
-  const filteredGroups = (balancesData ?? [])
-    .map((group) => ({
-      ...group,
-      balances: group.balances.filter((balance) => matchesSearch(balance, searchTerm))
-    }))
-    .filter((group) => group.balances.length > 0);
+  const filteredGroups = balancesData ?? [];
 
   return (
     <>

--- a/src/types/financialDiscounts/IFinancialDiscounts.ts
+++ b/src/types/financialDiscounts/IFinancialDiscounts.ts
@@ -133,4 +133,5 @@ export interface IBalancesFilter {
   to_date: string | null;
   client_uuid?: string;
   motive_ids?: number[]; // selected motive ids
+  search?: string; // free-text search term
 }


### PR DESCRIPTION
…ed query

The search functionality for balances has been refactored from client-side filtering to server-side filtering. This improves performance and ensures consistency with other filters.

- Added `search` parameter to `useBalances` hook, passed as query string with `encodeURIComponent`.
- Removed client-side `matchesSearch` function from both `BalancesView` and `ClientBalancesView`.
- Integrated `useDebounce` hook with 500ms delay to avoid excessive API calls.
- The debounced search term is now passed directly in the filter object to `useBalances`.