### PR TITLE
Add promotion_applyed flag to order payload

### DIFF
--- a/src/modules/commerce/components/create-order-cart/create-order-cart.tsx
+++ b/src/modules/commerce/components/create-order-cart/create-order-cart.tsx
@@ -82,7 +82,8 @@ const CreateOrderCart: FC<CreateOrderCartProps> = ({ onClose }) => {
     setCategories,
     executiveDiscounts,
     deactivateCrossSelling,
-    channelName
+    channelName,
+    bonus
   } = useContext(OrderViewContext);
   const numberOfSelectedProducts = selectedCategories.reduce(
     (acc, category) => acc + category.products.length,
@@ -306,12 +307,19 @@ const CreateOrderCart: FC<CreateOrderCartProps> = ({ onClose }) => {
             product_sku: product.SKU,
             quantity: product.quantity
           }));
+        // promotion_applyed se calcula SOLO con los bonificados comunes
+        // (bonusOptions). Los "other bonified" (otherBonificated) NO cuentan,
+        // porque no pertenecen al rango activo de la promoción.
+        const promotionApplyed = (bonus?.bonusOptions ?? []).some((opt) =>
+          opt.cards.some((card) => card.items.length > 0)
+        );
         const confirmOrderData = {
           discount_package: selectedDiscount,
           order_summary: products,
           executive_discounts: executiveDiscounts,
           deactivate_cross_selling: !deactivateCrossSelling,
-          ...(promotionId !== undefined && { promotion_id: promotionId })
+          ...(promotionId !== undefined && { promotion_id: promotionId }),
+          promotion_applyed: promotionApplyed
         };
         try {
           const response = await confirmOrder(projectId, client?.id || "", confirmOrderData);
@@ -339,7 +347,7 @@ const CreateOrderCart: FC<CreateOrderCartProps> = ({ onClose }) => {
     return () => {
       clearTimeout(timeOut);
     };
-  }, [selectedCategories, selectedDiscount, executiveDiscounts, promotionId]);
+  }, [selectedCategories, selectedDiscount, executiveDiscounts, promotionId, bonus]);
 
   useEffect(() => {
     const newState = selectedCategories.map((category) => ({

--- a/src/modules/commerce/components/create-order-checkout/create-order-checkout.tsx
+++ b/src/modules/commerce/components/create-order-checkout/create-order-checkout.tsx
@@ -88,12 +88,19 @@ export default function CheckoutPage() {
           product_sku: product.SKU,
           quantity: product.quantity
         }));
+      // promotion_applyed se calcula SOLO con los bonificados comunes
+      // (bonusOptions). Los "other bonified" (otherBonificated) NO cuentan,
+      // porque no pertenecen al rango activo de la promoción.
+      const promotionApplyed = (bonus?.bonusOptions ?? []).some((opt) =>
+        opt.cards.some((card) => card.items.length > 0)
+      );
       const payload: IConfirmOrderData = {
         discount_package: selectedDiscount,
         order_summary: products,
         executive_discounts: executiveDiscounts,
         deactivate_cross_selling: !deactivateCrossSelling,
-        ...(bonus?.id !== undefined && { promotion_id: bonus.id })
+        ...(bonus?.id !== undefined && { promotion_id: bonus.id }),
+        promotion_applyed: promotionApplyed
       };
       try {
         const response = await confirmOrder(projectId, client?.id || "", payload);

--- a/src/types/commerce/ICommerce.ts
+++ b/src/types/commerce/ICommerce.ts
@@ -80,6 +80,13 @@ export interface IConfirmOrderData {
   executive_discounts: IExecutiveDiscount[];
   deactivate_cross_selling: boolean;
   promotion_id?: number;
+  /**
+   * Indica si la promoción aplica al carrito actual. Se calcula en base a
+   * los bonificados comunes (`bonusOptions`), NO a los "other bonified"
+   * (`otherBonificated`). Es `true` cuando al menos una tarjeta de
+   * `bonusOptions` tiene productos, y `false` en caso contrario.
+   */
+  promotion_applyed: boolean;
 }
 
 export interface IProductInDetail {


### PR DESCRIPTION
Compute and include a promotion_applyed boolean in order confirmation flows. Updates CreateOrderCart and CreateOrderCheckout to derive promotion_applyed from bonus.bonusOptions (only common bonified cards count; otherBonificated are ignored) and add it to the payload sent to confirmOrder. Add promotion_applyed to IConfirmOrderData with a descriptive comment. Also include bonus in CreateOrderCart's useEffect dependency array to ensure re-calculation. These changes ensure the backend receives an explicit flag indicating whether the promotion applies to the current cart.