### PR TITLE
Add balance audit export feature

### DIFF
--- a/src/modules/balances/components/ModalBalancesActions/ModalBalancesActions.tsx
+++ b/src/modules/balances/components/ModalBalancesActions/ModalBalancesActions.tsx
@@ -1,9 +1,10 @@
 import React, { useState } from "react";
-import { Modal } from "antd";
-import { ArrowsClockwise } from "@phosphor-icons/react";
+import { message, Modal } from "antd";
+import { ArrowsClockwise, DownloadSimple } from "@phosphor-icons/react";
 
 import { ButtonGenerateAction } from "@/components/atoms/ButtonGenerateAction/ButtonGenerateAction";
 import { ModalChangeBalanceStatus } from "../ModalChangeBalanceStatus/ModalChangeBalanceStatus";
+import { downloadBalanceAuditExcel } from "@/services/balances/balances";
 
 import "@/components/molecules/modals/ModalActionAccountingAdjustments/modalActionAccountingAdjustments.scss";
 
@@ -21,6 +22,39 @@ export const ModalBalancesActions: React.FC<Props> = ({
   onSuccess
 }) => {
   const [isChangeStatusOpen, setIsChangeStatusOpen] = useState(false);
+  const [isDownloadLoading, setIsDownloadLoading] = useState(false);
+
+  const downloadFileFromUrl = (url: string, filename: string) => {
+    const link = document.createElement("a");
+    link.href = url;
+    link.download = filename;
+    document.body.appendChild(link);
+    link.click();
+    link.remove();
+  };
+
+  const handleDownloadCommercialReport = async () => {
+    setIsDownloadLoading(true);
+    const hide = message.open({
+      type: "loading",
+      content: "Descargando informe comercial...",
+      duration: 0
+    });
+    try {
+      const res = await downloadBalanceAuditExcel();
+      downloadFileFromUrl(res.url, res.filename);
+      message.success("Descarga exitosa");
+      onClose();
+    } catch (error) {
+      message.error(
+        error instanceof Error ? error.message : "Error al descargar el archivo"
+      );
+      console.error(error);
+    } finally {
+      hide();
+      setIsDownloadLoading(false);
+    }
+  };
 
   return (
     <>
@@ -34,13 +68,22 @@ export const ModalBalancesActions: React.FC<Props> = ({
       >
         <div className="modal-content">
           <ButtonGenerateAction
-            icon={<ArrowsClockwise size={20} />}
-            title="Cambiar estado"
-            onClick={() => {
-              setIsChangeStatusOpen(true);
-              onClose();
-            }}
+            icon={<DownloadSimple size={20} />}
+            title="Descargar informe comercial"
+            onClick={handleDownloadCommercialReport}
+            disabled={isDownloadLoading}
           />
+
+          {balanceIds.length > 0 && (
+            <ButtonGenerateAction
+              icon={<ArrowsClockwise size={20} />}
+              title="Cambiar estado"
+              onClick={() => {
+                setIsChangeStatusOpen(true);
+                onClose();
+              }}
+            />
+          )}
         </div>
       </Modal>
 

--- a/src/modules/balances/containers/BalancesView/BalancesView.tsx
+++ b/src/modules/balances/containers/BalancesView/BalancesView.tsx
@@ -3,7 +3,7 @@
 import { useState } from "react";
 import useSWR from "swr";
 
-import { message, Spin } from "antd";
+import { Spin } from "antd";
 import { CheckCircle, Clock, XCircle, CircleDot } from "lucide-react";
 import UiSearchInput from "@/components/ui/search-input/search-input";
 import { GenerateActionButton } from "@/components/atoms/GenerateActionButton";
@@ -89,10 +89,6 @@ export function BalancesView() {
 
                 <GenerateActionButton
                   onClick={() => {
-                    if (state.selectedSaldoIds.length === 0) {
-                      message.info("Selecciona al menos un saldo para generar una acción");
-                      return;
-                    }
                     setIsActionsOpen(true);
                   }}
                 />

--- a/src/modules/clients/containers/balances-tab/ClientBalancesView.tsx
+++ b/src/modules/clients/containers/balances-tab/ClientBalancesView.tsx
@@ -3,7 +3,7 @@
 import { useState } from "react";
 import { useParams } from "next/navigation";
 
-import { Flex, message, Spin } from "antd";
+import { Flex, Spin } from "antd";
 import UiSearchInput from "@/components/ui/search-input/search-input";
 import { GenerateActionButton } from "@/components/atoms/GenerateActionButton";
 import Collapse from "@/components/ui/collapse";
@@ -82,15 +82,11 @@ export function ClientBalancesView() {
               onChange={(e) => setSearchTerm(e.target.value)}
             />
 
-            <GenerateActionButton
-              onClick={() => {
-                if (state.selectedSaldoIds.length === 0) {
-                  message.info("Selecciona al menos un saldo para generar una acción");
-                  return;
-                }
-                setIsActionsOpen(true);
-              }}
-            />
+                <GenerateActionButton
+                  onClick={() => {
+                    setIsActionsOpen(true);
+                  }}
+                />
 
             {/* Saldos Filters Dropdown (Tipo + Fechas) */}
             <FilterBalances

--- a/src/services/balances/balances.ts
+++ b/src/services/balances/balances.ts
@@ -94,6 +94,19 @@ export interface UpdateBalancePayload {
   client_documents?: { id: number; document: string }[];
 }
 
+export const downloadBalanceAuditExcel = async (): Promise<{ url: string; filename: string }> => {
+  try {
+    const response: GenericResponse<{ url: string }> = await API.get(
+      `/financial-discount/balance-audit/export`
+    );
+    const filename = response.data.url.split("/").pop() || "balance_audit.xlsx";
+    return { url: response.data.url, filename };
+  } catch (error) {
+    console.error("Error downloading balance audit excel:", error);
+    throw error;
+  }
+};
+
 export const updateBalance = async (balanceId: number, payload: UpdateBalancePayload) => {
   const formData = new FormData();
   if (payload.motive_id !== undefined) formData.append("motive_id", String(payload.motive_id));


### PR DESCRIPTION
Implement balance audit Excel export functionality in the balance actions modal. Users can now download commercial reports via a new 'Descargar informe comercial' button. The 'Change status' action is now conditional and only appears when balances are selected. Removed redundant selection validation checks from view components as the modal now handles mixed action availability.