### PR TITLE
Show only pending archives count

### DIFF
--- a/src/modules/dataQuality/components/ClientDetailTable/ArchiveTypeCollapseLabel.tsx
+++ b/src/modules/dataQuality/components/ClientDetailTable/ArchiveTypeCollapseLabel.tsx
@@ -41,7 +41,7 @@ export function ArchiveTypeCollapseLabel({
             {group.tipo_archivo}
           </Badge>
           <span className="text-xs pr-3 font-medium" style={{ color: "#141414", opacity: 0.5 }}>
-            {group.pending_archives} / {group.total_archives} Pendientes
+            {group.pending_archives} Pendientes
           </span>
         </div>
         {intake && (


### PR DESCRIPTION
Updated `ArchiveTypeCollapseLabel` to display only `group.pending_archives` in the status text, removing the `pending / total` format so the label now reads just the number of pending archives.