### PR TITLE
Add filter support to sales dashboard

### DIFF
--- a/src/modules/commerce/components/sales-dashboard/salesTable/salesTable.tsx
+++ b/src/modules/commerce/components/sales-dashboard/salesTable/salesTable.tsx
@@ -1,18 +1,16 @@
 "use client";
 
 import React, { useState } from "react";
-import Link from "next/link";
 import useSWR from "swr";
-import { Button } from "antd";
 import { ChevronDown, ChevronRight, TrendingUp } from "lucide-react";
-import { CaretLeft } from "@phosphor-icons/react";
 
 import { useAppStore } from "@/lib/store/store";
 import { getSalesDashboard } from "@/services/commerce/commerce";
 
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/modules/chat/ui/card";
 import { Tooltip, TooltipProvider, TooltipTrigger } from "@/modules/chat/ui/tooltip";
-import { ISalesDashboardSellerLeader } from "@/types/commerce/ICommerce";
+import { useRevenueTracking } from "@/modules/commerce/contexts/revenue-tracking-context";
+import { appendSalesFilterParams } from "@/modules/commerce/hooks/revenue-tracking/salesFilterParams";
 
 type SortColumn =
   | "total_sales_in_process"
@@ -28,7 +26,15 @@ type SortDirection = "asc" | "desc";
 export default function SalesTable() {
   const formatMoney = useAppStore((state) => state.formatMoney);
 
-  const { data: salesData, isLoading } = useSWR("/sales/dashboard", getSalesDashboard);
+  const { filters } = useRevenueTracking();
+  const { data: salesData, isLoading } = useSWR(
+    () => {
+      const params = new URLSearchParams();
+      appendSalesFilterParams(params, filters);
+      return `/galderma-dashboard/sellers?${params.toString()}`;
+    },
+    (_key: string) => getSalesDashboard(filters)
+  );
 
   const [expandedSellerLeaders, setExpandedSellerLeaders] = useState<Set<string>>(
     new Set(["regional 1", "regional 2", "regional 3"])

--- a/src/services/commerce/commerce.ts
+++ b/src/services/commerce/commerce.ts
@@ -20,6 +20,8 @@ import {
   IWarehouseProductsStock
 } from "@/types/commerce/ICommerce";
 import { MessageType } from "@/context/MessageContext";
+import { FilterOption } from "@/modules/commerce/contexts/revenue-tracking-context";
+import { appendSalesFilterParams } from "@/modules/commerce/hooks/revenue-tracking/salesFilterParams";
 
 export const getAllOrders = async (projectId: number) => {
   const response: GenericResponse<IOrderData[]> = await API.get(
@@ -457,9 +459,14 @@ export const changeStatusOrder = async (orderId: number) => {
 
 // For dashboard sales data
 
-export const getSalesDashboard = async () => {
+export const getSalesDashboard = async (filters: Record<string, FilterOption[]> = {}) => {
   try {
-    const response: GenericResponse<ISalesDashboard> = await API.get(`/galderma-dashboard/sellers`);
+    const params = new URLSearchParams();
+    appendSalesFilterParams(params, filters);
+    const queryString = params.toString();
+    const response: GenericResponse<ISalesDashboard> = await API.get(
+      `/galderma-dashboard/sellers?${queryString}`
+    );
     return response.data;
   } catch (error) {
     console.error("Error fetching sales dashboard data:", error);


### PR DESCRIPTION
Add filtering capability to getSalesDashboard function. The function now accepts an optional filters parameter and builds URL query parameters using appendSalesFilterParams utility. This enables filtered dashboard views based on user-selected criteria.