### PR TITLE
fix: adjust column widths and truncate description in auxiliary files…

### DIFF
--- a/src/modules/dataQuality/components/AuxiliaryFilesTable/auxiliary-files-table.tsx
+++ b/src/modules/dataQuality/components/AuxiliaryFilesTable/auxiliary-files-table.tsx
@@ -89,15 +89,21 @@ export function AuxiliaryFilesTable() {
 
   return (
     <Spin spinning={isLoading || isValidating}>
-      <Table>
+      <Table className="table-fixed">
         <TableHeader>
           <TableRow style={{ borderColor: "#DDDDDD" }}>
             <TableHead style={{ color: "#141414", fontWeight: 600 }}>Tipo de archivo</TableHead>
-            <TableHead style={{ color: "#141414", fontWeight: 600 }}>Fecha archivo</TableHead>
+            <TableHead className="w-[124px]" style={{ color: "#141414", fontWeight: 600 }}>
+              Fecha archivo
+            </TableHead>
             <TableHead style={{ color: "#141414", fontWeight: 600 }}>Nombre</TableHead>
-            <TableHead style={{ color: "#141414", fontWeight: 600 }}>Fecha cargue</TableHead>
-            <TableHead style={{ color: "#141414", fontWeight: 600 }}>Tamaño</TableHead>
-            <TableHead className="w-0" style={{ color: "#141414", fontWeight: 600 }}>
+            <TableHead className="w-[124px]" style={{ color: "#141414", fontWeight: 600 }}>
+              Fecha cargue
+            </TableHead>
+            <TableHead className="w-24" style={{ color: "#141414", fontWeight: 600 }}>
+              Tamaño
+            </TableHead>
+            <TableHead className="w-20" style={{ color: "#141414", fontWeight: 600 }}>
               Acciones
             </TableHead>
           </TableRow>
@@ -131,7 +137,10 @@ export function AuxiliaryFilesTable() {
                     <span style={{ color: "#141414" }}>{formatDate(file.created_at)}</span>
                   </div>
                 </TableCell>
-                <TableCell>
+                <TableCell
+                  className="overflow-hidden text-ellipsis"
+                  title={file.description || undefined}
+                >
                   <span className="font-normal" style={{ color: "#141414" }}>
                     {file.description || "-"}
                   </span>


### PR DESCRIPTION
… table

- Set table class to `table-fixed` for consistent column widths
- Assign explicit widths to date, name, size, and actions columns
- Truncate overly long descriptions with ellipsis and show full text on hover

This pull request updates the `AuxiliaryFilesTable` component to improve the table's layout and usability. The main changes focus on enhancing the table's column widths for better alignment and adding UI improvements to handle long file descriptions.

**Table layout improvements:**
* Set fixed widths for important columns (`Fecha archivo`, `Fecha cargue`, `Tamaño`, and `Acciones`) using Tailwind CSS classes to ensure consistent and readable table alignment. (`src/modules/dataQuality/components/AuxiliaryFilesTable/auxiliary-files-table.tsx`)
* Added the `table-fixed` class to the main `Table` element to enforce fixed column widths across the table. (`src/modules/dataQuality/components/AuxiliaryFilesTable/auxiliary-files-table.tsx`)

**File description cell improvements:**
* Updated the file description cell to use `overflow-hidden` and `text-ellipsis` classes, and set the `title` attribute to the full description. This ensures that long descriptions are truncated in the UI but can be viewed in full on hover. (`src/modules/dataQuality/components/AuxiliaryFilesTable/auxiliary-files-table.tsx`)