### PR TITLE
feat(checkout): sanitize special characters in order comments

### DIFF
--- a/src/modules/commerce/components/create-order-checkout/modal-shipping-info/modal-shipping-info.tsx
+++ b/src/modules/commerce/components/create-order-checkout/modal-shipping-info/modal-shipping-info.tsx
@@ -10,7 +10,8 @@ import {
   NEW_ADDRESS_OPTION,
   isValidEmail,
   isValidPhone,
-  phoneErrorMessage
+  phoneErrorMessage,
+  sanitizeComment
 } from "@/modules/commerce/utils/constants/checkout";
 import { IShippingInfo } from "../../create-order-checkout/create-order-checkout";
 import { BonusRow } from "../order-shipment-confirm/order-shipment-confirm";
@@ -484,7 +485,9 @@ export default function ModalShippingInfo({
                 placeholder="Instrucciones especiales para esta entrega"
                 maxLength={35}
                 value={draft.observaciones}
-                onChange={(e) => setDraft((d) => ({ ...d, observaciones: e.target.value }))}
+                onChange={(e) =>
+                  setDraft((d) => ({ ...d, observaciones: sanitizeComment(e.target.value) }))
+                }
                 rows={3}
                 className="w-full px-2.5 py-2 text-xs bg-[#F7F7F7] border border-[#DDDDDD] rounded-lg outline-none focus:border-[#141414] transition-colors text-[#141414] placeholder:text-[#999999] resize-none"
               />

--- a/src/modules/commerce/components/create-order-checkout/order-shipment-confirm/order-shipment-confirm.tsx
+++ b/src/modules/commerce/components/create-order-checkout/order-shipment-confirm/order-shipment-confirm.tsx
@@ -21,7 +21,8 @@ import {
   NEW_ADDRESS_OPTION,
   isValidEmail,
   isValidPhone,
-  phoneErrorMessage
+  phoneErrorMessage,
+  sanitizeComment
 } from "@/modules/commerce/utils/constants/checkout";
 import { IShippingInfo } from "../../create-order-checkout/create-order-checkout";
 
@@ -601,7 +602,9 @@ export default function OrderShipmentConfirm({
                   placeholder="Ingresar un comentario"
                   maxLength={35}
                   value={singleForm.observaciones}
-                  onChange={(e) => setSingleForm((f) => ({ ...f, observaciones: e.target.value }))}
+                  onChange={(e) =>
+                    setSingleForm((f) => ({ ...f, observaciones: sanitizeComment(e.target.value) }))
+                  }
                   rows={3}
                   className="w-full px-3 py-2.5 text-sm bg-[#F7F7F7] border border-[#DDDDDD] rounded-lg outline-none focus:border-[#141414] transition-colors text-[#141414] placeholder:text-[#999999] resize-none"
                 />

--- a/src/modules/commerce/utils/constants/checkout.ts
+++ b/src/modules/commerce/utils/constants/checkout.ts
@@ -16,6 +16,13 @@ export const isValidPhone = (telefono: string, _indicativo: string) => {
   return true;
 };
 
+// Comentarios de envío: sin saltos de línea y sin caracteres de 4 bytes (emojis)
+// que la columna utf8mb3 del backend no admite. Se conservan tildes y ñ.
+export const sanitizeComment = (value: string) =>
+  value
+    .replace(/[\r\n]+/g, " ") // enters -> espacio
+    .replace(/[\u{10000}-\u{10FFFF}]/gu, ""); // emojis / 4-byte chars -> fuera
+
 export const phoneErrorMessage = (indicativo: string) =>
   indicativo === "+57"
     ? "Teléfono debe tener 10 dígitos"


### PR DESCRIPTION
Sanitize observaciones field by removing newlines and 4-byte Unicode characters (emojis) that are incompatible with the backend utf8mb3 database column. The sanitizeComment utility preserves accented characters and ñ while normalizing line breaks to spaces.