### PR TITLE
fix(create-order-products): clear order state when client is reset

### DIFF
--- a/src/modules/commerce/components/create-order-products/create-order-products.tsx
+++ b/src/modules/commerce/components/create-order-products/create-order-products.tsx
@@ -10,7 +10,7 @@ import CreateOrderProduct from "../create-order-product";
 import { getProductsByClient } from "@/services/commerce/commerce";
 
 import { ISelectType } from "@/types/clients/IClients";
-import { ISelectedProduct } from "@/types/commerce/ICommerce";
+import { IOrderConfirmedResponse, ISelectedProduct } from "@/types/commerce/ICommerce";
 
 import styles from "./create-order-products.module.scss";
 import { useDebounce } from "@/hooks/useSearch";
@@ -39,6 +39,10 @@ const CreateOrderProducts: FC = () => {
     categories,
     setCategories,
     setSelectedCategories,
+    setExecutiveDiscounts,
+    setBonus,
+    setConfirmOrderData,
+    setDeactivateCrossSelling,
     toggleCart,
     numberOfItems,
     businessUnit
@@ -204,6 +208,10 @@ const CreateOrderProducts: FC = () => {
           icon={<CaretLeft size={"1.3rem"} />}
           onClick={() => {
             setSelectedCategories([]);
+            setExecutiveDiscounts([]);
+            setBonus(undefined);
+            setConfirmOrderData({} as IOrderConfirmedResponse);
+            setDeactivateCrossSelling(true);
             setClient(undefined as any);
           }}
         >


### PR DESCRIPTION
Reset executive discounts, bonus, confirm order data, and deactivate cross-selling when the back button is clicked to clear the selected client.
This pull request updates the `CreateOrderProducts` component to improve state management and reset logic when navigating away from the order creation flow. The main changes involve adding new state setters and ensuring related state is properly reset when the user goes back.

**State management improvements:**

* Added new state setter functions: `setExecutiveDiscounts`, `setBonus`, `setConfirmOrderData`, and `setDeactivateCrossSelling` to the component's context, allowing for more granular control of order-related state.
* Updated the import statement to include the `IOrderConfirmedResponse` type, supporting the new state for confirmed order data.

**Reset logic enhancements:**

* Enhanced the back navigation handler to reset executive discounts, bonus, confirmed order data, and cross-selling deactivation in addition to clearing selected categories and client, ensuring a clean state when starting a new order.