### PR TITLE
feat: add modal to change task status and integrate in task detail

### DIFF
--- a/src/modules/taskManager/components/ModalChangeTaskStatus/ModalChangeTaskStatus.tsx
+++ b/src/modules/taskManager/components/ModalChangeTaskStatus/ModalChangeTaskStatus.tsx
@@ -1,0 +1,86 @@
+import React, { useEffect, useState } from "react";
+import { Button, Modal, Radio } from "antd";
+import { CaretLeft } from "phosphor-react";
+
+import { changeTaskStatus } from "@/services/tasks/tasks";
+import { useMessageApi } from "@/context/MessageContext";
+import FooterButtons from "@/components/atoms/FooterButtons/FooterButtons";
+
+import styles from "./modalChangeTaskStatus.module.scss";
+
+interface Props {
+  isOpen: boolean;
+  onClose: () => void;
+  taskId: number;
+  onSuccess?: () => void;
+}
+
+const TASK_STATUS_OPTIONS = [
+  { id: "6d5ee261-8e77-11f0-b08c-0635ef5156a1", label: "Completado" },
+  { id: "b2bbe2c2-d542-11f0-80fa-06e6795ff363", label: "Spam" },
+  { id: "c3a7f8d4-8e77-11f0-b08c-0635ef5156a1", label: "Novedad" }
+];
+
+export const ModalChangeTaskStatus: React.FC<Props> = ({ isOpen, onClose, taskId, onSuccess }) => {
+  const { showMessage } = useMessageApi();
+
+  const [selectedStatusId, setSelectedStatusId] = useState<string | undefined>();
+  const [loading, setLoading] = useState(false);
+
+  useEffect(() => {
+    if (!isOpen) {
+      setSelectedStatusId(undefined);
+    }
+  }, [isOpen]);
+
+  const handleConfirm = async () => {
+    if (!selectedStatusId) return;
+    setLoading(true);
+    try {
+      await changeTaskStatus(taskId, selectedStatusId);
+      showMessage("success", "El estado de la tarea se actualizó correctamente.");
+      onSuccess?.();
+      onClose();
+    } catch (error) {
+      const errorMessage =
+        error instanceof Error ? error.message : "Ha ocurrido un error al cambiar el estado.";
+      showMessage("error", errorMessage);
+    }
+    setLoading(false);
+  };
+
+  return (
+    <Modal className={styles.wrapper} width="50%" open={isOpen} footer={null} closable={false}>
+      <Button onClick={onClose} className={styles.content__header}>
+        <CaretLeft size="1.25rem" />
+        <span>Cambio de estado</span>
+      </Button>
+      <div className={styles.content}>
+        <p className={styles.content__description}>Selecciona el nuevo estado de la tarea</p>
+
+        <div className={styles.content__status}>
+          <Radio.Group
+            onChange={(e) => setSelectedStatusId(e.target.value)}
+            value={selectedStatusId}
+          >
+            {TASK_STATUS_OPTIONS.map((status) => (
+              <Radio className={styles.content__status__item} value={status.id} key={status.id}>
+                {status.label}
+              </Radio>
+            ))}
+          </Radio.Group>
+        </div>
+
+        <FooterButtons
+          handleOk={handleConfirm}
+          onClose={onClose}
+          titleConfirm="Cambiar de estado"
+          isConfirmDisabled={!selectedStatusId}
+          isConfirmLoading={loading}
+        />
+      </div>
+    </Modal>
+  );
+};
+
+export default ModalChangeTaskStatus;

--- a/src/modules/taskManager/components/ModalChangeTaskStatus/modalChangeTaskStatus.module.scss
+++ b/src/modules/taskManager/components/ModalChangeTaskStatus/modalChangeTaskStatus.module.scss
@@ -1,0 +1,59 @@
+@import "@/styles/variables";
+
+.wrapper {
+    .content {
+        display: flex;
+        flex-direction: column;
+        gap: 1rem;
+        margin: 0.75rem 0rem;
+
+        &__description {
+            font-size: 1rem;
+            font-weight: 300;
+        }
+
+        &__status {
+            display: flex;
+            flex-direction: column;
+            gap: 0.5rem;
+            overflow-y: auto;
+
+            :global(.ant-radio-group) {
+                display: flex;
+                flex-direction: column;
+                gap: 0.5rem;
+                width: 100%;
+            }
+
+            &__item {
+                width: 100%;
+                display: flex;
+                gap: 0.5rem;
+                background-color: $background;
+                border-radius: 0.5rem;
+                padding: 0.875rem 1rem;
+                font-size: 1rem;
+
+                span {
+                    padding: 0 !important;
+                }
+            }
+        }
+
+        &__header {
+            display: flex;
+            align-items: center;
+            gap: 0.5rem;
+            font-size: 1.25rem;
+            font-weight: 600;
+            border: none;
+            padding: 0;
+            box-shadow: none;
+            width: fit-content;
+
+            &:hover {
+                opacity: 0.6;
+            }
+        }
+    }
+}

