### PR TITLE
feat(commerce): add SCULPTRA_PACK_PRODUCT with doubled complement ratio

### DIFF
--- a/src/modules/commerce/utils/complementCalculation.ts
+++ b/src/modules/commerce/utils/complementCalculation.ts
@@ -4,6 +4,7 @@ import {
   EVEN_QUANTITY_PRODUCT,
   FULL_CANULA_CLIENT_IDS,
   SCULPTRA_MAIN_PRODUCT,
+  SCULPTRA_PACK_PRODUCT,
   matchesProductIdentifier
 } from "./constants/evenQuantityProducts";
 
@@ -24,6 +25,11 @@ export const computeComplementRequirements = (
 
   selectedCategories.forEach((category) => {
     category.products.forEach((p) => {
+      if (matchesProductIdentifier(p, SCULPTRA_PACK_PRODUCT)) {
+        // El pack requiere 4 cánulas + 8 aguas por unidad = 2× el ratio de Sculptra
+        sculptraQty += p.quantity * 2;
+        return;
+      }
       if (matchesProductIdentifier(p, SCULPTRA_MAIN_PRODUCT)) {
         sculptraQty += p.quantity;
         return;

--- a/src/modules/commerce/utils/constants/evenQuantityProducts.ts
+++ b/src/modules/commerce/utils/constants/evenQuantityProducts.ts
@@ -33,6 +33,12 @@ export const SCULPTRA_MAIN_PRODUCT: ProductIdentifier = {
   description: "SCULPTRA INJPRO 2 VIAL"
 };
 
+export const SCULPTRA_PACK_PRODUCT: ProductIdentifier = {
+  SKU: "033920",
+  EAN: null,
+  description: "Pack Sculptra + Alastin B"
+};
+
 export const CANULA_COMPLEMENT: ProductIdentifier = {
   SKU: "011022",
   EAN: null,


### PR DESCRIPTION
Add support for the Sculptra pack product (SKU: 033920) in complement calculations. The pack requires 4 cánulas + 8 aguas per unit, which is 2× the normal Sculptra ratio.