### PR TITLE
Fix/table shown based on project revenue tracking marketplace

### DIFF
--- a/src/modules/banks/components/payment-applications-table/PaymentApplicationsTable.tsx
+++ b/src/modules/banks/components/payment-applications-table/PaymentApplicationsTable.tsx
@@ -12,7 +12,6 @@ import {
 } from "antd";
 import {
   ArrowCounterClockwise,
-  ArrowUUpLeft,
   DotsThreeVertical,
   DownloadSimple,
   FileArrowUp
@@ -24,10 +23,8 @@ import { IPaymentApplication } from "@/types/paymentApplications/IPaymentApplica
 import {
   reprocessExcel,
   reprocessPDF,
-  reversePaymentApplication,
   uploadFinalFile
 } from "@/services/paymentApplications/paymentApplications";
-import { ModalConfirmAction } from "@/components/molecules/modals/ModalConfirmAction/ModalConfirmAction";
 
 import "./payment-applications-table.scss";
 
@@ -65,11 +62,6 @@ export const PaymentApplicationsTable = ({
   const isXXL = !!screens.xxl;
 
   const [selectedRowKeys, setSelectedRowKeys] = useState<React.Key[]>([]);
-  const [reverseModalOpen, setReverseModalOpen] = useState(false);
-  const [applicationToReverse, setApplicationToReverse] = useState<IPaymentApplication | null>(
-    null
-  );
-  const [isReversing, setIsReversing] = useState(false);
 
   useEffect(() => {
     setSelectedRowKeys([]);
@@ -187,57 +179,6 @@ export const PaymentApplicationsTable = ({
     } catch (error) {
       hide();
       message.error(error instanceof Error ? error.message : "Error al regenerar el archivo");
-    }
-  };
-
-  const handleOpenReverseModal = (record: IPaymentApplication) => {
-    setApplicationToReverse(record);
-    setReverseModalOpen(true);
-  };
-
-  const handleCloseReverseModal = () => {
-    if (isReversing) return;
-    setReverseModalOpen(false);
-    setApplicationToReverse(null);
-  };
-
-  const handleConfirmReverse = async () => {
-    if (!applicationToReverse || isReversing) return;
-    setIsReversing(true);
-    try {
-      await reversePaymentApplication(applicationToReverse.id);
-      message.success("Aplicación reversada correctamente");
-      setReverseModalOpen(false);
-      setApplicationToReverse(null);
-      mutate();
-    } catch (error) {
-      const errorMessage = error instanceof Error ? error.message : "";
-      const normalizedMessage = errorMessage.toLowerCase();
-
-      if (
-        normalizedMessage.includes("permiso") ||
-        normalizedMessage.includes("unauthorized") ||
-        normalizedMessage.includes("forbidden")
-      ) {
-        message.error("No tienes permisos para reversar aplicaciones");
-      } else if (
-        normalizedMessage.includes("sesión") ||
-        normalizedMessage.includes("session") ||
-        normalizedMessage.includes("token") ||
-        normalizedMessage.includes("401")
-      ) {
-        message.error("Tu sesión expiró, inicia sesión nuevamente");
-      } else if (
-        normalizedMessage.includes("procesada") ||
-        normalizedMessage.includes("processed") ||
-        normalizedMessage.includes("cierre")
-      ) {
-        message.error("Esta aplicación ya fue procesada y no puede reversarse");
-      } else {
-        message.error("No se pudo reversar, intenta de nuevo");
-      }
-    } finally {
-      setIsReversing(false);
     }
   };
 
@@ -403,22 +344,6 @@ export const PaymentApplicationsTable = ({
                   )
                 }
               ]
-            : []),
-          ...(statusName !== "Reversada"
-            ? [
-                {
-                  key: "reverse-application",
-                  label: (
-                    <Button
-                      icon={<ArrowUUpLeft size={20} />}
-                      className="buttonNoBorder"
-                      onClick={() => handleOpenReverseModal(record)}
-                    >
-                      Reversar aplicación
-                    </Button>
-                  )
-                }
-              ]
             : [])
         ];
 
@@ -443,64 +368,26 @@ export const PaymentApplicationsTable = ({
   ];
 
   return (
-    <>
-      <Table
-        className="paymentApplicationsTable customSticky"
-        loading={false}
-        columns={columns}
-        rowSelection={rowSelection}
-        dataSource={applicationsByStatus.map((data) => ({
-          ...data,
-          key: data.id
-        }))}
-        pagination={{
-          pageSize: 15,
-          showSizeChanger: false
-        }}
-        sticky={
-          {
-            offsetHeader: 120,
-            offsetScroll: 0
-          } as TableProps<applicationByStatus>["sticky"]
-        }
-      />
-      <ModalConfirmAction
-        isOpen={reverseModalOpen}
-        onClose={handleCloseReverseModal}
-        onOk={handleConfirmReverse}
-        title="Reversar aplicación de pago"
-        okText="Confirmar reversión"
-        cancelText="Cancelar"
-        okLoading={isReversing}
-        content={
-          applicationToReverse ? (
-            <div>
-              <p>¿Estás seguro de que deseas reversar esta aplicación de pago?</p>
-              <p style={{ marginTop: "0.5rem" }}>
-                <strong>Id. Aplicación:</strong> {applicationToReverse.id}
-              </p>
-              <p>
-                <strong>Cliente:</strong> {applicationToReverse.client_name}
-              </p>
-              <p>
-                <strong>Recaudo:</strong>{" "}
-                {formatMoney(applicationToReverse.amount, { hideDecimals: true })}
-              </p>
-              <p>
-                <strong>Id. Pago Cashport:</strong>{" "}
-                {applicationToReverse.payment_ids?.length
-                  ? applicationToReverse.payment_ids.join(", ")
-                  : "-"}
-              </p>
-              <p style={{ marginTop: "0.5rem", color: "#888" }}>
-                Esta acción no se puede deshacer. Las facturas vinculadas volverán a estar
-                disponibles y los pagos quedarán sin aplicar.
-              </p>
-            </div>
-          ) : null
-        }
-      />
-    </>
+    <Table
+      className="paymentApplicationsTable customSticky"
+      loading={false}
+      columns={columns}
+      rowSelection={rowSelection}
+      dataSource={applicationsByStatus.map((data) => ({
+        ...data,
+        key: data.id
+      }))}
+      pagination={{
+        pageSize: 15,
+        showSizeChanger: false
+      }}
+      sticky={
+        {
+          offsetHeader: 120,
+          offsetScroll: 0
+        } as TableProps<applicationByStatus>["sticky"]
+      }
+    />
   );
 };
 

--- a/src/modules/commerce/containers/revenue-tracking/revenue-tracking.tsx
+++ b/src/modules/commerce/containers/revenue-tracking/revenue-tracking.tsx
@@ -9,9 +9,12 @@ import TopSales from "@/modules/commerce/components/revenue-tracking/top-sales/t
 import ProductTreemap from "@/modules/commerce/components/revenue-tracking/product-treemap/product-treemap";
 import { DashboardBottomSection } from "@/modules/commerce/components/revenue-tracking/dashboard-bottom-section/dashboard-bottom-section";
 import { RevenueTrackingProvider } from "@/modules/commerce/contexts/revenue-tracking-context";
+import { useAppStore } from "@/lib/store/store";
+import { GILEAD_PROJECT_ID } from "@/utils/constants/globalConstants";
 
 function RevenueTrackingInner() {
   // Theme (.dark class + AntD dark algorithm) is applied by ComercioLayout, an ancestor.
+  const { ID: projectId } = useAppStore((projects) => projects.selectedProject);
   return (
     <main className="space-y-6">
       <FiltersBar />
@@ -29,7 +32,11 @@ function RevenueTrackingInner() {
         <ProductTreemap />
       </div>
 
-      <DashboardBottomSection />
+      {projectId === GILEAD_PROJECT_ID ? null : (
+        <div className="w-full">
+          <DashboardBottomSection />
+        </div>
+      )}
     </main>
   );
 }

--- a/src/services/paymentApplications/paymentApplications.ts
+++ b/src/services/paymentApplications/paymentApplications.ts
@@ -41,16 +41,3 @@ export const uploadFinalFile = async (applicationId: string, file: File): Promis
     throw error;
   }
 };
-
-export const reversePaymentApplication = async (applicationId: number): Promise<{ success: boolean; message: string }> => {
-  try {
-    const response: GenericResponse<{ success: boolean; message: string }> = await API.post(
-      `/paymentApplication/reverse-payment-applications`,
-      { identification_id: applicationId }
-    );
-    return response.data;
-  } catch (error) {
-    console.error("Error reversing payment application:", error);
-    throw error;
-  }
-};

--- a/src/utils/constants/globalConstants.ts
+++ b/src/utils/constants/globalConstants.ts
@@ -37,3 +37,5 @@ export const FILE_EXTENSIONS = [
 export const GALDERMA_PROJECT_ID = 165;
 
 export const CETAPHIL_PROJECT_ID = 175;
+
+export const GILEAD_PROJECT_ID = 166;


### PR DESCRIPTION
This pull request removes the "reverse payment application" feature from the `PaymentApplicationsTable` component and its related service logic. Additionally, it introduces a small UI change in the revenue tracking module to hide the dashboard bottom section for a specific project.

**Payment Application Table: Removal of Reverse Feature**
- Removed all UI and state logic related to reversing payment applications, including the "Reversar aplicación" button, modal confirmation dialog, and associated handlers from `PaymentApplicationsTable.tsx`. [[1]](diffhunk://#diff-92e9794197211a7f294b9f251d4cc01977c37e6be9cd4b3cfc6b6c15463322eeL15) [[2]](diffhunk://#diff-92e9794197211a7f294b9f251d4cc01977c37e6be9cd4b3cfc6b6c15463322eeL27-L30) [[3]](diffhunk://#diff-92e9794197211a7f294b9f251d4cc01977c37e6be9cd4b3cfc6b6c15463322eeL68-L72) [[4]](diffhunk://#diff-92e9794197211a7f294b9f251d4cc01977c37e6be9cd4b3cfc6b6c15463322eeL193-L243) [[5]](diffhunk://#diff-92e9794197211a7f294b9f251d4cc01977c37e6be9cd4b3cfc6b6c15463322eeL406-L421) [[6]](diffhunk://#diff-92e9794197211a7f294b9f251d4cc01977c37e6be9cd4b3cfc6b6c15463322eeL446) [[7]](diffhunk://#diff-92e9794197211a7f294b9f251d4cc01977c37e6be9cd4b3cfc6b6c15463322eeL467-L503)
- Deleted the `reversePaymentApplication` API function from the payment applications service, ensuring the backend call is no longer available.

**Revenue Tracking: Conditional UI Rendering**
- Added the `GILEAD_PROJECT_ID` constant and updated the revenue tracking container to hide the `DashboardBottomSection` component when the selected project matches this ID. [[1]](diffhunk://#diff-d949541b1b82613092446eb89bd46f41110ffd93dc3d3825ca9e5c1c9ac7863fR40-R41) [[2]](diffhunk://#diff-50b8bc5beb3dd809b5dbed21ee1be9118b572893446cf74657faf65f927cb339R12-R17) [[3]](diffhunk://#diff-50b8bc5beb3dd809b5dbed21ee1be9118b572893446cf74657faf65f927cb339R35-R39)