### PR TITLE
Add legalize action for payment applications

### DIFF
--- a/src/modules/banks/components/payment-applications-table/PaymentApplicationsTable.tsx
+++ b/src/modules/banks/components/payment-applications-table/PaymentApplicationsTable.tsx
@@ -12,6 +12,7 @@ import {
 } from "antd";
 import {
   ArrowCounterClockwise,
+  CheckCircle,
   DotsThreeVertical,
   DownloadSimple,
   FileArrowUp
@@ -21,6 +22,7 @@ import { useAppStore } from "@/lib/store/store";
 import { formatDate } from "@/utils/utils";
 import { IPaymentApplication } from "@/types/paymentApplications/IPaymentApplication";
 import {
+  changeStatusToApplied,
   reprocessExcel,
   reprocessPDF,
   uploadFinalFile
@@ -182,6 +184,23 @@ export const PaymentApplicationsTable = ({
     }
   };
 
+  const handleChangeStatusToApplied = async (applicationId: number) => {
+    const hide = message.open({
+      type: "loading",
+      content: "Legalizando...",
+      duration: 0
+    });
+    try {
+      await changeStatusToApplied(applicationId);
+      message.success("Estado actualizado a Aplicado");
+      mutate();
+    } catch (error) {
+      message.error(error instanceof Error ? error.message : "Error al legalizar");
+    } finally {
+      hide();
+    }
+  };
+
   const columns: TableProps<applicationByStatus>["columns"] = [
     {
       title: "Id. Aplicación",
@@ -340,6 +359,22 @@ export const PaymentApplicationsTable = ({
                       onClick={() => handleUploadFile(record.id)}
                     >
                       Cargar Template
+                    </Button>
+                  )
+                }
+              ]
+            : []),
+          ...(statusName === "Legalización"
+            ? [
+                {
+                  key: "change-to-applied",
+                  label: (
+                    <Button
+                      icon={<CheckCircle size={20} />}
+                      className="buttonNoBorder"
+                      onClick={() => handleChangeStatusToApplied(record.id)}
+                    >
+                      Legalizar
                     </Button>
                   )
                 }

--- a/src/services/paymentApplications/paymentApplications.ts
+++ b/src/services/paymentApplications/paymentApplications.ts
@@ -1,5 +1,6 @@
 import { GenericResponse } from "@/types/global/IGlobal";
 import { API } from "@/utils/api/api";
+import { useAppStore } from "@/lib/store/store";
 
 export const reprocessExcel = async (applicationId: number): Promise<{ excel_url: string }> => {
   try {
@@ -38,6 +39,20 @@ export const uploadFinalFile = async (applicationId: string, file: File): Promis
     return response.data;
   } catch (error) {
     console.error("Error uploading final file:", error);
+    throw error;
+  }
+};
+
+export const changeStatusToApplied = async (identificationId: number): Promise<any> => {
+  const userId = useAppStore.getState().userId;
+  try {
+    const response: GenericResponse<any> = await API.put(
+      `/paymentApplication/change-status-to-applied/${identificationId}`,
+      { user: { user_id: userId.toString() } }
+    );
+    return response.data;
+  } catch (error) {
+    console.error("Error changing status to applied:", error);
     throw error;
   }
 };


### PR DESCRIPTION
Adds a new `changeStatusToApplied` service call and wires it into the payment applications table as a "Legalizar" action for items in "Legalización" status, including loading/success/error messaging and data refresh