### PR TITLE
Feat/add email data quality client detail

### DIFF
--- a/src/modules/dataQuality/components/CountryClientsActionsModal/CountryClientsActionsModal.tsx
+++ b/src/modules/dataQuality/components/CountryClientsActionsModal/CountryClientsActionsModal.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { Modal } from "antd";
-import { DownloadSimple, UploadSimple } from "@phosphor-icons/react";
+import { DownloadSimple, UploadSimple, EnvelopeSimple } from "@phosphor-icons/react";
 
 import { ButtonGenerateAction } from "@/components/atoms/ButtonGenerateAction/ButtonGenerateAction";
 
@@ -15,6 +15,7 @@ type CountryClientsActionsModalProps = {
   onUploadFile?: () => void;
   onUploadMaterialsAuxiliary?: () => void;
   onUploadPointsOfSale?: () => void;
+  onAddEmails?: () => void;
   isDownloadCatalogLoading: boolean;
   isInDetailView?: boolean;
 };
@@ -28,6 +29,7 @@ export const CountryClientsActionsModal: React.FC<CountryClientsActionsModalProp
   onUploadFile,
   onUploadMaterialsAuxiliary,
   onUploadPointsOfSale,
+  onAddEmails,
   isDownloadCatalogLoading,
   isInDetailView = false
 }) => {
@@ -72,6 +74,13 @@ export const CountryClientsActionsModal: React.FC<CountryClientsActionsModalProp
           onClick={onUploadPointsOfSale}
           disabled={isDownloadPointsOfSaleLoading}
         />
+        {onAddEmails && (
+          <ButtonGenerateAction
+            icon={<EnvelopeSimple size={20} />}
+            title="Agregar correos"
+            onClick={onAddEmails}
+          />
+        )}
       </div>
     </Modal>
   );

--- a/src/modules/dataQuality/components/CountryClientsActionsModal/CountryClientsActionsModal.tsx
+++ b/src/modules/dataQuality/components/CountryClientsActionsModal/CountryClientsActionsModal.tsx
@@ -77,7 +77,7 @@ export const CountryClientsActionsModal: React.FC<CountryClientsActionsModalProp
         {onAddEmails && (
           <ButtonGenerateAction
             icon={<EnvelopeSimple size={20} />}
-            title="Agregar correos"
+            title="Agregar remitentes"
             onClick={onAddEmails}
           />
         )}

