### PR TITLE
feat(chat): add author type indicator to message bubbles

### DIFF
--- a/src/modules/chat/components/bubble-message/BubbleMessage.tsx
+++ b/src/modules/chat/components/bubble-message/BubbleMessage.tsx
@@ -4,6 +4,8 @@ import {
   Checks,
   Clock,
   FileArrowDown,
+  Robot,
+  User,
   WarningCircle
 } from "@phosphor-icons/react";
 
@@ -75,9 +77,26 @@ function ReadStatus({ mine, status }: { mine: boolean; status: string }) {
   return iconMap[status] ?? null;
 }
 
-function Footer({ timestamp, mine, status }: { timestamp: string; mine: boolean; status: string }) {
+function AuthorIcon({ authorType }: { authorType: IMessage["authorType"] }) {
+  if (!authorType) return null;
+  const Icon = authorType === "BOT" ? Robot : User;
+  return <Icon size={15} color="#CBE71E" />;
+}
+
+function Footer({
+  timestamp,
+  mine,
+  status,
+  authorType
+}: {
+  timestamp: string;
+  mine: boolean;
+  status: string;
+  authorType: IMessage["authorType"];
+}) {
   return (
     <div className="flex items-center justify-end gap-1 mt-1">
+      {mine && <AuthorIcon authorType={authorType} />}
       <div className="text-[11px] text-[#9c9c9c]">{formatTime(timestamp)}</div>
       <ReadStatus mine={mine} status={status} />
     </div>
@@ -122,7 +141,9 @@ export default function BubbleMessage({
   onMediaLoad
 }: BubbleMessageProps) {
   const mine = m.direction === "OUTBOUND";
-  const footer = <Footer timestamp={m.timestamp} mine={mine} status={m.status} />;
+  const footer = (
+    <Footer timestamp={m.timestamp} mine={mine} status={m.status} authorType={m.authorType} />
+  );
 
   const aditionals = m.metadata?.aditionals;
   if (aditionals?.type === "reaction" && aditionals?.reaction?.emoji) {

--- a/src/modules/chat/components/chat-footer/ChatFooter.tsx
+++ b/src/modules/chat/components/chat-footer/ChatFooter.tsx
@@ -107,7 +107,8 @@ export default function ChatFooter({
         status: "SENT",
         timestamp: new Date().toISOString(),
         mediaUrl: null,
-        metadata: {}
+        metadata: {},
+        authorType: null
       };
 
       mutate((currentData) => {

--- a/src/modules/chat/containers/chat-thread.tsx
+++ b/src/modules/chat/containers/chat-thread.tsx
@@ -128,7 +128,8 @@ export default function ChatThread({
         mediaUrl: msg.mediaUrl,
         templateName: msg.templateName ?? undefined,
         templateData: msg.templateData ?? undefined,
-        metadata: msg.metadata
+        metadata: msg.metadata,
+        authorType: msg.authorType ?? null
       };
 
       // Update the SWR cache by adding the new message only if it doesn't exist

--- a/src/types/chat/IChat.ts
+++ b/src/types/chat/IChat.ts
@@ -62,6 +62,7 @@ export interface IMessage {
       email: string;
     };
   };
+  authorType: "BOT" | "HUMAN_AGENT" | "CUSTOMER" | null;
 }
 
 interface IPagination {
@@ -124,11 +125,24 @@ export interface IMessageSocket {
   updatedAt: string;
   customer: ICustomerSocket;
   ticket: ITicketSocket;
+  authorType: "BOT" | "HUMAN_AGENT" | "CUSTOMER" | null;
+}
+
+export interface ITicketEvent {
+  id: string;
+  ticketId: string;
+  type: string;
+  actor: string;
+  reason: string;
+  summary: string;
+  metadata: any;
+  createdAt: string;
 }
 
 export interface IChatData {
   messages: IMessage[];
   pagination: IPagination;
+  events?: ITicketEvent[];
 }
 
 export interface IWhatsAppTemplate {


### PR DESCRIPTION
- Display Robot/User icon based on message author (BOT, HUMAN_AGENT, CUSTOMER)
- Add authorType field to IMessage and IMessageSocket interfaces
- Introduce ITicketEvent interface for ticket events
This pull request enhances the chat message system by introducing an `authorType` field to messages, allowing the UI to distinguish between messages sent by bots, human agents, and customers. The UI now displays an icon next to outbound messages based on the author type, improving clarity for users. Additionally, a new `ITicketEvent` interface is added to support ticket-related events in chat data.

**Message Author Identification and UI Improvements:**

* Added an `authorType` field to both `IMessage` and `IMessageSocket` interfaces, supporting values `"BOT"`, `"HUMAN_AGENT"`, `"CUSTOMER"`, or `null`. This enables the system to track and display the type of message author. [[1]](diffhunk://#diff-8760d261c17d3fd4e99aa3d6da11b092ea512bb9241571bd95c717d97542d1e7R65) [[2]](diffhunk://#diff-8760d261c17d3fd4e99aa3d6da11b092ea512bb9241571bd95c717d97542d1e7R128-R145)
* Updated the `BubbleMessage` component to pass the `authorType` to the `Footer`, and introduced an `AuthorIcon` component that displays a robot or user icon based on the author type for outbound messages. [[1]](diffhunk://#diff-7b2346a87129be3dc5d72019ef885309e9995afa4ce76902f501540e06f5434dR7-R8) [[2]](diffhunk://#diff-7b2346a87129be3dc5d72019ef885309e9995afa4ce76902f501540e06f5434dL78-R99) [[3]](diffhunk://#diff-7b2346a87129be3dc5d72019ef885309e9995afa4ce76902f501540e06f5434dL125-R146)
* Ensured that new messages in the chat thread include the `authorType` property when updating the SWR cache.

**Ticket Event Support:**

* Introduced a new `ITicketEvent` interface and updated the `IChatData` interface to optionally include a list of ticket events, laying the groundwork for future event-based features in chat.