### PR TITLE
feat: add warehouse info display and fix product count in orders

### DIFF
--- a/src/modules/commerce/components/orders-view-table/orders-view-table.tsx
+++ b/src/modules/commerce/components/orders-view-table/orders-view-table.tsx
@@ -332,7 +332,9 @@ const OrdersViewTable = ({
   ];
 
   const columns = onlyKeyInfo
-    ? allColumns.filter((col) => ["id", "client_name", "total"].includes(col.key as string))
+    ? allColumns.filter((col) =>
+        ["id", "client_name", "total", "buttonOpenModal"].includes(col.key as string)
+      )
     : allColumns;
 
   return (

--- a/src/modules/commerce/containers/confirmed-order/confirmed-order.tsx
+++ b/src/modules/commerce/containers/confirmed-order/confirmed-order.tsx
@@ -110,7 +110,9 @@ export const ConfirmedOrderView: FC = () => {
 
               <div className={styles.summaryContainer}>
                 <div className={styles.summaryContainer__top}>
-                  <h2>Datos de envío</h2>
+                  <h2>
+                    <strong>Datos de envío</strong>
+                  </h2>
                   <div className={styles.shippingData}>
                     <ConfirmedOrderShippingInfo title="Cliente" data={order?.client_name} />
                     <ConfirmedOrderShippingInfo title="Nit" data={order?.client_id} />
@@ -119,6 +121,7 @@ export const ConfirmedOrderView: FC = () => {
                       data={order?.shipping_info?.dispatch_address}
                     />
                     <ConfirmedOrderShippingInfo title="Ciudad" data={order?.shipping_info?.city} />
+                    <ConfirmedOrderShippingInfo title="Bodega" data={order?.warehouse_name} />
                     <ConfirmedOrderShippingInfo title="Email" data={order?.shipping_info?.email} />
                     <ConfirmedOrderShippingInfo
                       title="Contacto"
@@ -136,9 +139,15 @@ export const ConfirmedOrderView: FC = () => {
                     align="center"
                     justify="space-between"
                   >
-                    <h2>Resumen</h2>
+                    <strong>Resumen</strong>
                     <Flex className={styles.quantities}>
-                      <p className={styles.quantity}>SKUs: {order?.detail?.products?.length}</p>
+                      <p className={styles.quantity}>
+                        SKUs:{" "}
+                        {order?.detail?.products?.reduce(
+                          (acc, category) => acc + category.products.length,
+                          0
+                        )}
+                      </p>
                       <p className={styles.quantity}>
                         Total Productos:{" "}
                         {order?.detail?.products?.length &&

--- a/src/types/commerce/ICommerce.ts
+++ b/src/types/commerce/ICommerce.ts
@@ -375,6 +375,8 @@ export interface ISingleOrder {
   client_name: string;
   block_flag: boolean;
   vendor_name: string;
+  warehouse_id: number;
+  warehouse_name: string;
 }
 
 interface IDetailOrder {


### PR DESCRIPTION
- Add warehouse_id and warehouse_name to ISingleOrder interface
- Display warehouse ("Bodega") in confirmed order shipping details
- Fix SKUs count to sum products across all categories using reduce
- Make section headings bold for improved visual hierarchy