### PR TITLE
Update email and phone fallback logic in order creation

### DIFF
--- a/src/modules/commerce/components/create-order-checkout/order-shipment-confirm/order-shipment-confirm.tsx
+++ b/src/modules/commerce/components/create-order-checkout/order-shipment-confirm/order-shipment-confirm.tsx
@@ -181,7 +181,7 @@ export default function OrderShipmentConfirm({
     const matchedAddress =
       draftAddressId !== undefined ? addresses.find((a) => a.id === draftAddressId) : undefined;
 
-    const phoneRaw = shippingInfo.phone_number ?? "";
+    const phoneRaw = shippingInfo.phone_number || singleForm.telefono || "";
     const phoneMatch = phoneRaw.match(/^(\+\d{1,3})(\d+)$/);
     const indicativo = phoneMatch ? phoneMatch[1] : "+57";
     const telefono = phoneMatch ? phoneMatch[2] : phoneRaw;

--- a/src/modules/commerce/components/create-order-search-client/create-order-search-client.tsx
+++ b/src/modules/commerce/components/create-order-search-client/create-order-search-client.tsx
@@ -183,7 +183,7 @@ const CreateOrderSearchClient: FC = () => {
       address: selectedAddress.dispatch_address,
       city: selectedAddress.city,
       dispatch_address: selectedAddress.dispatch_address,
-      email: selectedClient.client_email || selectedAddress.email || "",
+      email: selectedAddress.email || "",
       phone_number: "",
       comments: ""
     };


### PR DESCRIPTION
Adjust phone number and email resolution during order checkout:
- Use singleForm.telefono as fallback for phone number in shipment confirmation
- Simplify email field to only use address email, removing client email fallback