### PR TITLE
Feat/add auxiliary files flow

### DIFF
--- a/src/app/data-quality/auxiliary-catalogs/page.tsx
+++ b/src/app/data-quality/auxiliary-catalogs/page.tsx
@@ -1,0 +1,7 @@
+import AuxiliaryCatalogsView from "@/modules/dataQuality/containers/AuxiliaryCatalogsView/AuxiliaryCatalogsView";
+
+function Page() {
+  return <AuxiliaryCatalogsView />;
+}
+
+export default Page;

--- a/src/modules/dataQuality/components/AuxiliaryFilesTable/auxiliary-files-table.tsx
+++ b/src/modules/dataQuality/components/AuxiliaryFilesTable/auxiliary-files-table.tsx
@@ -1,0 +1,186 @@
+import { useState } from "react";
+import dayjs from "dayjs";
+import { Calendar, MoreHorizontal } from "lucide-react";
+import { Dropdown, Spin, message } from "antd";
+
+import { uploadAuxiliaryFile } from "@/services/dataQuality/dataQuality";
+import { useAuxiliaryFiles } from "../../hooks/useAuxiliaryFiles";
+
+import { Badge } from "@/modules/chat/ui/badge";
+import { Button } from "@/modules/chat/ui/button";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow
+} from "@/modules/chat/ui/table";
+import { IAuxiliaryFile } from "@/types/dataQuality/IDataQuality";
+
+const bytesToMB = (bytes: number | null): string => {
+  if (!bytes) return "-";
+  return (bytes / (1024 * 1024)).toFixed(2) + " MB";
+};
+
+const formatDate = (isoDateString: string | null): string => {
+  return isoDateString ? dayjs(isoDateString).format("YYYY-MM-DD") : "-";
+};
+
+export function AuxiliaryFilesTable() {
+  const { auxiliaryFiles, isLoading, isValidating, mutate } = useAuxiliaryFiles();
+  const [isUploading, setIsUploading] = useState(false);
+
+  const handleUpload = (id: number) => {
+    const input = document.createElement("input");
+    input.type = "file";
+    input.onchange = async (e) => {
+      const file = (e.target as HTMLInputElement).files?.[0];
+      if (file) {
+        setIsUploading(true);
+        const hide = message.open({ type: "loading", content: "Cargando archivo...", duration: 0 });
+        try {
+          await uploadAuxiliaryFile(id, file);
+          message.success("Archivo cargado exitosamente.");
+          mutate();
+        } catch (error) {
+          message.error(
+            error instanceof Error
+              ? error.message
+              : "Error al cargar el archivo. Por favor, inténtalo de nuevo."
+          );
+        } finally {
+          hide();
+          setIsUploading(false);
+        }
+      }
+      input.remove();
+    };
+    input.click();
+  };
+
+  const handleDownload = async (file: IAuxiliaryFile) => {
+    if (!file.file_url) {
+      message.error("No hay archivo disponible para descargar.");
+      return;
+    }
+    const hide = message.open({ type: "loading", content: "Descargando archivo...", duration: 0 });
+    try {
+      const response = await fetch(file.file_url);
+      const blob = await response.blob();
+      const url = window.URL.createObjectURL(blob);
+      const link = document.createElement("a");
+      link.href = url;
+      link.setAttribute("download", file.description || file.file_type);
+      document.body.appendChild(link);
+      link.click();
+      link.remove();
+      window.URL.revokeObjectURL(url);
+    } catch (error) {
+      message.error(
+        error instanceof Error
+          ? error.message
+          : "Error al descargar el archivo. Por favor, inténtalo de nuevo."
+      );
+    } finally {
+      hide();
+    }
+  };
+
+  return (
+    <Spin spinning={isLoading || isValidating}>
+      <Table>
+        <TableHeader>
+          <TableRow style={{ borderColor: "#DDDDDD" }}>
+            <TableHead style={{ color: "#141414", fontWeight: 600 }}>Tipo de archivo</TableHead>
+            <TableHead style={{ color: "#141414", fontWeight: 600 }}>Fecha archivo</TableHead>
+            <TableHead style={{ color: "#141414", fontWeight: 600 }}>Nombre</TableHead>
+            <TableHead style={{ color: "#141414", fontWeight: 600 }}>Fecha cargue</TableHead>
+            <TableHead style={{ color: "#141414", fontWeight: 600 }}>Tamaño</TableHead>
+            <TableHead className="w-0" style={{ color: "#141414", fontWeight: 600 }}>
+              Acciones
+            </TableHead>
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          {!isLoading && !auxiliaryFiles?.length ? (
+            <TableRow style={{ borderColor: "#DDDDDD" }}>
+              <TableCell colSpan={6} className="py-10 text-center text-gray-500">
+                No hay archivos auxiliares
+              </TableCell>
+            </TableRow>
+          ) : (
+            auxiliaryFiles?.map((file) => (
+              <TableRow
+                key={file.id}
+                className="hover:bg-gray-50"
+                style={{ borderColor: "#DDDDDD" }}
+              >
+                <TableCell>
+                  <Badge
+                    variant="secondary"
+                    className="text-xs text-white"
+                    style={{ backgroundColor: file.file_type_color }}
+                  >
+                    {file.file_type}
+                  </Badge>
+                </TableCell>
+                <TableCell>
+                  <div className="flex items-center space-x-2">
+                    <Calendar className="w-4 h-4" style={{ color: "#141414" }} />
+                    <span style={{ color: "#141414" }}>{formatDate(file.created_at)}</span>
+                  </div>
+                </TableCell>
+                <TableCell>
+                  <span className="font-normal" style={{ color: "#141414" }}>
+                    {file.description || "-"}
+                  </span>
+                </TableCell>
+                <TableCell>
+                  <div className="flex items-center space-x-2">
+                    <Calendar className="w-4 h-4" style={{ color: "#141414" }} />
+                    <span style={{ color: "#141414" }}>{formatDate(file.uploaded_at)}</span>
+                  </div>
+                </TableCell>
+                <TableCell>
+                  <span style={{ color: "#141414" }}>{bytesToMB(file.file_size)}</span>
+                </TableCell>
+                <TableCell className="w-0">
+                  <div className="flex items-center justify-end">
+                    <Dropdown
+                      menu={{
+                        items: [
+                          {
+                            key: "upload",
+                            label: "Cargar",
+                            onClick: () => handleUpload(file.id),
+                            disabled: isUploading
+                          },
+                          {
+                            key: "download",
+                            label: "Descargar",
+                            onClick: () => handleDownload(file),
+                            disabled: !file.file_url
+                          }
+                        ]
+                      }}
+                      trigger={["click"]}
+                    >
+                      <Button
+                        variant="outline"
+                        size="icon"
+                        className="bg-[#f7f7f7] border-[#DDDDDD] hover:bg-[#f7f7f7] hover:border-black p-1 !p-0 size-7"
+                      >
+                        <MoreHorizontal className="w-4 h-4" />
+                      </Button>
+                    </Dropdown>
+                  </div>
+                </TableCell>
+              </TableRow>
+            ))
+          )}
+        </TableBody>
+      </Table>
+    </Spin>
+  );
+}

