### PR TITLE
fix: update balance status options and add new NC created status

### DIFF
--- a/src/modules/balances/components/ModalChangeBalanceStatus/ModalChangeBalanceStatus.tsx
+++ b/src/modules/balances/components/ModalChangeBalanceStatus/ModalChangeBalanceStatus.tsx
@@ -17,7 +17,8 @@ interface Props {
 
 const BALANCE_STATUS_OPTIONS = [
   { id: 5, code: "rejected", label: "Novedad" },
-  { id: 2, code: "pending_nc", label: "Pendiente NC" }
+  { id: 2, code: "pending_nc", label: "NC Aprobada - Pendiente creación" },
+  { id: 10, code: "nc_created", label: "NC Creada - Pendiente cruce" }
 ];
 
 export const ModalChangeBalanceStatus: React.FC<Props> = ({


### PR DESCRIPTION
Modify BALANCE_STATUS_OPTIONS in ModalChangeBalanceStatus to improve label clarity for existing status and add new status for NC created pending matching
This pull request updates the list of balance status options in the `ModalChangeBalanceStatus` component to provide more detailed and descriptive status labels. The main changes are:

**Balance Status Options Update:**

* Updated the label for the `pending_nc` status to "NC Aprobada - Pendiente creación" for better clarity.
* Added a new status option with code `nc_created` and label "NC Creada - Pendiente cruce" to represent an additional balance status.