### PR TITLE
feat: add document evidence viewing in client detail table

### DIFF
--- a/src/modules/dataQuality/components/ClientDetailIntakesTable/client-detail-intakes-table.tsx
+++ b/src/modules/dataQuality/components/ClientDetailIntakesTable/client-detail-intakes-table.tsx
@@ -106,13 +106,14 @@ export function ClientDetailIntakesTable({
                 </TableCell>
                 <TableCell>
                   <Button
-                    variant="ghost"
-                    size="sm"
+                    variant="outline"
+                    size="icon"
                     title="Ver detalles"
                     onClick={() => {
                       handleOpenIntakeModal("view", intake);
                       onDetailClicked?.(intake);
                     }}
+                    className="bg-[#f7f7f7] border-[#DDDDDD] hover:bg-[#f7f7f7] hover:border-black p-1 !p-0 size-7"
                   >
                     <Eye className="w-4 h-4" />
                   </Button>

--- a/src/modules/dataQuality/components/ClientDetailTable/client-detail-table.tsx
+++ b/src/modules/dataQuality/components/ClientDetailTable/client-detail-table.tsx
@@ -16,6 +16,7 @@ import { DateRangeFilter } from "@/components/atoms/DateRangeFilter/DateRangeFil
 import { ModalConfirmAction } from "@/components/molecules/modals/ModalConfirmAction/ModalConfirmAction";
 import { ModalUploadIntakeFiles } from "@/components/molecules/modals/ModalUploadIntakeFiles/ModalUploadIntakeFiles";
 import ModalCreateNewFile from "../ModalCreateNewFile/ModalCreateNewFile";
+import InvoiceDownloadModal from "@/modules/clients/components/invoice-download-modal";
 
 import { Badge } from "@/modules/chat/ui/badge";
 import { Button } from "@/modules/chat/ui/button";
@@ -29,7 +30,7 @@ import {
 } from "@/modules/chat/ui/table";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/modules/chat/ui/tooltip";
 import { IClientDetailArchiveClient } from "@/types/dataQuality/IDataQuality";
-import { Plus } from "phosphor-react";
+import { Plus, Receipt } from "phosphor-react";
 
 interface IClientDetailTableProps {
   clientId: string;
@@ -66,6 +67,8 @@ export function ClientDetailTable({
     start: null,
     end: null
   });
+  const [isModalFileDetailOpen, setIsModalFileDetailOpen] = useState(false);
+  const [fileURL, setFileURL] = useState("");
 
   const { archives: files, mutate } = useArchivesClientData(
     clientId,
@@ -76,6 +79,16 @@ export function ClientDetailTable({
   const handleUploadIntake = (id: number) => {
     setActiveFileId(id);
     setIsUploadIntakeModalOpen(true);
+  };
+
+  const handleDocumentClick = (documentUrl: string) => {
+    const fileExtension = documentUrl?.split(".").pop()?.toLowerCase() ?? "";
+    if (["png", "jpg", "jpeg"].includes(fileExtension)) {
+      setFileURL(documentUrl);
+      if (!isModalFileDetailOpen) setIsModalFileDetailOpen(true);
+    } else {
+      window.open(documentUrl, "_blank");
+    }
   };
 
   const handleProcessedFile = async (file: IClientDetailArchiveClient, type: "excel" | "csv") => {
@@ -383,7 +396,17 @@ export function ClientDetailTable({
                 )}
               </TableCell>
               <TableCell className="w-0">
-                <div className="flex items-center justify-center">
+                <div className="flex items-center justify-end gap-1">
+                  {file.evidence_url && (
+                    <Button
+                      variant="outline"
+                      size="icon"
+                      onClick={() => file.evidence_url && handleDocumentClick(file.evidence_url)}
+                      className="bg-[#f7f7f7] border-[#DDDDDD] hover:bg-[#f7f7f7] hover:border-black p-1 !p-0 size-7"
+                    >
+                      <Receipt className="w-4 h-4" />
+                    </Button>
+                  )}
                   <Dropdown
                     menu={{
                       items: [
@@ -461,7 +484,11 @@ export function ClientDetailTable({
                     }}
                     trigger={["click"]}
                   >
-                    <Button variant="ghost" size="sm">
+                    <Button
+                      variant="outline"
+                      size="icon"
+                      className="bg-[#f7f7f7] border-[#DDDDDD] hover:bg-[#f7f7f7] hover:border-black p-1 !p-0 size-7"
+                    >
                       <MoreHorizontal className="w-4 h-4" />
                     </Button>
                   </Dropdown>
@@ -533,6 +560,12 @@ export function ClientDetailTable({
         okText="Eliminar"
         cancelText="Cancelar"
         okLoading={isDeleteDateLoading}
+      />
+      <InvoiceDownloadModal
+        isModalOpen={isModalFileDetailOpen}
+        handleCloseModal={setIsModalFileDetailOpen}
+        title="Soporte auditoría"
+        url={fileURL}
       />
     </div>
   );


### PR DESCRIPTION
Added ability to view evidence documents directly in the client detail table. Images (png, jpg, jpeg) open in a modal preview while other file types open in a new tab. Implemented InvoiceDownloadModal component for viewing attached documents.
This pull request enhances the `ClientDetailTable` component by adding a feature to view or download evidence documents (such as invoices) associated with client files. It introduces a new modal for previewing image files and provides a dedicated button in the table for accessing these documents. The main changes are grouped as follows:

**New evidence document handling:**

* Added a `Receipt` button to each row in the table when an `evidence_url` is present, allowing users to view or download supporting documents. Clicking the button opens image files in a modal or other file types in a new browser tab.
* Introduced new state variables (`isModalFileDetailOpen`, `fileURL`) and a handler (`handleDocumentClick`) to manage the opening and display of evidence documents. [[1]](diffhunk://#diff-4896603cf9416b13d2c4f20c0369abf50fbab9aa315dbb98bb61ac3f5371e66cR70-R71) [[2]](diffhunk://#diff-4896603cf9416b13d2c4f20c0369abf50fbab9aa315dbb98bb61ac3f5371e66cR84-R93)
* Integrated the `InvoiceDownloadModal` component to display image files in a modal when appropriate.

**UI improvements:**

* Updated the table action buttons to use consistent styling for both the new `Receipt` button and the existing dropdown menu button.
* Added the `Receipt` icon import and the `InvoiceDownloadModal` import to the component. [[1]](diffhunk://#diff-4896603cf9416b13d2c4f20c0369abf50fbab9aa315dbb98bb61ac3f5371e66cL32-R33) [[2]](diffhunk://#diff-4896603cf9416b13d2c4f20c0369abf50fbab9aa315dbb98bb61ac3f5371e66cR19)