--- a/src/modules/taskManager/components/modalTaskDetail/ModalTaskDetail.tsx
+++ b/src/modules/taskManager/components/modalTaskDetail/ModalTaskDetail.tsx
@@ -23,11 +23,18 @@ interface IModalTaskDetail {
   isOpen: boolean;
   onClose: () => void;
   taskTypes: ITaskTypes[];
+  onTaskUpdated?: () => void;
 }
 
 const DEFAULT_STATUS: ITaskStatus = { id: "", name: "", color: "", backgroundColor: "" };
 
-export function ModalTaskDetail({ task, isOpen, onClose, taskTypes }: IModalTaskDetail) {
+export function ModalTaskDetail({
+  task,
+  isOpen,
+  onClose,
+  taskTypes,
+  onTaskUpdated
+}: IModalTaskDetail) {
   const [taskDetail, setTaskDetail] = useState<ITaskDetail | null>(null);
   const [isLoadingDetail, setIsLoadingDetail] = useState(false);
   const [detailError, setDetailError] = useState<string | null>(null);
@@ -208,7 +215,13 @@ export function ModalTaskDetail({ task, isOpen, onClose, taskTypes }: IModalTask
             </div>
 
             <div className="flex items-center gap-3">
-              <TaskActionsDropdown task={task} />
+              <TaskActionsDropdown
+                task={task}
+                onStatusChanged={() => {
+                  fetchTaskDetail();
+                  onTaskUpdated?.();
+                }}
+              />
               {taskDetail && getEstadoBadge(watchedStatus)}
               <Button
                 variant="ghost"

--- a/src/modules/taskManager/components/taskActionsDropdown/TaskActionsDropdown.tsx
+++ b/src/modules/taskManager/components/taskActionsDropdown/TaskActionsDropdown.tsx
@@ -1,95 +1,108 @@
 "use client";
 
-import { FC } from "react";
+import { FC, useState } from "react";
 import {
-  Mail,
-  Phone,
-  MessageSquare,
-  AlertCircle,
-  Clock,
-  CheckCircle,
-  XCircle,
+  // Mail,
+  // Phone,
+  // MessageSquare,
+  // AlertCircle,
+  // Clock,
+  // CheckCircle,
+  // XCircle,
+  Pencil,
   MoreVertical
 } from "lucide-react";
-import {
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuItem,
-  DropdownMenuTrigger
-} from "@/modules/chat/ui/dropdown-menu";
-import { Button } from "@/modules/chat/ui/button";
+import { Dropdown, Button } from "antd";
+import type { MenuProps } from "antd";
 import { ITask } from "@/types/tasks/ITasks";
+import { ModalChangeTaskStatus } from "../ModalChangeTaskStatus/ModalChangeTaskStatus";
 
 interface TaskActionsDropdownProps {
   task: ITask;
   triggerClassName?: string;
   align?: "start" | "center" | "end";
+  onStatusChanged?: () => void;
 }
+
+const alignToPlacement = {
+  start: "bottomLeft",
+  center: "bottom",
+  end: "bottomRight"
+} as const;
 
 export const TaskActionsDropdown: FC<TaskActionsDropdownProps> = ({
   task,
   triggerClassName = "h-8 w-8",
-  align = "end"
+  align = "end",
+  onStatusChanged
 }) => {
-  const getMenuItems = () => {
-    const baseItems = [
-      { key: "email", icon: Mail, label: "Enviar correo" },
-      { key: "call", icon: Phone, label: "Llamar" },
-      { key: "whatsapp", icon: MessageSquare, label: "WhatsApp" },
-      { key: "visit", icon: AlertCircle, label: "Agendar visita" },
-      { key: "reconcile", icon: Clock, label: "Conciliar" },
-      { key: "payment", icon: CheckCircle, label: "Aplicar pago" },
-      { key: "file", icon: AlertCircle, label: "Radicar" },
-      { key: "report", icon: CheckCircle, label: "Reportar pago" }
-    ];
+  const [isStatusModalOpen, setIsStatusModalOpen] = useState(false);
 
-    if (task.task_type === "Saldo") {
-      baseItems.push({ key: "legalize", icon: CheckCircle, label: "Legalizar saldo" });
+  // const getMenuItems = () => {
+  //   const baseItems = [
+  //     { key: "email", icon: Mail, label: "Enviar correo" },
+  //     { key: "call", icon: Phone, label: "Llamar" },
+  //     { key: "whatsapp", icon: MessageSquare, label: "WhatsApp" },
+  //     { key: "visit", icon: AlertCircle, label: "Agendar visita" },
+  //     { key: "reconcile", icon: Clock, label: "Conciliar" },
+  //     { key: "payment", icon: CheckCircle, label: "Aplicar pago" },
+  //     { key: "file", icon: AlertCircle, label: "Radicar" },
+  //     { key: "report", icon: CheckCircle, label: "Reportar pago" }
+  //   ];
+
+  //   if (task.task_type === "Saldo") {
+  //     baseItems.push({ key: "legalize", icon: CheckCircle, label: "Legalizar saldo" });
+  //   }
+
+  //   if (task.task_type === "Desbloqueo") {
+  //     baseItems.push({ key: "unlock", icon: XCircle, label: "Desbloquear pedido" });
+  //   }
+
+  //   return baseItems;
+  // };
+
+  // const handleMenuItemClick = (key: string) => {
+  //   // Placeholder - no action for now
+  //   console.log(`Action: ${key} for task ${task.id}`);
+  // };
+
+  const items: MenuProps["items"] = [
+    {
+      key: "edit",
+      icon: <Pencil className="h-4 w-4" />,
+      label: "Cambiar estado",
+      disabled: task.id === null,
+      onClick: ({ domEvent }) => {
+        domEvent.stopPropagation();
+        setIsStatusModalOpen(true);
+      }
     }
-
-    if (task.task_type === "Desbloqueo") {
-      baseItems.push({ key: "unlock", icon: XCircle, label: "Desbloquear pedido" });
-    }
-
-    return baseItems;
-  };
-
-  const handleMenuItemClick = (key: string) => {
-    // Placeholder - no action for now
-    console.log(`Action: ${key} for task ${task.id}`);
-  };
+  ];
 
   return (
-    <DropdownMenu>
-      <DropdownMenuTrigger asChild>
+    <>
+      <Dropdown
+        menu={{ items }}
+        trigger={["click"]}
+        placement={alignToPlacement[align]}
+      >
         <Button
-          variant="ghost"
-          size="icon"
+          type="text"
           className={triggerClassName}
           onClick={(e) => e.stopPropagation()}
           title="Acciones"
-        >
-          <MoreVertical className="h-4 w-4 text-gray-600" />
-        </Button>
-      </DropdownMenuTrigger>
-      <DropdownMenuContent align={align} className="w-48">
-        {getMenuItems().map((item) => {
-          const IconComponent = item.icon;
-          return (
-            <DropdownMenuItem
-              key={item.key}
-              onClick={(e) => {
-                e.stopPropagation();
-                handleMenuItemClick(item.key);
-              }}
-              className="hover:bg-accent hover:text-accent-foreground cursor-pointer"
-            >
-              <IconComponent className="h-4 w-4 mr-2" />
-              {item.label}
-            </DropdownMenuItem>
-          );
-        })}
-      </DropdownMenuContent>
-    </DropdownMenu>
+          icon={<MoreVertical className="h-4 w-4 text-gray-600" />}
+        />
+      </Dropdown>
+
+      {task.id !== null && (
+        <ModalChangeTaskStatus
+          isOpen={isStatusModalOpen}
+          onClose={() => setIsStatusModalOpen(false)}
+          taskId={task.id}
+          onSuccess={onStatusChanged}
+        />
+      )}
+    </>
   );
 };

--- a/src/modules/taskManager/components/tasksTable/TasksTable.tsx
+++ b/src/modules/taskManager/components/tasksTable/TasksTable.tsx
@@ -66,6 +66,7 @@ interface ITasksTableProps {
   sortConfig: { key: SortKey; direction: SortDirection } | null;
   onSort: (key: SortKey) => void;
   isLoading?: boolean;
+  onTaskStatusChanged?: () => void;
 }
 
 const TasksTable: FC<ITasksTableProps> = ({
@@ -75,7 +76,8 @@ const TasksTable: FC<ITasksTableProps> = ({
   onSelectAll,
   onViewTask,
   onSort,
-  isLoading = false
+  isLoading = false,
+  onTaskStatusChanged
 }) => {
   const isAllSelected =
     tasks.length > 0 && tasks.every((task) => task.id !== null && selectedIds.includes(task.id));
@@ -301,7 +303,7 @@ const TasksTable: FC<ITasksTableProps> = ({
                   </td>
                   <td className="p-2 md:p-4 text-center">
                     <div className="flex items-center justify-center gap-1">
-                      <TaskActionsDropdown task={task} />
+                      <TaskActionsDropdown task={task} onStatusChanged={onTaskStatusChanged} />
                       <Button
                         variant="ghost"
                         size="icon"

--- a/src/modules/taskManager/containers/taskManagerView/TaskManagerView.tsx
+++ b/src/modules/taskManager/containers/taskManagerView/TaskManagerView.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { useEffect, useState } from "react";
+import React, { useCallback, useEffect, useState } from "react";
 import { Plus } from "lucide-react";
 import useSWR from "swr";
 import { getTasksByStatus, getTaskTabs, getTaskTypes } from "@/services/tasks/tasks";
@@ -83,7 +83,11 @@ export const TaskManagerView: React.FC = () => {
   }, []);
 
   // SWR for tabs data
-  const { data: tabsData, isLoading: isLoadingTabs } = useSWR("taskTabs", getTaskTabs, {
+  const {
+    data: tabsData,
+    isLoading: isLoadingTabs,
+    mutate: mutateTasksCount
+  } = useSWR("taskTabs", getTaskTabs, {
     revalidateOnFocus: false,
     revalidateOnReconnect: true
   });
@@ -97,6 +101,39 @@ export const TaskManagerView: React.FC = () => {
     }
   }, [tabsData, isLoadingTabs]);
 
+  // Fetch tasks for the active tab; reused as a refresh callback after mutations
+  const refreshActiveTabTasks = useCallback(async () => {
+    if (activeTabKey) {
+      setIsLoadingPagination(true);
+      try {
+        const response = await getTasksByStatus(activeTabKey, 1);
+        const tasksArray = response?.tasks ?? [];
+        setTasksByStatus((prev) => ({
+          ...prev,
+          [activeTabKey]: tasksArray
+        }));
+        setPaginationByStatus((prev) => ({
+          ...prev,
+          [activeTabKey]: {
+            page: response?.page ?? 1,
+            total: response?.total ?? 0,
+            limit: response?.limit ?? 25
+          }
+        }));
+      } catch (error) {
+        console.error("Error fetching tasks for active tab:", error);
+      } finally {
+        setIsLoadingPagination(false);
+      }
+    }
+  }, [activeTabKey]);
+
+  // After a task status change: refresh the active tab's list AND revalidate the tab counts
+  const handleTaskStatusChanged = useCallback(() => {
+    refreshActiveTabTasks();
+    mutateTasksCount();
+  }, [refreshActiveTabTasks, mutateTasksCount]);
+
   useEffect(() => {
     // Clear selected rows when switching tabs
     setState((prev) => ({
@@ -104,34 +141,8 @@ export const TaskManagerView: React.FC = () => {
       selectedTaskIds: []
     }));
 
-    // Fetch tasks for the active tab only if not already loaded
-    const fetchTasksForActiveTab = async () => {
-      if (activeTabKey) {
-        setIsLoadingPagination(true);
-        try {
-          const response = await getTasksByStatus(activeTabKey, 1);
-          const tasksArray = response?.tasks ?? [];
-          setTasksByStatus((prev) => ({
-            ...prev,
-            [activeTabKey]: tasksArray
-          }));
-          setPaginationByStatus((prev) => ({
-            ...prev,
-            [activeTabKey]: {
-              page: response?.page ?? 1,
-              total: response?.total ?? 0,
-              limit: response?.limit ?? 25
-            }
-          }));
-        } catch (error) {
-          console.error("Error fetching tasks for active tab:", error);
-        } finally {
-          setIsLoadingPagination(false);
-        }
-      }
-    };
-    fetchTasksForActiveTab();
-  }, [activeTabKey]);
+    refreshActiveTabTasks();
+  }, [activeTabKey, refreshActiveTabTasks]);
 
   const handleOpenModal = (selected: number) => {
     setIsModalOpen({ selected });
@@ -304,6 +315,7 @@ export const TaskManagerView: React.FC = () => {
             sortConfig={sortConfig}
             onSort={handleSort}
             isLoading={isLoadingPagination}
+            onTaskStatusChanged={handleTaskStatusChanged}
           />
           {pagination && pagination.total > pagination.limit && (
             <div className="flex items-center justify-between mt-2 px-4 py-2">
@@ -376,6 +388,7 @@ export const TaskManagerView: React.FC = () => {
           setSelectedTask(null);
         }}
         taskTypes={taskTypes}
+        onTaskUpdated={handleTaskStatusChanged}
       />
     </main>
   );

--- a/src/services/tasks/tasks.ts
+++ b/src/services/tasks/tasks.ts
@@ -99,6 +99,18 @@ export const patchTask = async (
   }
 };
 
+export const changeTaskStatus = async (taskId: number, statusId: string) => {
+  try {
+    const response: GenericResponse<any> = await API.patch(
+      `${config.API_HOST}/task/${taskId}/status`,
+      { status_id: statusId }
+    );
+    return response.data;
+  } catch (error) {
+    throw error;
+  }
+};
+
 export const reprocessAttachmentTask = async (attachmentId: number) => {
   try {
     const response: GenericResponse<any> = await API.post(


### PR DESCRIPTION
Implement ModalChangeTaskStatus component with radio selection for status options (completed, spam, novelty) and call changeTaskStatus API. Add onTaskUpdated callback to ModalTaskDetail to refresh parent after successful status change.
This pull request implements the ability to change a task's status from the UI, with a new modal, integration with the backend, and full refresh of the task list and tab counts after status changes. It also refactors the actions dropdown to use Ant Design components and improves status update flows.

**Key changes:**

### Feature: Task Status Change Modal

* Added the new `ModalChangeTaskStatus` component, which allows users to select and confirm a new status for a task. The modal handles loading state, error/success messages, and triggers callbacks on success. (`src/modules/taskManager/components/ModalChangeTaskStatus/ModalChangeTaskStatus.tsx`, `src/modules/taskManager/components/ModalChangeTaskStatus/modalChangeTaskStatus.module.scss`) [[1]](diffhunk://#diff-5f5b527b857172b3a66fb647aa96b1107a1bb3b41ac61946c67e5e3d88833c62R1-R86) [[2]](diffhunk://#diff-2d1a8e3ab8b2f14f9828a3c6918debafa2da4f11b1468bd91902f586a0848e5dR1-R59)
* Introduced the `changeTaskStatus` service function to perform the backend PATCH request for updating a task's status. (`src/services/tasks/tasks.ts`)

### UI Integration & Refactor

* Refactored `TaskActionsDropdown` to use Ant Design's `Dropdown` and `Button` instead of custom UI components, and added a "Cambiar estado" (Change status) menu item that opens the new status modal. The dropdown now accepts an `onStatusChanged` callback. (`src/modules/taskManager/components/taskActionsDropdown/TaskActionsDropdown.tsx`)
* Updated `TasksTable` to pass an `onTaskStatusChanged` handler to each `TaskActionsDropdown`, so the table can refresh when a task status is changed. (`src/modules/taskManager/components/tasksTable/TasksTable.tsx`) [[1]](diffhunk://#diff-131766449e508799a7e95096fda7df1b4beeedcd8b78621325cb46152cacef79R69) [[2]](diffhunk://#diff-131766449e508799a7e95096fda7df1b4beeedcd8b78621325cb46152cacef79L78-R80) [[3]](diffhunk://#diff-131766449e508799a7e95096fda7df1b4beeedcd8b78621325cb46152cacef79L304-R306)

### Data Refresh and Propagation

* In `TaskManagerView`, added logic to refresh both the active tab's task list and the tab counts after a status change, using SWR's `mutate`. The handler is passed to both the table and the task detail modal. (`src/modules/taskManager/containers/taskManagerView/TaskManagerView.tsx`) [[1]](diffhunk://#diff-fdfb60cc2bf1e99703fef10a897596d3785c9f5d71456e131a2b0b90e735b528L86-R90) [[2]](diffhunk://#diff-fdfb60cc2bf1e99703fef10a897596d3785c9f5d71456e131a2b0b90e735b528L100-R105) [[3]](diffhunk://#diff-fdfb60cc2bf1e99703fef10a897596d3785c9f5d71456e131a2b0b90e735b528L132-R146) [[4]](diffhunk://#diff-fdfb60cc2bf1e99703fef10a897596d3785c9f5d71456e131a2b0b90e735b528R318) [[5]](diffhunk://#diff-fdfb60cc2bf1e99703fef10a897596d3785c9f5d71456e131a2b0b90e735b528R391)
* Updated `ModalTaskDetail` and its usage to accept an `onTaskUpdated` callback, so status changes from the detail view also trigger data refresh. (`src/modules/taskManager/components/modalTaskDetail/ModalTaskDetail.tsx`) [[1]](diffhunk://#diff-2b71dc99f9d65d53adf064df4aa4eb953430e04a013da37f4aeaa043952f2f4eR26-R37) [[2]](diffhunk://#diff-2b71dc99f9d65d53adf064df4aa4eb953430e04a013da37f4aeaa043952f2f4eL211-R224)

These changes together provide a seamless, user-friendly way to update a task's status and ensure the UI remains in sync with the backend.