### PR TITLE
feat: improve email fallback logic in order checkout flow

### DIFF
--- a/src/modules/commerce/components/create-order-checkout/modal-shipping-info/modal-shipping-info.tsx
+++ b/src/modules/commerce/components/create-order-checkout/modal-shipping-info/modal-shipping-info.tsx
@@ -36,6 +36,7 @@ interface ModalShippingInfoProps {
   addresses: ICommerceAdresses[];
   callingCodeOptions: { value: number; label: string; className: string }[];
   isLoadingOptions: boolean;
+  clientEmail?: string;
 }
 
 export default function ModalShippingInfo({
@@ -52,7 +53,8 @@ export default function ModalShippingInfo({
   otherBonusAsignadasExcluyendo,
   addresses,
   callingCodeOptions,
-  isLoadingOptions
+  isLoadingOptions,
+  clientEmail
 }: ModalShippingInfoProps) {
   const { projectId, formatMoney } = useAppStore((s) => ({
     projectId: s.selectedProject.ID,
@@ -156,7 +158,7 @@ export default function ModalShippingInfo({
           addressId: sel.id,
           city: sel.city,
           dispatch_address: sel.address,
-          email: d.email || sel.email
+          email: d.email || sel.email || clientEmail || ""
         }));
       }
     }

--- a/src/modules/commerce/components/create-order-checkout/order-shipment-confirm/order-shipment-confirm.tsx
+++ b/src/modules/commerce/components/create-order-checkout/order-shipment-confirm/order-shipment-confirm.tsx
@@ -233,7 +233,7 @@ export default function OrderShipmentConfirm({
           addressId: sel.id,
           city: sel.city,
           dispatch_address: sel.address,
-          email: f.email || sel.email
+          email: f.email || sel.email || client?.email || ""
         }));
       }
     }
@@ -752,6 +752,7 @@ export default function OrderShipmentConfirm({
               bonusAsignadasExcluyendo={bonusAsignadasExcluyendo}
               otherBonusAsignadasExcluyendo={otherBonusAsignadasExcluyendo}
               addresses={addresses}
+              clientEmail={client?.email}
               callingCodeOptions={callingCodeOptions}
               isLoadingOptions={isLoadingOptions}
             />

--- a/src/modules/commerce/components/create-order-search-client/create-order-search-client.tsx
+++ b/src/modules/commerce/components/create-order-search-client/create-order-search-client.tsx
@@ -183,7 +183,7 @@ const CreateOrderSearchClient: FC = () => {
       address: selectedAddress.dispatch_address,
       city: selectedAddress.city,
       dispatch_address: selectedAddress.dispatch_address,
-      email: selectedAddress.email || "",
+      email: selectedAddress.email || selectedClient.client_email || "",
       phone_number: "",
       comments: ""
     };


### PR DESCRIPTION
Add client email as fallback in shipping info forms to ensure email is always captured when creating orders. Updates modal-shipping-info, order-shipment-confirm, and create-order-search-client components.
This pull request improves how the client’s email is handled and propagated throughout the order creation and shipping confirmation flow. The main change is to ensure that the email field is always populated with the most reliable source, falling back to the client’s email if it’s not present on the address or form data. This makes the email handling more robust and reduces the chance of missing or empty email fields.

**Email handling improvements:**

* Added an optional `clientEmail` prop to the `ModalShippingInfo` component and ensured it is passed from the parent component (`OrderShipmentConfirm`). (`src/modules/commerce/components/create-order-checkout/modal-shipping-info/modal-shipping-info.tsx`, `src/modules/commerce/components/create-order-checkout/order-shipment-confirm/order-shipment-confirm.tsx`) [[1]](diffhunk://#diff-2e1f1a59b8dddb69323f5ee3f61a1d246defd5d9f86c4f374ae07dd17f276762R39) [[2]](diffhunk://#diff-2e1f1a59b8dddb69323f5ee3f61a1d246defd5d9f86c4f374ae07dd17f276762L55-R57) [[3]](diffhunk://#diff-b4b4f1944cce9e8aa8c492a8f2f229c936efa65b0f39a3a91defef11e8fe7911R755)
* Updated logic in both `ModalShippingInfo` and `OrderShipmentConfirm` to use the client’s email as a fallback if the email is not present on the address or form data. (`src/modules/commerce/components/create-order-checkout/modal-shipping-info/modal-shipping-info.tsx`, `src/modules/commerce/components/create-order-checkout/order-shipment-confirm/order-shipment-confirm.tsx`) [[1]](diffhunk://#diff-2e1f1a59b8dddb69323f5ee3f61a1d246defd5d9f86c4f374ae07dd17f276762L159-R161) [[2]](diffhunk://#diff-b4b4f1944cce9e8aa8c492a8f2f229c936efa65b0f39a3a91defef11e8fe7911L236-R236)
* Improved default email assignment in `CreateOrderSearchClient` to use the client’s email if the selected address does not have one. (`src/modules/commerce/components/create-order-search-client/create-order-search-client.tsx`)