### PR TITLE
Add business_unit support for marketplace orders

### DIFF
--- a/src/app/comercio/cetaphil/page.tsx
+++ b/src/app/comercio/cetaphil/page.tsx
@@ -53,6 +53,13 @@ export interface IOrderViewContext {
   setShippingInfo: Dispatch<IShippingInformation>;
   channelCode: string;
   setChannelCode: Dispatch<SetStateAction<string>>;
+  /**
+   * Nombre de la unidad de negocio (`client_bu[n].bu_name`) elegida en el
+   * dropdown "Canal". Se envía como `business_unit` en la orden de
+   * marketplace. Vacío cuando no se ha seleccionado un canal.
+   */
+  businessUnit: string;
+  setBusinessUnit: Dispatch<SetStateAction<string>>;
   selectedDiscount: IDiscountPackageAvailable | undefined;
   setSelectedDiscount: Dispatch<IDiscountPackageAvailable | undefined>;
   categories: IFetchedCategories[];
@@ -84,6 +91,7 @@ const CreateOrderView: FC = () => {
   const [confirmOrderData, setConfirmOrderData] = useState({} as IOrderConfirmedResponse);
   const [shippingInfo, setShippingInfo] = useState<IShippingInformation>();
   const [channelCode, setChannelCode] = useState("");
+  const [businessUnit, setBusinessUnit] = useState("");
   const [selectedDiscount, setSelectedDiscount] = useState<IDiscountPackageAvailable | undefined>(
     undefined
   );
@@ -155,6 +163,8 @@ const CreateOrderView: FC = () => {
         setShippingInfo,
         channelCode,
         setChannelCode,
+        businessUnit,
+        setBusinessUnit,
         selectedDiscount,
         setSelectedDiscount,
         categories,

--- a/src/modules/commerce/components/create-order-checkout/create-order-checkout.tsx
+++ b/src/modules/commerce/components/create-order-checkout/create-order-checkout.tsx
@@ -59,7 +59,8 @@ export default function CheckoutPage() {
     order_split_details,
     deactivateCrossSelling,
     bonus,
-    channelCode
+    channelCode,
+    businessUnit
   } = useContext(OrderViewContext);
   const { showMessage } = useMessageApi();
 
@@ -206,6 +207,9 @@ export default function CheckoutPage() {
       order_split_details: splitDetails,
       promotion_id: bonus?.id || undefined,
       nit_id: channelCode,
+      // business_unit solo se envía cuando el usuario eligió un canal
+      // (client_bu[n].bu_name). Es opcional y solo aplica a marketplace.
+      ...(businessUnit ? { business_unit: businessUnit } : {}),
       ...(hasCommonBonusProducts && activeRangeId
         ? { range_promotion_id: activeRangeId }
         : {})

--- a/src/modules/commerce/components/create-order-market/create-order-market.tsx
+++ b/src/modules/commerce/components/create-order-market/create-order-market.tsx
@@ -39,7 +39,8 @@ const CreateOrderMarket: FC = () => {
     setCategories,
     setSelectedCategories,
     toggleCart,
-    numberOfItems
+    numberOfItems,
+    businessUnit
   } = useContext(OrderViewContext);
   const [searchTerm, setSearchTerm] = useState("");
   const [activeTab, setActiveTab] = useState<string>("");
@@ -52,7 +53,7 @@ const CreateOrderMarket: FC = () => {
     const fetchProducts = async () => {
       if (!client?.id) return;
 
-      const response = await getProductsByClient(ID, client.id);
+      const response = await getProductsByClient(ID, client.id, businessUnit);
       if (!response.data) return;
 
       const newProductsMap = new Map<number, ISelectedProduct>();

--- a/src/modules/commerce/components/create-order-search-client/create-order-search-client.tsx
+++ b/src/modules/commerce/components/create-order-search-client/create-order-search-client.tsx
@@ -39,7 +39,7 @@ export interface ISelectClientForm {
 }
 
 const CreateOrderSearchClient: FC = () => {
-  const { setClient, setShippingInfo, setChannelCode } = useContext(OrderViewContext);
+  const { setClient, setShippingInfo, setChannelCode, setBusinessUnit } = useContext(OrderViewContext);
   const { config, projectId } = useAppStore((state) => ({
     config: state.config,
     projectId: state.selectedProject?.ID
@@ -109,12 +109,21 @@ const CreateOrderSearchClient: FC = () => {
     setSelectedClient(c);
     const channelOptions = c.client_bu ?? [];
     // Auto-select the channel when the client has exactly one available.
-    setCanal(channelOptions.length === 1 ? channelOptions[0].internal_code : "");
+    if (channelOptions.length === 1) {
+      setCanal(channelOptions[0].internal_code);
+      setBusinessUnit(channelOptions[0].bu_name);
+    } else {
+      setCanal("");
+      setBusinessUnit("");
+    }
     setSelectedAddress(null);
   };
 
   const handleSelectCanal = (value: string) => {
     setCanal(value);
+    // Sincronizar business_unit con el bu_name del canal seleccionado
+    const matched = selectedClient?.client_bu?.find((bu) => bu.internal_code === value);
+    setBusinessUnit(matched?.bu_name ?? "");
     setSelectedAddress(null);
   };
 

--- a/src/modules/commerce/containers/create-order/create-order.tsx
+++ b/src/modules/commerce/containers/create-order/create-order.tsx
@@ -62,6 +62,13 @@ interface IOrderViewContext {
   setExecutiveDiscounts: Dispatch<SetStateAction<IExecutiveDiscount[]>>;
   deactivateCrossSelling: boolean;
   setDeactivateCrossSelling: Dispatch<SetStateAction<boolean>>;
+  /**
+   * Nombre de la unidad de negocio (`client_bu[n].bu_name`) elegida en el
+   * dropdown "Canal". Se envía como `business_unit` en la orden de
+   * marketplace. Vacío cuando no se ha seleccionado un canal.
+   */
+  businessUnit: string;
+  setBusinessUnit: Dispatch<string>;
   toggleCart?: () => void;
   isCartVisible?: boolean;
   numberOfItems?: number;
@@ -75,6 +82,7 @@ export const CreateOrderView: FC = () => {
   const [confirmOrderData, setConfirmOrderData] = useState({} as IOrderConfirmedResponse);
   const [shippingInfo, setShippingInfo] = useState<IShippingInformation>();
   const [channelCode, setChannelCode] = useState("");
+  const [businessUnit, setBusinessUnit] = useState("");
   const [selectedDiscount, setSelectedDiscount] = useState<IDiscountPackageAvailable | undefined>(
     undefined
   );
@@ -176,6 +184,7 @@ export const CreateOrderView: FC = () => {
     setShippingInfo(shipping_info);
     // Drafts carry no channel internal_code; clear it so the checkout falls back to client id.
     setChannelCode("");
+    setBusinessUnit("");
     setSelectedDiscount(order_summary.discount_package);
     setConfirmOrderData(order_summary);
     setExecutiveDiscounts(executive_discounts ?? []);
@@ -249,6 +258,8 @@ export const CreateOrderView: FC = () => {
         setExecutiveDiscounts,
         deactivateCrossSelling,
         setDeactivateCrossSelling,
+        businessUnit,
+        setBusinessUnit,
         order_split_details: orderSplitDetails,
         setOrderSplitDetails,
         toggleCart,

--- a/src/services/commerce/commerce.ts
+++ b/src/services/commerce/commerce.ts
@@ -42,9 +42,14 @@ export const getClients = async (projectId: number) => {
   return response;
 };
 
-export const getProductsByClient = async (projectId: number, clientId: string) => {
+export const getProductsByClient = async (projectId: number, clientId: string, businessUnit?: string) => {
+  const queryParams = new URLSearchParams();
+  if (businessUnit) {
+    queryParams.append("business_unit", businessUnit);
+  }
   const response: GenericResponse<IProductData[]> = await API.get(
-    `/marketplace/projects/${projectId}/clients/${clientId}/products`
+    `/marketplace/projects/${projectId}/clients/${clientId}/products`,
+    { params: queryParams }
   );
   return response;
 };

--- a/src/types/commerce/ICommerce.ts
+++ b/src/types/commerce/ICommerce.ts
@@ -284,6 +284,15 @@ export interface ICreateOrderData {
   promotion_id?: number;
   nit_id: string;
   /**
+   * Unidad de negocio seleccionada por el usuario en el dropdown "Canal"
+   * durante la creación de la orden. Se obtiene de `client_bu[n].bu_name`
+   * del endpoint `/marketplace/projects/:project/clients`.
+   *
+   * Opcional: solo aplica al flujo de marketplace (esta interfaz no se usa
+   * en órdenes de compra / purchase orders).
+   */
+  business_unit?: string;
+  /**
    * ID del rango activo (`promotion.active_range.range_id`) del que
    * provienen los productos bonificados comunes (bonusOptions).
    * No aplica a los "other bonified" (otherBonificated), que no


### PR DESCRIPTION
Introduce businessUnit into the order view context and state, synchronize it with the Canal (client_bu) selection, and clear it for drafts. Propagate businessUnit through marketplace components: include it as an optional business_unit field in the checkout payload, pass it as a query param to getProductsByClient to filter products, and auto-select/set it when a client has a single channel. Update the ICreateOrderData type to include optional business_unit. This enables sending the selected BU name (client_bu[n].bu_name) in marketplace orders and ensures product queries respect the selected business unit.