### PR TITLE
feat(dataQuality): add periodicity field and display in DataExplorati…

### DIFF
--- a/src/modules/dataQuality/components/Dashboard/DataExplorationCard/DataExplorationCard.tsx
+++ b/src/modules/dataQuality/components/Dashboard/DataExplorationCard/DataExplorationCard.tsx
@@ -64,6 +64,7 @@ export function DataExplorationCard() {
         client_name: client.client_name,
         country: client.dates[0]?.rows[0]?.country ?? "",
         country_client_id: client.country_client_id,
+        periodicity: client.periodicity,
         days,
         total: client.totals.units_haleon,
         totalRegistros: client.totals.total_registros,
@@ -280,6 +281,7 @@ export function DataExplorationCard() {
                         </Link>
                         <span className="block" style={{ color: "#9CA3AF", fontSize: "9px" }}>
                           {row.country}
+                          {row.periodicity ? ` (${row.periodicity})` : ""}
                         </span>
                       </div>
                     </td>

--- a/src/types/dataQuality/IDataQuality.ts
+++ b/src/types/dataQuality/IDataQuality.ts
@@ -523,6 +523,7 @@ export interface IDataExplorationClient {
   dates: IDataExplorationDate[];
   totals: IDataExplorationTotals;
   last_month: ILastMonthDataExploration | null;
+  periodicity: string | null;
 }
 
 export interface IGetDataExploration {


### PR DESCRIPTION
…onCard

- Added `periodicity` property to IDataExplorationClient type and to the mapped client object.
- Shows periodicity in parentheses next to country when available.
This pull request adds support for displaying the `periodicity` property for each client in the Data Exploration Card. The main changes include updating the data model, passing the new property through the component, and rendering it in the UI.

**Data model update:**
* Added a new `periodicity` field to the `IDataExplorationClient` interface in `IDataQuality.ts` to store the periodicity information for each client.

**Component and UI updates:**
* Passed the `periodicity` property from the client data into the row object in the `DataExplorationCard` component.
* Displayed the `periodicity` value (in parentheses) next to the country name in the Data Exploration Card UI, if available.