--- a/src/modules/dataQuality/components/AuxiliaryFilesTable/auxiliary-files-table.tsx
+++ b/src/modules/dataQuality/components/AuxiliaryFilesTable/auxiliary-files-table.tsx
@@ -89,15 +89,21 @@ export function AuxiliaryFilesTable() {
 
   return (
     <Spin spinning={isLoading || isValidating}>
-      <Table>
+      <Table className="table-fixed">
         <TableHeader>
           <TableRow style={{ borderColor: "#DDDDDD" }}>
             <TableHead style={{ color: "#141414", fontWeight: 600 }}>Tipo de archivo</TableHead>
-            <TableHead style={{ color: "#141414", fontWeight: 600 }}>Fecha archivo</TableHead>
+            <TableHead className="w-[124px]" style={{ color: "#141414", fontWeight: 600 }}>
+              Fecha archivo
+            </TableHead>
             <TableHead style={{ color: "#141414", fontWeight: 600 }}>Nombre</TableHead>
-            <TableHead style={{ color: "#141414", fontWeight: 600 }}>Fecha cargue</TableHead>
-            <TableHead style={{ color: "#141414", fontWeight: 600 }}>Tamaño</TableHead>
-            <TableHead className="w-0" style={{ color: "#141414", fontWeight: 600 }}>
+            <TableHead className="w-[124px]" style={{ color: "#141414", fontWeight: 600 }}>
+              Fecha cargue
+            </TableHead>
+            <TableHead className="w-24" style={{ color: "#141414", fontWeight: 600 }}>
+              Tamaño
+            </TableHead>
+            <TableHead className="w-20" style={{ color: "#141414", fontWeight: 600 }}>
               Acciones
             </TableHead>
           </TableRow>
@@ -131,7 +137,10 @@ export function AuxiliaryFilesTable() {
                     <span style={{ color: "#141414" }}>{formatDate(file.created_at)}</span>
                   </div>
                 </TableCell>
-                <TableCell>
+                <TableCell
+                  className="overflow-hidden text-ellipsis"
+                  title={file.description || undefined}
+                >
                   <span className="font-normal" style={{ color: "#141414" }}>
                     {file.description || "-"}
                   </span>

--- a/src/modules/dataQuality/components/AuxiliaryFilesTable/index.ts
+++ b/src/modules/dataQuality/components/AuxiliaryFilesTable/index.ts
@@ -1,0 +1,1 @@
+export { AuxiliaryFilesTable } from "./auxiliary-files-table";

--- a/src/modules/dataQuality/containers/AuxiliaryCatalogsView/AuxiliaryCatalogsView.tsx
+++ b/src/modules/dataQuality/containers/AuxiliaryCatalogsView/AuxiliaryCatalogsView.tsx
@@ -1,0 +1,38 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+
+import Header from "@/components/organisms/header";
+import { AuxiliaryFilesTable } from "../../components/AuxiliaryFilesTable";
+
+import { Button } from "@/modules/chat/ui/button";
+import { ArrowLeft } from "lucide-react";
+import { Card } from "@/modules/chat/ui/card";
+
+export default function AuxiliaryCatalogsView() {
+  const router = useRouter();
+
+  const handleGoBack = () => {
+    router.back();
+  };
+
+  return (
+    <div className="flex flex-col gap-4">
+      <Header title="Auxiliares LATAM" />
+      {/* Main Content */}
+      <Card className="border-none gap-2 p-6">
+        <Button
+          onClick={handleGoBack}
+          variant="ghost"
+          size="sm"
+          className="text-gray-700 hover:text-gray-900 w-fit"
+        >
+          <ArrowLeft className="h-4 w-4 mr-1" />
+          Volver a vista general
+        </Button>
+
+        <AuxiliaryFilesTable />
+      </Card>
+    </div>
+  );
+}

--- a/src/modules/dataQuality/containers/DataQualityView/DataQualityView.tsx
+++ b/src/modules/dataQuality/containers/DataQualityView/DataQualityView.tsx
@@ -99,7 +99,7 @@ export default function DataQualityView() {
         <div className="flex gap-2">
           <Link href="/data-quality/auxiliary-catalogs">
             <Button variant="outline" className="text-[#141414]">
-              Catálogos
+              Auxiliares
             </Button>
           </Link>
           <Link href="/data-quality/alerts">

--- a/src/modules/dataQuality/containers/DataQualityView/DataQualityView.tsx
+++ b/src/modules/dataQuality/containers/DataQualityView/DataQualityView.tsx
@@ -97,6 +97,11 @@ export default function DataQualityView() {
         </div>
 
         <div className="flex gap-2">
+          <Link href="/data-quality/auxiliary-catalogs">
+            <Button variant="outline" className="text-[#141414]">
+              Catálogos
+            </Button>
+          </Link>
           <Link href="/data-quality/alerts">
             <Badge count={totalAlerts} color="#E53935">
               <Button variant="outline">

--- a/src/modules/dataQuality/hooks/useAuxiliaryFiles.ts
+++ b/src/modules/dataQuality/hooks/useAuxiliaryFiles.ts
@@ -1,0 +1,25 @@
+import useSWR from "swr";
+import { fetcher } from "@/utils/api/api";
+import { IAuxiliaryFile } from "@/types/dataQuality/IDataQuality";
+import { GenericResponse } from "@/types/global/IGlobal";
+
+export const useAuxiliaryFiles = () => {
+  const { data, error, isValidating, mutate } = useSWR<GenericResponse<IAuxiliaryFile[]>>(
+    "/data/auxiliary-files",
+    fetcher,
+    {
+      revalidateOnFocus: false,
+      revalidateOnReconnect: false,
+      dedupingInterval: 60000,
+      keepPreviousData: true
+    }
+  );
+
+  return {
+    auxiliaryFiles: data?.data,
+    isLoading: !error && !data,
+    isValidating,
+    error,
+    mutate
+  };
+};

--- a/src/services/dataQuality/dataQuality.ts
+++ b/src/services/dataQuality/dataQuality.ts
@@ -694,6 +694,21 @@ export const deleteFileDateIntake = async (fileId: number): Promise<any> => {
   }
 };
 
+export const uploadAuxiliaryFile = async (id: number, file: File): Promise<any> => {
+  const formData = new FormData();
+  formData.append("file", file);
+  try {
+    const response: GenericResponse<any> = await API.patch(
+      `${config.API_HOST}/data/auxiliary-files/${id}`,
+      formData
+    );
+    return response.data;
+  } catch (error) {
+    console.error("Error uploading auxiliary file:", error);
+    throw error;
+  }
+};
+
 // Email routing rules ENDPOINTS
 
 export const getClientDataEmails = async (clientId?: number | string): Promise<IDataEmail[]> => {

--- a/src/types/dataQuality/IDataQuality.ts
+++ b/src/types/dataQuality/IDataQuality.ts
@@ -633,3 +633,14 @@ export interface IFileType {
   id: number;
   description: string;
 }
+
+export interface IAuxiliaryFile {
+  id: number;
+  file_type: string;
+  file_type_color: string;
+  description: string | null;
+  file_url: string | null;
+  file_size: number | null; // bytes
+  created_at: string;
+  uploaded_at: string | null;
+}


### PR DESCRIPTION
This pull request introduces a new "Auxiliary Catalogs" feature to the data quality module. It adds a dedicated page and view for managing auxiliary files, including a table that lists files, allows uploading and downloading, and displays file metadata. Supporting hooks, API services, and type definitions are also included. Additionally, a navigation button is added to access this new section from the main data quality view.

**New Auxiliary Catalogs feature:**

* Added a new page (`page.tsx`) and container view (`AuxiliaryCatalogsView.tsx`) for auxiliary catalogs, including navigation and layout. [[1]](diffhunk://#diff-8eac64081be47f933b051a1f9ed281c81651275fa6a3f680f2325ef4ccef43b9R1-R7) [[2]](diffhunk://#diff-f2991ca756b07052000baf12e340613656eec33119fb0692cb589e125dfb7553R1-R38)
* Implemented the `AuxiliaryFilesTable` component to display auxiliary files, with upload and download actions, file metadata, and improved UI using Ant Design and custom UI components.
* Created a custom hook (`useAuxiliaryFiles`) to fetch and manage auxiliary files data using SWR.
* Added the `uploadAuxiliaryFile` service to handle file uploads to the backend.
* Defined the `IAuxiliaryFile` TypeScript interface for auxiliary file data structure.

**Navigation and integration:**

* Added an "Auxiliares" button to the main data quality view for easy access to the new auxiliary catalogs page.

**Exports and organization:**

* Exported the `AuxiliaryFilesTable` component in its index file for modular use.