### PR TITLE
Fix/confirmed order view and commerce orders list

### DIFF
--- a/src/modules/commerce/components/create-order-market/create-order-market.module.scss
+++ b/src/modules/commerce/components/create-order-market/create-order-market.module.scss
@@ -68,6 +68,9 @@
     }
 
     .categoryDivider {
+        position: sticky;
+        top: 0;
+        z-index: 10;
         margin: 0.25rem 0 1rem;
         background-color: $background;
         padding: 0.5rem;

--- a/src/modules/commerce/components/modal-bonus/modal-bonus.tsx
+++ b/src/modules/commerce/components/modal-bonus/modal-bonus.tsx
@@ -6,6 +6,7 @@ import { ArrowLeft, Gift } from "@phosphor-icons/react";
 import { IBonus, IGiftOption } from "@/types/commerce/ICommerce";
 import { IPromotion } from "@/services/promotion/promotion";
 import { OrderViewContext } from "@/modules/commerce/contexts/orderViewContext";
+import { SPANISH_MONTHS } from "@/modules/dataQuality/utils/months";
 
 import styles from "./modal-bonus.module.scss";
 
@@ -40,10 +41,12 @@ const ModalBonus = ({
   const flexPromotion = promotions.find((p) => p.isFlex);
   const nonFlexPromotions = promotions.filter((p) => !p.isFlex);
 
+  const currentMonthName = SPANISH_MONTHS[new Date().getMonth()];
+
   type Segment = "flex" | "promos" | "otros";
 
   const [activeSegment, setActiveSegment] = useState<Segment>("flex");
-  // sub-view of the Promos Junio tab: the non-flex list vs. a selected promo's detail
+  // sub-view of the Promos tab: the non-flex list vs. a selected promo's detail
   const [promosScreen, setPromosScreen] = useState<"list" | "detail">("list");
   const [activeTab, setActiveTab] = useState(0);
   const [poolQty, setPoolQty] = useState<Record<number, Record<number, number>>>({});
@@ -480,7 +483,7 @@ const ModalBonus = ({
                 }}
                 className={activeSegment === "promos" ? styles.segmentActive : styles.segment}
               >
-                Promos Junio
+                Promos {currentMonthName}
               </button>
             )}
           </div>


### PR DESCRIPTION
This pull request introduces a minor UI improvement and a small refactor to the `modal-bonus` component. The most notable changes are making the month label in the "Promos" tab dynamic and improving the visual behavior of category dividers.

UI/UX improvements:

* Made the `.categoryDivider` in `create-order-market.module.scss` sticky at the top of its container to enhance navigation and context when scrolling through categories.
* Updated the "Promos" tab label in `modal-bonus.tsx` to display the current month dynamically using the Spanish month name, instead of hardcoding "Junio". [[1]](diffhunk://#diff-aa693f7f15112a16ec868895743cd41b1fe41938e382dd6f78e3dbfe8c12b5e6R44-R49) [[2]](diffhunk://#diff-aa693f7f15112a16ec868895743cd41b1fe41938e382dd6f78e3dbfe8c12b5e6L483-R486)

Refactoring:

* Imported `SPANISH_MONTHS` from the shared utility module to support the dynamic month label in the "Promos" tab.