### PR TITLE
(dashboard): standardize filter params across revenue tracking compon…

### DIFF
--- a/src/modules/commerce/components/revenue-tracking/product-treemap/product-treemap.tsx
+++ b/src/modules/commerce/components/revenue-tracking/product-treemap/product-treemap.tsx
@@ -6,6 +6,7 @@ import { Maximize2, Minimize2, ChevronDown } from "lucide-react";
 import * as Dialog from "@radix-ui/react-dialog";
 
 import { useDashboardSalesTreemap } from "@/modules/commerce/hooks/revenue-tracking/useDashboardSalesTreemap";
+import { useRevenueTracking } from "@/modules/commerce/contexts/revenue-tracking-context";
 
 type DimensionKey = "linea" | "producto" | "cliente" | "ciudad" | "vendedor" | "canal";
 
@@ -264,11 +265,12 @@ function TreemapRender({
 }
 
 export default function ProductTreemap() {
+  const { filters } = useRevenueTracking();
   const [isFullscreen, setIsFullscreen] = useState(false);
   const [activeDim1, setActiveDim1] = useState<DimensionKey>("linea");
   const [activeDim2, setActiveDim2] = useState<DimensionKey>("producto");
 
-  const { data, isLoading } = useDashboardSalesTreemap(activeDim1, activeDim2);
+  const { data, isLoading } = useDashboardSalesTreemap(activeDim1, activeDim2, filters);
 
   const chartData = useMemo(
     () => ({

--- a/src/modules/commerce/hooks/revenue-tracking/salesFilterParams.ts
+++ b/src/modules/commerce/hooks/revenue-tracking/salesFilterParams.ts
@@ -38,15 +38,12 @@ const ID_PARAM_BY_KEY: Record<string, string> = {
 
 export const appendSalesFilterParams = (
   params: URLSearchParams,
-  filters: Record<string, FilterOption[]>,
-  allowedEntityKeys?: string[]
+  filters: Record<string, FilterOption[]>
 ) => {
-  Object.entries(ID_PARAM_BY_KEY)
-    .filter(([key]) => !allowedEntityKeys || allowedEntityKeys.includes(key))
-    .forEach(([key, param]) => {
-      const ids = (filters[key] ?? []).map((o) => o.id);
-      if (ids.length > 0) params.append(param, ids.join(","));
-    });
+  Object.entries(ID_PARAM_BY_KEY).forEach(([key, param]) => {
+    const ids = (filters[key] ?? []).map((o) => o.id);
+    if (ids.length > 0) params.append(param, ids.join(","));
+  });
 
   const preset = filters.fecha?.[0]?.id;
   if (preset) {

--- a/src/modules/commerce/hooks/revenue-tracking/useDashboardSalesEvolucion.ts
+++ b/src/modules/commerce/hooks/revenue-tracking/useDashboardSalesEvolucion.ts
@@ -4,15 +4,15 @@ import { fetcher } from "@/utils/api/api";
 import { GenericResponse } from "@/types/global/IGlobal";
 import { IDashboardSalesEvolucion } from "@/types/dashboardSales/IDashboardSales";
 import { type FilterOption } from "@/modules/commerce/contexts/revenue-tracking-context";
+import { appendSalesFilterParams } from "./salesFilterParams";
 
 export const useDashboardSalesEvolucion = (filters: Record<string, FilterOption[]> = {}) => {
   const params = new URLSearchParams();
 
+  appendSalesFilterParams(params, filters);
+
   const frequency = filters.frecuencia?.[0]?.id;
   if (frequency) params.append("frequency", frequency);
-
-  const period = filters.fecha?.[0]?.id;
-  if (period) params.append("period", period);
 
   const queryString = params.toString();
   const pathKey = `/dashboard/sales/evolucion${queryString ? `?${queryString}` : ""}`;

--- a/src/modules/commerce/hooks/revenue-tracking/useDashboardSalesRanking.ts
+++ b/src/modules/commerce/hooks/revenue-tracking/useDashboardSalesRanking.ts
@@ -14,7 +14,7 @@ export const useDashboardSalesRanking = (
   const params = new URLSearchParams();
 
   if (dimension) params.append("dimension", dimension);
-  appendSalesFilterParams(params, filters, ["channelIds"]);
+  appendSalesFilterParams(params, filters);
   params.append("limit", String(limit));
 
   const pathKey = `/dashboard/sales/ranking?${params.toString()}`;

--- a/src/modules/commerce/hooks/revenue-tracking/useDashboardSalesTreemap.ts
+++ b/src/modules/commerce/hooks/revenue-tracking/useDashboardSalesTreemap.ts
@@ -3,11 +3,18 @@ import useSWR from "swr";
 import { fetcher } from "@/utils/api/api";
 import { GenericResponse } from "@/types/global/IGlobal";
 import { IDashboardSalesTreemap } from "@/types/dashboardSales/IDashboardSales";
+import { type FilterOption } from "@/modules/commerce/contexts/revenue-tracking-context";
+import { appendSalesFilterParams } from "./salesFilterParams";
 
-export const useDashboardSalesTreemap = (dim1: string, dim2: string) => {
+export const useDashboardSalesTreemap = (
+  dim1: string,
+  dim2: string,
+  filters: Record<string, FilterOption[]> = {}
+) => {
   const params = new URLSearchParams();
   if (dim1) params.append("dim1", dim1);
   if (dim2) params.append("dim2", dim2);
+  appendSalesFilterParams(params, filters);
 
   const queryString = params.toString();
   const pathKey = `/dashboard/sales/treemap${queryString ? `?${queryString}` : ""}`;


### PR DESCRIPTION
…ents

Refactored filter parameter handling to use appendSalesFilterParams consistently across dashboard hooks (Treemap, Evolucion, Ranking). Removed manual allowedEntityKeys filtering and now pass filters from context to hooks for unified filtering behavior.