### PR TITLE
Fix/UI data email rules

### DIFF
--- a/src/modules/dataQuality/components/ModalDataRegisteredEmails/ModalDataEmailRules.tsx
+++ b/src/modules/dataQuality/components/ModalDataRegisteredEmails/ModalDataEmailRules.tsx
@@ -172,6 +172,8 @@ export const ModalDataEmailRules: React.FC<Props> = ({ isOpen, onClose, clientId
               />
             </div>
 
+            <p className="modalDataEmailRules__title">Remitentes</p>
+
             {existingEmails.length === 0 && newEmails.length === 0 && (
               <p className="modalDataEmailRules__empty">No hay correos registrados.</p>
             )}

--- a/src/modules/dataQuality/components/ModalDataRegisteredEmails/modalDataEmailRules.scss
+++ b/src/modules/dataQuality/components/ModalDataRegisteredEmails/modalDataEmailRules.scss
@@ -62,6 +62,13 @@
         }
     }
 
+    &__title {
+        font-size: 16px;
+        font-weight: 600;
+        color: #141414;
+        margin: 0;
+    }
+
     &__label {
         font-size: 0.75rem;
         font-weight: 600;


### PR DESCRIPTION
This pull request makes a small UI improvement to the registered emails modal by adding a new section title and its corresponding styling.

- Added a "Remitentes" section title to the modal (`ModalDataEmailRules.tsx`).
- Introduced new styling for the section title in the SCSS file (`modalDataEmailRules.scss`).
- 
<img width="442" height="487" alt="image" src="https://github.com/user-attachments/assets/29a51fb7-8611-4c55-b89b-0a989580ed2f" />