--- a/src/modules/dataQuality/components/ModalDataRegisteredEmails/ModalDataRegisteredEmails.tsx
+++ b/src/modules/dataQuality/components/ModalDataRegisteredEmails/ModalDataRegisteredEmails.tsx
@@ -105,7 +105,7 @@ export const ModalDataRegisteredEmails: React.FC<Props> = ({ isOpen, onClose, cl
       open={isOpen}
       onCancel={onClose}
       onClose={onClose}
-      title="Correos"
+      title="Remitentes"
       footer={null}
       centered
       destroyOnClose

--- a/src/modules/dataQuality/components/ModalDataRegisteredEmails/ModalDataRegisteredEmails.tsx
+++ b/src/modules/dataQuality/components/ModalDataRegisteredEmails/ModalDataRegisteredEmails.tsx
@@ -1,0 +1,191 @@
+import React, { useEffect, useState } from "react";
+import { Modal, Spin, Input, message } from "antd";
+import { Trash, Plus, X } from "@phosphor-icons/react";
+
+import {
+  getClientDataEmails,
+  addClientDataEmail,
+  deleteClientDataEmail
+} from "@/services/dataQuality/dataQuality";
+import { isValidEmail } from "@/modules/commerce/utils/constants/checkout";
+import PrincipalButton from "@/components/atoms/buttons/principalButton/PrincipalButton";
+import { IDataEmail } from "@/types/dataQuality/IDataQuality";
+
+import "./modalDataRegisteredEmails.scss";
+
+interface Props {
+  isOpen: boolean;
+  onClose: () => void;
+  clientId: number;
+}
+
+export const ModalDataRegisteredEmails: React.FC<Props> = ({ isOpen, onClose, clientId }) => {
+  const [existingEmails, setExistingEmails] = useState<IDataEmail[]>([]);
+  const [isLoading, setIsLoading] = useState(false);
+  const [newEmails, setNewEmails] = useState<string[]>([]);
+  const [isSaving, setIsSaving] = useState(false);
+
+  const fetchEmails = async () => {
+    setIsLoading(true);
+    try {
+      const rules = await getClientDataEmails(clientId);
+      setExistingEmails(rules);
+    } catch (error) {
+      message.error(
+        error instanceof Error ? error.message : "Error al obtener los correos registrados"
+      );
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    if (isOpen) {
+      setNewEmails([]);
+      fetchEmails();
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [isOpen]);
+
+  const handleDelete = async (rule: IDataEmail) => {
+    const hide = message.loading("Eliminando correo...", 0);
+    try {
+      await deleteClientDataEmail([rule.id]);
+      message.success("Correo eliminado exitosamente");
+      setExistingEmails((prev) => prev.filter((email) => email.id !== rule.id));
+    } catch (error) {
+      message.error(error instanceof Error ? error.message : "Error al eliminar el correo");
+    } finally {
+      hide();
+    }
+  };
+
+  const handleAddRow = () => {
+    setNewEmails((prev) => [...prev, ""]);
+  };
+
+  const handleChangeNewEmail = (index: number, value: string) => {
+    setNewEmails((prev) => prev.map((email, i) => (i === index ? value : email)));
+  };
+
+  const handleRemoveNewRow = (index: number) => {
+    setNewEmails((prev) => prev.filter((_, i) => i !== index));
+  };
+
+  const handleSave = async () => {
+    const nonEmpty = newEmails.map((email) => email.trim()).filter((email) => email.length > 0);
+
+    if (nonEmpty.length === 0) return;
+    if (!nonEmpty.every((email) => isValidEmail(email))) {
+      message.error("Ingresa correos válidos");
+      return;
+    }
+
+    setIsSaving(true);
+    const hide = message.loading("Guardando correos...", 0);
+    try {
+      await addClientDataEmail(nonEmpty.map((sender) => ({ client_id: clientId, sender })));
+      message.success("Correos guardados exitosamente");
+      setNewEmails([]);
+      await fetchEmails();
+    } catch (error) {
+      message.error(error instanceof Error ? error.message : "Error al guardar los correos");
+    } finally {
+      hide();
+      setIsSaving(false);
+    }
+  };
+
+  const nonEmptyEmails = newEmails.filter((email) => email.trim().length > 0);
+  const hasNonEmpty = nonEmptyEmails.length > 0;
+  const allValid = nonEmptyEmails.every((email) => isValidEmail(email));
+
+  return (
+    <Modal
+      open={isOpen}
+      onCancel={onClose}
+      onClose={onClose}
+      title="Correos"
+      footer={null}
+      centered
+      destroyOnClose
+      className="modalDataRegisteredEmails"
+    >
+      <div className="modalDataRegisteredEmails__content">
+        {isLoading ? (
+          <div className="modalDataRegisteredEmails__loader">
+            <Spin />
+          </div>
+        ) : (
+          <div className="modalDataRegisteredEmails__list">
+            {existingEmails.length === 0 && newEmails.length === 0 && (
+              <p className="modalDataRegisteredEmails__empty">No hay correos registrados.</p>
+            )}
+
+            {existingEmails.map((rule) => (
+              <div key={rule.id} className="modalDataRegisteredEmails__row">
+                <span className="modalDataRegisteredEmails__email">{rule.sender}</span>
+                <button
+                  type="button"
+                  className="modalDataRegisteredEmails__iconButton"
+                  onClick={() => handleDelete(rule)}
+                  aria-label="Eliminar correo"
+                >
+                  <Trash size={18} />
+                </button>
+              </div>
+            ))}
+
+            {newEmails.map((email, index) => {
+              const isInvalid = email.trim().length > 0 && !isValidEmail(email);
+              return (
+                <div key={`new-${index}`} className="modalDataRegisteredEmails__newItem">
+                  <div className="modalDataRegisteredEmails__row">
+                    <div className="modalDataRegisteredEmails__field">
+                      <Input
+                        value={email}
+                        placeholder="correo@ejemplo.com"
+                        status={isInvalid ? "error" : undefined}
+                        onChange={(e) => handleChangeNewEmail(index, e.target.value)}
+                      />
+                    </div>
+                    <button
+                      type="button"
+                      className="modalDataRegisteredEmails__iconButton"
+                      onClick={() => handleRemoveNewRow(index)}
+                      aria-label="Quitar correo"
+                    >
+                      <X size={14} />
+                    </button>
+                  </div>
+                  {isInvalid && (
+                    <p className="modalDataRegisteredEmails__error">Correo no válido</p>
+                  )}
+                </div>
+              );
+            })}
+
+            <button
+              type="button"
+              className="modalDataRegisteredEmails__addButton"
+              onClick={handleAddRow}
+            >
+              <Plus size={18} />
+              Agregar correo
+            </button>
+          </div>
+        )}
+
+        <div className="modalDataRegisteredEmails__footer">
+          <PrincipalButton
+            onClick={handleSave}
+            loading={isSaving}
+            disabled={!hasNonEmpty || !allValid || isSaving}
+          >
+            Guardar
+          </PrincipalButton>
+        </div>
+      </div>
+    </Modal>
+  );
+};

--- a/src/modules/dataQuality/components/ModalDataRegisteredEmails/modalDataRegisteredEmails.scss
+++ b/src/modules/dataQuality/components/ModalDataRegisteredEmails/modalDataRegisteredEmails.scss
@@ -1,0 +1,130 @@
+.modalDataRegisteredEmails {
+    .ant-modal-content {
+        padding: 24px;
+        border-radius: 8px;
+    }
+
+    .ant-modal-header {
+        border-bottom: none;
+        padding: 0 0 16px 0;
+    }
+
+    .ant-modal-title {
+        font-size: 16px;
+        font-weight: 600;
+    }
+
+    &__content {
+        display: flex;
+        flex-direction: column;
+        gap: 16px;
+    }
+
+    &__loader {
+        display: flex;
+        justify-content: center;
+        align-items: center;
+        min-height: 120px;
+    }
+
+    &__list {
+        display: flex;
+        flex-direction: column;
+        padding: 2px;
+        padding-top: 4px;
+        gap: 12px;
+        max-height: 50vh;
+        overflow-y: auto;
+        scrollbar-width: thin;
+    }
+
+    &__empty {
+        color: #8c8c8c;
+        margin: 0;
+    }
+
+    &__row {
+        display: flex;
+        align-items: center;
+        gap: 4px;
+    }
+
+    &__newItem {
+        display: flex;
+        flex-direction: column;
+        gap: 4px;
+    }
+
+    &__email {
+        flex: 1;
+        padding: 8px 12px;
+        border: 1px solid #e8e8e8;
+        border-radius: 8px;
+        background-color: #f5f5f5;
+        word-break: break-all;
+    }
+
+    &__field {
+        flex: 1;
+        display: flex;
+        flex-direction: column;
+        gap: 4px;
+
+        .ant-input {
+            height: 38px;
+
+            &::placeholder {
+                color: #8c8c8c;
+            }
+        }
+    }
+
+    &__error {
+        font-size: 12px;
+        color: #ff4d4f;
+        margin: 0;
+    }
+
+    &__iconButton {
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        height: 24px;
+        width: 24px;
+        border: none;
+        border-radius: 8px;
+        background-color: transparent;
+        color: #141414;
+        cursor: pointer;
+        transition: all 0.3s;
+
+        &:hover {
+            background-color: #f5f5f5;
+            color: #ff4d4f;
+        }
+    }
+
+    &__addButton {
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        gap: 8px;
+        width: 100%;
+        padding: 10px 16px;
+        border: 1px dashed #cccccc;
+        border-radius: 8px;
+        background-color: #ffffff;
+        cursor: pointer;
+        transition: all 0.3s;
+
+        &:hover {
+            background-color: #f5f5f5;
+        }
+    }
+
+    &__footer {
+        display: flex;
+        justify-content: flex-end;
+        padding-top: 8px;
+    }
+}

--- a/src/modules/dataQuality/containers/DataQualityClientDetail/DataQualityClientDetail.tsx
+++ b/src/modules/dataQuality/containers/DataQualityClientDetail/DataQualityClientDetail.tsx
@@ -26,6 +26,7 @@ import { ClientDetailIntakesTable } from "../../components/ClientDetailIntakesTa
 import { ClientDetailTable } from "../../components/ClientDetailTable";
 import { ModalUploadFile } from "@/components/atoms/ModalUploadFile/ModalUploadFile";
 import { CountryClientsActionsModal } from "../../components/CountryClientsActionsModal/CountryClientsActionsModal";
+import { ModalDataRegisteredEmails } from "../../components/ModalDataRegisteredEmails/ModalDataRegisteredEmails";
 
 import { IUploadMassiveOrHistoricalRequest } from "@/types/dataQuality/IDataQuality";
 
@@ -320,6 +321,13 @@ export default function DataQualityClientDetails() {
         isDownloadPointsOfSaleLoading={isDownloadPointsOfSaleLoading}
         onUploadFile={handleOpenMassiveUpload}
         onUploadMaterialsAuxiliary={handleOpenAuxiliaryUpload}
+        onAddEmails={() => setWhichModalIsOpen(4)}
+      />
+
+      <ModalDataRegisteredEmails
+        isOpen={whichModalIsOpen === 4}
+        onClose={() => setWhichModalIsOpen(0)}
+        clientId={Number(clientId)}
       />
 
       <ModalUploadFile

--- a/src/services/dataQuality/dataQuality.ts
+++ b/src/services/dataQuality/dataQuality.ts
@@ -22,7 +22,8 @@ import {
   IPOSPayload,
   IClientDetailArchiveClient,
   IPostCatalogMaterialEquivalence,
-  IFileType
+  IFileType,
+  IDataEmail
 } from "@/types/dataQuality/IDataQuality";
 
 export const getSummaryCountries = async (projectId: number): Promise<ISummaryCountries> => {
@@ -689,6 +690,49 @@ export const deleteFileDateIntake = async (fileId: number): Promise<any> => {
     return response.data;
   } catch (error) {
     console.error("Error deleting file date intake:", error);
+    throw error;
+  }
+};
+
+// Email routing rules ENDPOINTS
+
+export const getClientDataEmails = async (clientId?: number | string): Promise<IDataEmail[]> => {
+  try {
+    const query = clientId ? `?client_id=${clientId}` : "";
+    const response: GenericResponse<{ rules: IDataEmail[] }> = await API.get(
+      `${config.API_HOST}/data/email-routing/rules${query}`
+    );
+    return response.data.rules;
+  } catch (error) {
+    console.error("Error fetching client data emails:", error);
+    throw error;
+  }
+};
+
+export const addClientDataEmail = async (
+  rules: { client_id?: number; sender: string }[]
+): Promise<any> => {
+  try {
+    const response: GenericResponse<any> = await API.post(
+      `${config.API_HOST}/data/email-routing/rules`,
+      { rules }
+    );
+    return response.data;
+  } catch (error) {
+    console.error("Error adding client data email:", error);
+    throw error;
+  }
+};
+
+export const deleteClientDataEmail = async (ids: number[]): Promise<any> => {
+  try {
+    const response: GenericResponse<any> = await API.delete(
+      `${config.API_HOST}/data/email-routing/rules`,
+      { data: { ids } }
+    );
+    return response.data;
+  } catch (error) {
+    console.error("Error deleting client data email:", error);
     throw error;
   }
 };

--- a/src/types/dataQuality/IDataQuality.ts
+++ b/src/types/dataQuality/IDataQuality.ts
@@ -4,6 +4,18 @@ export interface GenericResponseWithFilters<T = any, F = any> extends GenericRes
   filters: F;
 }
 
+export interface IDataEmail {
+  id: number;
+  project_id: number;
+  client_id: number | null;
+  client_name: string | null;
+  sender: string;
+  subject: string | null;
+  destination_folder: string | null;
+  outlook_folder_id: string | null;
+  outlook_subfolder: string | null;
+}
+
 export interface ICountryClientsFilters {
   status: string[];
   periodicity: string[];


### PR DESCRIPTION
This pull request introduces the ability to manage registered sender emails for a client in the Data Quality module. It adds a modal for viewing, adding, and removing sender emails, integrates this modal into the client detail view, and implements the necessary backend service calls and types. Styling for the new modal is also included.

**New sender email management feature:**

* Added the `ModalDataRegisteredEmails` component, which allows users to view, add, and delete sender emails associated with a client. The modal includes form validation, loading states, and user feedback. (`src/modules/dataQuality/components/ModalDataRegisteredEmails/ModalDataRegisteredEmails.tsx`)
* Created a corresponding SCSS file for the modal to provide custom styles. (`src/modules/dataQuality/components/ModalDataRegisteredEmails/modalDataRegisteredEmails.scss`)

**Integration into client detail view:**

* Updated the `CountryClientsActionsModal` to include an "Agregar remitentes" button, which opens the new modal when clicked. (`src/modules/dataQuality/components/CountryClientsActionsModal/CountryClientsActionsModal.tsx`) [[1]](diffhunk://#diff-0ce5257f77d37c0ee25a1127fd5dffbe14a82314c0f675d011ec8c670090053aL3-R3) [[2]](diffhunk://#diff-0ce5257f77d37c0ee25a1127fd5dffbe14a82314c0f675d011ec8c670090053aR18) [[3]](diffhunk://#diff-0ce5257f77d37c0ee25a1127fd5dffbe14a82314c0f675d011ec8c670090053aR32) [[4]](diffhunk://#diff-0ce5257f77d37c0ee25a1127fd5dffbe14a82314c0f675d011ec8c670090053aR77-R83)
* Integrated the new modal into the `DataQualityClientDetail` container, wiring up its open/close logic and passing the appropriate `clientId`. (`src/modules/dataQuality/containers/DataQualityClientDetail/DataQualityClientDetail.tsx`) [[1]](diffhunk://#diff-23f97646fb5f1f8d0a332549def06eec913badeb54caa86bd64a0a8233ddf8a5R29) [[2]](diffhunk://#diff-23f97646fb5f1f8d0a332549def06eec913badeb54caa86bd64a0a8233ddf8a5R324-R330)

**Backend service and type support:**

* Added new service methods to fetch, add, and delete sender emails via the backend API. (`src/services/dataQuality/dataQuality.ts`) [[1]](diffhunk://#diff-46cd6b20a7bf80434585e157cd855abf626e614a2dd03843d5e2dd4af041d71eL25-R26) [[2]](diffhunk://#diff-46cd6b20a7bf80434585e157cd855abf626e614a2dd03843d5e2dd4af041d71eR696-R738)
* Introduced the `IDataEmail` interface to type sender email objects throughout the codebase. (`src/types/dataQuality/IDataQuality.ts`)