### PR TITLE
fix: enforce 35 character limit on dispatch address inputs with helpe…

### DIFF
--- a/src/modules/commerce/components/create-order-checkout/modal-shipping-info/modal-shipping-info.tsx
+++ b/src/modules/commerce/components/create-order-checkout/modal-shipping-info/modal-shipping-info.tsx
@@ -412,10 +412,12 @@ export default function ModalShippingInfo({
                 type="text"
                 placeholder="Cl. 76 9-88"
                 value={draft.dispatch_address}
+                maxLength={35}
                 readOnly={!isNewAddress}
                 onChange={(e) => setDraft((d) => ({ ...d, dispatch_address: e.target.value }))}
                 className="w-full px-2.5 py-2 text-xs bg-[#F7F7F7] border border-[#DDDDDD] rounded-lg outline-none focus:border-[#141414] transition-colors text-[#141414] placeholder:text-[#999999] read-only:opacity-60 read-only:cursor-not-allowed"
               />
+              {isNewAddress && <p className="text-[10px] text-[#999999]">Máximo 35 caracteres</p>}
             </div>
 
             <div className="flex flex-col gap-1">

--- a/src/modules/commerce/components/create-order-checkout/order-shipment-confirm/order-shipment-confirm.tsx
+++ b/src/modules/commerce/components/create-order-checkout/order-shipment-confirm/order-shipment-confirm.tsx
@@ -519,12 +519,16 @@ export default function OrderShipmentConfirm({
                   type="text"
                   placeholder="Cl. 76 9-88"
                   value={singleForm.dispatch_address}
+                  maxLength={35}
                   readOnly={!isNewAddressSingle}
                   onChange={(e) =>
                     setSingleForm((f) => ({ ...f, dispatch_address: e.target.value }))
                   }
                   className="w-full px-3 py-2.5 text-sm bg-[#F7F7F7] border border-[#DDDDDD] rounded-lg outline-none focus:border-[#141414] transition-colors text-[#141414] placeholder:text-[#999999] read-only:opacity-60 read-only:cursor-not-allowed"
                 />
+                {isNewAddressSingle && (
+                  <p className="text-[10px] text-[#999999]">Máximo 35 caracteres</p>
+                )}
               </div>
 
               <div className="flex flex-col gap-1.5">

--- a/src/modules/commerce/components/create-order-search-client/new-address-modal/new-address-modal.tsx
+++ b/src/modules/commerce/components/create-order-search-client/new-address-modal/new-address-modal.tsx
@@ -58,12 +58,14 @@ function NewAddressModal({ open, onSave, onCancel }: INewAddressModalProps) {
             type="text"
             placeholder="Cl. 76 9-88"
             value={newDireccion}
+            maxLength={35}
             onChange={(e) => setNewDireccion(e.target.value)}
             onKeyDown={(e) => {
               if (e.key === "Enter") handleSave();
             }}
             className="w-full px-3 py-2.5 text-sm bg-[#F7F7F7] border border-[#DDDDDD] rounded-lg outline-none focus:border-[#141414] transition-colors text-[#141414] placeholder:text-[#999999]"
           />
+          <p className="text-[10px] text-[#999999]">Máximo 35 caracteres</p>
         </div>
       </div>
     </Modal>


### PR DESCRIPTION
…r text
This pull request adds a character limit and helper text to the dispatch address input fields in the checkout and address modals. These changes help ensure that users cannot enter addresses longer than 35 characters and are clearly informed of this restriction.

**User input validation and UX improvements:**

* Added a `maxLength={35}` attribute to the dispatch address input fields in `modal-shipping-info.tsx`, `order-shipment-confirm.tsx`, and `new-address-modal.tsx` to restrict input to 35 characters. [[1]](diffhunk://#diff-2e1f1a59b8dddb69323f5ee3f61a1d246defd5d9f86c4f374ae07dd17f276762R415-R420) [[2]](diffhunk://#diff-b4b4f1944cce9e8aa8c492a8f2f229c936efa65b0f39a3a91defef11e8fe7911R522-R531) [[3]](diffhunk://#diff-ee2bf7a0ed5b8bd85af0d8d76bc5d095f0f1152e3875bbd85fbe85e2970b8d81R61-R68)
* Displayed a helper message "Máximo 35 caracteres" below the dispatch address input fields to inform users of the character limit. The message is conditionally shown when a new address is being entered. [[1]](diffhunk://#diff-2e1f1a59b8dddb69323f5ee3f61a1d246defd5d9f86c4f374ae07dd17f276762R415-R420) [[2]](diffhunk://#diff-b4b4f1944cce9e8aa8c492a8f2f229c936efa65b0f39a3a91defef11e8fe7911R522-R531) [[3]](diffhunk://#diff-ee2bf7a0ed5b8bd85af0d8d76bc5d095f0f1152e3875bbd85fbe85e2970b8d81R61-R68)