### PR TITLE
Add nit_id support for discount and promotion lookup

### DIFF
--- a/src/app/comercio/cetaphil/page.tsx
+++ b/src/app/comercio/cetaphil/page.tsx
@@ -36,12 +36,14 @@ export interface IOrderViewContext {
     id: string;
     email: string;
     payment_type: number;
+    nit_id: string;
   };
   setClient: Dispatch<{
     name: string;
     id: string;
     email: string;
     payment_type: number;
+    nit_id: string;
   }>;
   selectedCategories: ISelectedCategories[];
   setSelectedCategories: Dispatch<ISelectedCategories[]>;
@@ -114,7 +116,7 @@ const CreateOrderView: FC = () => {
 
       setDiscountsLoading(true);
       try {
-        const response = await getDiscounts(selectedProject.ID, client.id);
+        const response = await getDiscounts(selectedProject.ID, client.nit_id || client.id);
 
         if (response.data && response.data.length > 0) {
           setDiscounts(response.data);
@@ -144,7 +146,8 @@ const CreateOrderView: FC = () => {
         name: decodedToken?.claims?.guestName || "",
         id: decodedToken?.claims?.guestDocument || "",
         email: decodedToken?.claims?.guestEmail || "",
-        payment_type: client?.payment_type || 3
+        payment_type: client?.payment_type || 3,
+        nit_id: decodedToken?.claims?.guestDocument || ""
       });
       setIsLoadingLocalClient(false);
     }

--- a/src/modules/commerce/components/create-order-cart/create-order-cart.tsx
+++ b/src/modules/commerce/components/create-order-cart/create-order-cart.tsx
@@ -97,7 +97,7 @@ const CreateOrderCart: FC<CreateOrderCartProps> = ({ onClose }) => {
     const fetchPromotions = async () => {
       if (!client?.id) return;
       try {
-        const promotions = await getPromotions(client.id);
+        const promotions = await getPromotions(client.nit_id || client.id);
         setPromotions(promotions.promotions);
         if (promotions.promotions[0]) setPromotionId(promotions.promotions[0].id);
       } catch (error) {

--- a/src/modules/commerce/components/create-order-search-client/create-order-search-client.tsx
+++ b/src/modules/commerce/components/create-order-search-client/create-order-search-client.tsx
@@ -196,7 +196,8 @@ const CreateOrderSearchClient: FC = () => {
       name: selectedClient.client_name,
       id: selectedClient.client_id,
       email: selectedClient.client_email,
-      payment_type: selectedClient.payment_type
+      payment_type: selectedClient.payment_type,
+      nit_id: selectedBu?.internal_code || selectedClient.client_id
     });
   };
 

--- a/src/modules/commerce/containers/create-order/create-order.tsx
+++ b/src/modules/commerce/containers/create-order/create-order.tsx
@@ -37,11 +37,14 @@ interface IOrderViewContext {
     id: string;
     email: string;
     payment_type: number;
+    nit_id: string;
   };
   setClient: Dispatch<{
     name: string;
     id: string;
     email: string;
+    payment_type: number;
+    nit_id: string;
   }>;
   selectedCategories: ISelectedCategories[];
   setSelectedCategories: Dispatch<ISelectedCategories[]>;
@@ -111,7 +114,7 @@ export const CreateOrderView: FC = () => {
 
       setDiscountsLoading(true);
       try {
-        const response = await getDiscounts(selectedProject.ID, client.id);
+        const response = await getDiscounts(selectedProject.ID, client.nit_id || client.id);
 
         if (response.data && response.data.length > 0) {
           setDiscounts(response.data);
@@ -173,14 +176,15 @@ export const CreateOrderView: FC = () => {
   useEffect(() => {
     if (!draftDetail || categories.length === 0) return;
 
-    const { client_name, client_id, shipping_info, order_summary, executive_discounts } =
+    const { nit_id, client_name, client_id, shipping_info, order_summary, executive_discounts } =
       draftDetail;
 
     setClient({
       name: client_name,
       id: client_id,
       email: shipping_info?.email ?? "",
-      payment_type: 1
+      payment_type: 1,
+      nit_id: nit_id || client_id
     });
     setShippingInfo(shipping_info);
     // Drafts carry no channel internal_code; clear it so the checkout falls back to client id.

--- a/src/types/commerce/ICommerce.ts
+++ b/src/types/commerce/ICommerce.ts
@@ -456,6 +456,7 @@ export interface IDraftOrderDetail {
   mongo_id: string;
   project_id: number;
   client_id: string;
+  nit_id?: string;
   created_by: number;
   total: number;
   subtotal: number;


### PR DESCRIPTION
Add nit_id field to client context and use it as the primary identifier for fetching discounts and promotions, with fallback to client_id. This includes updating the order context interfaces and draft order detail type to support the new identifier. The nit_id is sourced from authentication claims, business unit internal code, or draft order details.