### PR TITLE
fix(modal-bonus): reset bonus quantities to 0 instead of pre-filling …

### DIFF
--- a/src/modules/commerce/components/modal-bonus/modal-bonus.tsx
+++ b/src/modules/commerce/components/modal-bonus/modal-bonus.tsx
@@ -51,7 +51,7 @@ const ModalBonus = ({
   const [activeTab, setActiveTab] = useState(0);
   const [poolQty, setPoolQty] = useState<Record<number, Record<number, number>>>({});
   const [otherQty, setOtherQty] = useState<Record<number, number>>(() =>
-    Object.fromEntries(otherBonificated.map((p) => [p.product_id, p.qty]))
+    Object.fromEntries(otherBonificated.map((p) => [p.product_id, 0]))
   );
 
   useEffect(() => {
@@ -80,7 +80,7 @@ const ModalBonus = ({
   // frequent cart refetch (which hands back a new array each time) doesn't wipe
   // the user's in-progress input back to the seed value
   useEffect(() => {
-    setOtherQty(Object.fromEntries(otherBonificated.map((p) => [p.product_id, p.qty])));
+    setOtherQty(Object.fromEntries(otherBonificated.map((p) => [p.product_id, 0])));
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [otherKey]);
 


### PR DESCRIPTION
…from cart
This pull request updates the initialization and reset behavior for the `otherQty` state in the `ModalBonus` component. The main change is to always initialize and reset the `otherQty` quantities to zero, rather than to the existing quantity of each product.

State initialization and reset:

* [`src/modules/commerce/components/modal-bonus/modal-bonus.tsx`](diffhunk://#diff-aa693f7f15112a16ec868895743cd41b1fe41938e382dd6f78e3dbfe8c12b5e6L54-R54): Changed the initialization and reset logic for `otherQty` so that all quantities start at `0` instead of the previous product quantity (`p.qty`). This ensures that when the modal is opened or the `otherKey` changes, users always start with zero quantities for "other" bonificated products. [[1]](diffhunk://#diff-aa693f7f15112a16ec868895743cd41b1fe41938e382dd6f78e3dbfe8c12b5e6L54-R54) [[2]](diffhunk://#diff-aa693f7f15112a16ec868895743cd41b1fe41938e382dd6f78e3dbfe8c12b5e6L83-R83)