### PR TITLE
Feat/86e2ecm00/draft

### DIFF
--- a/src/hooks/useClientsGroups.ts
+++ b/src/hooks/useClientsGroups.ts
@@ -33,7 +33,7 @@ export const useClientsGroups = ({
   const pageQuery = page ? `&page=${page}` : "";
   const limitQuery = noLimit ? "&noLimit=true" : "";
   const searchQueryParam = searchQuery
-    ? `&searchQuery=${encodeURIComponent(searchQuery.toLowerCase().trim())}`
+    ? `&name=${encodeURIComponent(searchQuery.toLowerCase().trim())}`
     : "";
 
   const pathKey = `/group-client/?project_id=${projectId}${pageQuery}${clientsQuery}${subsQuery}${statusQuery}${limitQuery}${searchQueryParam}`;

--- a/src/modules/chat/components/bubble-message/BubbleMessage.tsx
+++ b/src/modules/chat/components/bubble-message/BubbleMessage.tsx
@@ -4,6 +4,8 @@ import {
   Checks,
   Clock,
   FileArrowDown,
+  Robot,
+  User,
   WarningCircle
 } from "@phosphor-icons/react";
 
@@ -75,9 +77,26 @@ function ReadStatus({ mine, status }: { mine: boolean; status: string }) {
   return iconMap[status] ?? null;
 }
 
-function Footer({ timestamp, mine, status }: { timestamp: string; mine: boolean; status: string }) {
+function AuthorIcon({ authorType }: { authorType: IMessage["authorType"] }) {
+  if (!authorType) return null;
+  const Icon = authorType === "BOT" ? Robot : User;
+  return <Icon size={15} color="#CBE71E" />;
+}
+
+function Footer({
+  timestamp,
+  mine,
+  status,
+  authorType
+}: {
+  timestamp: string;
+  mine: boolean;
+  status: string;
+  authorType: IMessage["authorType"];
+}) {
   return (
     <div className="flex items-center justify-end gap-1 mt-1">
+      {mine && <AuthorIcon authorType={authorType} />}
       <div className="text-[11px] text-[#9c9c9c]">{formatTime(timestamp)}</div>
       <ReadStatus mine={mine} status={status} />
     </div>
@@ -122,7 +141,9 @@ export default function BubbleMessage({
   onMediaLoad
 }: BubbleMessageProps) {
   const mine = m.direction === "OUTBOUND";
-  const footer = <Footer timestamp={m.timestamp} mine={mine} status={m.status} />;
+  const footer = (
+    <Footer timestamp={m.timestamp} mine={mine} status={m.status} authorType={m.authorType} />
+  );
 
   const aditionals = m.metadata?.aditionals;
   if (aditionals?.type === "reaction" && aditionals?.reaction?.emoji) {

--- a/src/modules/chat/components/chat-footer/ChatFooter.tsx
+++ b/src/modules/chat/components/chat-footer/ChatFooter.tsx
@@ -107,7 +107,8 @@ export default function ChatFooter({
         status: "SENT",
         timestamp: new Date().toISOString(),
         mediaUrl: null,
-        metadata: {}
+        metadata: {},
+        authorType: null
       };
 
       mutate((currentData) => {

--- a/src/modules/chat/containers/chat-thread.tsx
+++ b/src/modules/chat/containers/chat-thread.tsx
@@ -128,7 +128,8 @@ export default function ChatThread({
         mediaUrl: msg.mediaUrl,
         templateName: msg.templateName ?? undefined,
         templateData: msg.templateData ?? undefined,
-        metadata: msg.metadata
+        metadata: msg.metadata,
+        authorType: msg.authorType ?? null
       };
 
       // Update the SWR cache by adding the new message only if it doesn't exist

--- a/src/modules/commerce/components/create-order-checkout/create-order-checkout.tsx
+++ b/src/modules/commerce/components/create-order-checkout/create-order-checkout.tsx
@@ -5,12 +5,7 @@ import { useRouter } from "next/navigation";
 import { AxiosError } from "axios";
 
 import { useAppStore } from "@/lib/store/store";
-import {
-  confirmOrder,
-  createDraft,
-  createOrder,
-  createOrderFromDraft
-} from "@/services/commerce/commerce";
+import { confirmOrder, createDraft, createOrder } from "@/services/commerce/commerce";
 import { OrderViewContext } from "@/modules/commerce/contexts/orderViewContext";
 import {
   IConfirmOrderData,

--- a/src/modules/commerce/components/create-order-checkout/create-order-checkout.tsx
+++ b/src/modules/commerce/components/create-order-checkout/create-order-checkout.tsx
@@ -194,7 +194,9 @@ export default function CheckoutPage() {
       },
       discount_package: selectedDiscount as IDiscountPackageAvailable,
       executive_discounts: executiveDiscounts,
-      deactivate_cross_selling: !deactivateCrossSelling
+      deactivate_cross_selling: !deactivateCrossSelling,
+      client: client,
+      bussines_untit: businessUnit
     };
 
     // El range_promotion_id es el id del rango activo
@@ -214,6 +216,7 @@ export default function CheckoutPage() {
       order_split_details: splitDetails,
       promotion_id: bonus?.id || undefined,
       nit_id: channelCode,
+      draft_id: draftInfo?.id,
       // business_unit solo se envía cuando el usuario eligió un canal
       // (client_bu[n].bu_name). Es opcional y solo aplica a marketplace.
       ...(businessUnit ? { business_unit: businessUnit } : {}),
@@ -230,24 +233,6 @@ export default function CheckoutPage() {
       }
       const payload = buildOrderPayload(isElectronic);
       const paymentSupportFile = selectedPaymentSupport[0];
-
-      if (draftInfo?.id) {
-        const response = (await createOrderFromDraft(
-          projectId,
-          client.id,
-          draftInfo.id,
-          payload,
-          showMessage,
-          paymentSupportFile
-        )) as GenericResponse<{ id_order: number }>;
-
-        if (response.status === 200) {
-          const url = `/comercio/pedidoConfirmado/${draftInfo.id}`;
-          router.prefetch(url);
-          router.push(url);
-        }
-        return;
-      }
 
       const response = await createOrder(
         projectId,

--- a/src/modules/commerce/components/create-order-checkout/order-shipment-confirm/order-shipment-confirm.tsx
+++ b/src/modules/commerce/components/create-order-checkout/order-shipment-confirm/order-shipment-confirm.tsx
@@ -803,13 +803,13 @@ export default function OrderShipmentConfirm({
 
           {/* Actions */}
           <div className="flex gap-3 pt-2 pb-1 flex-shrink-0">
-            {/* <button
+            <button
               onClick={onDraft}
               disabled={loadingDraft || loadingFinish || !!draftInfo?.id}
               className="flex-1 py-3 text-sm font-semibold bg-[#141414] text-white rounded-lg hover:bg-[#333333] transition-colors disabled:opacity-40 disabled:cursor-not-allowed"
             >
               {loadingDraft ? "Guardando…" : "Guardar borrador"}
-            </button> */}
+            </button>
             <button
               onClick={onConfirm}
               disabled={

--- a/src/modules/commerce/components/create-order-checkout/order-shipment-confirm/order-shipment-confirm.tsx
+++ b/src/modules/commerce/components/create-order-checkout/order-shipment-confirm/order-shipment-confirm.tsx
@@ -185,8 +185,27 @@ export default function OrderShipmentConfirm({
 
     const draftAddressId =
       typeof shippingInfo.id === "string" ? Number(shippingInfo.id) : shippingInfo.id;
-    const matchedAddress =
+    let matchedAddress =
       draftAddressId !== undefined ? addresses.find((a) => a.id === draftAddressId) : undefined;
+
+    // Draft carries a real (existing) address id. If it isn't among the client's
+    // fetched addresses, inject it as the first option and select it rather than
+    // treating it as a brand-new address (which would drop its id from the payload).
+    if (!matchedAddress && draftAddressId !== undefined && !Number.isNaN(draftAddressId)) {
+      const draftAddress: ICommerceAdresses = {
+        id: draftAddressId,
+        address: shippingInfo.dispatch_address || shippingInfo.address || "",
+        city: shippingInfo.city ?? "",
+        email: shippingInfo.email ?? "",
+        warehouse_id: 0,
+        warehouse: "",
+        warehouse_description: ""
+      };
+      setAddresses((prev) =>
+        prev.some((a) => a.id === draftAddressId) ? prev : [draftAddress, ...prev]
+      );
+      matchedAddress = draftAddress;
+    }
 
     const phoneRaw = shippingInfo.phone_number || singleForm.telefono || "";
     const phoneMatch = phoneRaw.match(/^(\+\d{1,3})(\d+)$/);

--- a/src/modules/commerce/components/orders-view-table/orders-view-table.tsx
+++ b/src/modules/commerce/components/orders-view-table/orders-view-table.tsx
@@ -284,7 +284,6 @@ const OrdersViewTable = ({
                 key: "verBodega",
                 label: (
                   <Button
-                    disabled={row.order_status === "Pedidos en proceso"}
                     icon={<WarningDiamond size={20} />}
                     className="buttonNoBorder"
                     onClick={() => {

--- a/src/modules/commerce/containers/create-order/create-order.tsx
+++ b/src/modules/commerce/containers/create-order/create-order.tsx
@@ -111,7 +111,6 @@ export const CreateOrderView: FC = () => {
     const fetchDiscounts = async () => {
       setSelectedDiscount(undefined);
       if (!client?.id || !selectedProject?.ID) return;
-      console.log(client);
 
       setDiscountsLoading(true);
       try {
@@ -185,9 +184,10 @@ export const CreateOrderView: FC = () => {
 
     if (order_summary.client) setClient({ ...order_summary.client });
     setShippingInfo(shipping_info);
-    // Drafts carry no channel internal_code; clear it so the checkout falls back to client id.
+    // The channel internal_code is not persisted on drafts, but the business unit is —
+    // restore it so the market re-fetch and the final order stay filtered by business unit.
     setChannelCode("");
-    setBusinessUnit("");
+    setBusinessUnit(order_summary.bussines_untit ?? "");
     setSelectedDiscount(order_summary.discount_package);
     setConfirmOrderData(order_summary);
     setExecutiveDiscounts(executive_discounts ?? []);

--- a/src/modules/commerce/containers/create-order/create-order.tsx
+++ b/src/modules/commerce/containers/create-order/create-order.tsx
@@ -111,6 +111,7 @@ export const CreateOrderView: FC = () => {
     const fetchDiscounts = async () => {
       setSelectedDiscount(undefined);
       if (!client?.id || !selectedProject?.ID) return;
+      console.log(client);
 
       setDiscountsLoading(true);
       try {
@@ -141,7 +142,11 @@ export const CreateOrderView: FC = () => {
     if (!draftInfo.client_name || !draftId || !projectId) return;
     const fetchDraft = async () => {
       const draftResponse = await getOrderDraft(projectId, draftId);
-      const productsResponse = await getProductsByClient(projectId, draftResponse.client_id);
+      const productsResponse = await getProductsByClient(
+        projectId,
+        draftResponse.order_summary?.client?.id,
+        draftResponse.order_summary.bussines_untit
+      );
       if (productsResponse.data) {
         const categoriesList: IFetchedCategories[] = productsResponse.data.map((category) => ({
           category: category.category,
@@ -176,16 +181,9 @@ export const CreateOrderView: FC = () => {
   useEffect(() => {
     if (!draftDetail || categories.length === 0) return;
 
-    const { nit_id, client_name, client_id, shipping_info, order_summary, executive_discounts } =
-      draftDetail;
+    const { shipping_info, order_summary, executive_discounts } = draftDetail;
 
-    setClient({
-      name: client_name,
-      id: client_id,
-      email: shipping_info?.email ?? "",
-      payment_type: 1,
-      nit_id: nit_id || client_id
-    });
+    if (order_summary.client) setClient({ ...order_summary.client });
     setShippingInfo(shipping_info);
     // Drafts carry no channel internal_code; clear it so the checkout falls back to client id.
     setChannelCode("");

--- a/src/modules/commerce/containers/create-order/create-order.tsx
+++ b/src/modules/commerce/containers/create-order/create-order.tsx
@@ -4,6 +4,7 @@ import { useAppStore } from "@/lib/store/store";
 import { getDiscounts, getOrderDraft, getProductsByClient } from "@/services/commerce/commerce";
 
 import { OrderViewContext } from "../../contexts/orderViewContext";
+import { buildBonusFromPromotion } from "../../utils/buildBonusFromPromotion";
 
 import SearchClient from "../../components/create-order-search-client/create-order-search-client";
 import CreateOrderMarket from "../../components/create-order-market";
@@ -191,6 +192,10 @@ export const CreateOrderView: FC = () => {
     setSelectedDiscount(order_summary.discount_package);
     setConfirmOrderData(order_summary);
     setExecutiveDiscounts(executive_discounts ?? []);
+    // Restore the promotion/bonificados from the draft. order_summary.promotion +
+    // other_bonificated_products are the only record of the picks (the draft
+    // response has no order_split_details), so rebuild `bonus` straight from them.
+    setBonus(buildBonusFromPromotion(order_summary.promotion, order_summary.other_bonificated_products));
 
     const grouped =
       order_summary.products?.reduce<ISelectedCategories[]>((acc, p) => {

--- a/src/modules/commerce/containers/create-order/create-order.tsx
+++ b/src/modules/commerce/containers/create-order/create-order.tsx
@@ -185,17 +185,16 @@ export const CreateOrderView: FC = () => {
 
     if (order_summary.client) setClient({ ...order_summary.client });
     setShippingInfo(shipping_info);
-    // The channel internal_code is not persisted on drafts, but the business unit is —
-    // restore it so the market re-fetch and the final order stay filtered by business unit.
-    setChannelCode("");
+    setChannelCode(order_summary.client?.nit_id || draftDetail.nit_id || "");
+    setChannelName(order_summary.bussines_untit ?? "");
     setBusinessUnit(order_summary.bussines_untit ?? "");
     setSelectedDiscount(order_summary.discount_package);
     setConfirmOrderData(order_summary);
     setExecutiveDiscounts(executive_discounts ?? []);
-    // Restore the promotion/bonificados from the draft. order_summary.promotion +
-    // other_bonificated_products are the only record of the picks (the draft
-    // response has no order_split_details), so rebuild `bonus` straight from them.
-    setBonus(buildBonusFromPromotion(order_summary.promotion, order_summary.other_bonificated_products));
+
+    setBonus(
+      buildBonusFromPromotion(order_summary.promotion, order_summary.other_bonificated_products)
+    );
 
     const grouped =
       order_summary.products?.reduce<ISelectedCategories[]>((acc, p) => {

--- a/src/modules/commerce/containers/orders-view/orders-view.tsx
+++ b/src/modules/commerce/containers/orders-view/orders-view.tsx
@@ -47,6 +47,7 @@ export const OrdersView: FC = () => {
   const [isLoadingPagination, setIsLoadingPagination] = useState(false);
 
   const { ID: projectId } = useAppStore((state) => state.selectedProject);
+  const setDraftInfo = useAppStore((state) => state.setDraftInfo);
 
   // Usar el nuevo hook useOrders
   const { ordersByCategory, isLoading, mutate } = useOrders({
@@ -145,7 +146,13 @@ export const OrdersView: FC = () => {
               {isMobile || isTablet ? <PresentationChart size={24} /> : "Dashboard"}
             </Button>
           </Link>
-          <Link href="/comercio/pedido" className={styles.ctaButton}>
+          <Link
+            href="/comercio/pedido"
+            className={styles.ctaButton}
+            // Empezar una orden nueva: limpiar el borrador previo (persistido) para
+            // que CreateOrderView no cargue el último draft abierto.
+            onClick={() => setDraftInfo({ id: 0, client_name: undefined })}
+          >
             <PrincipalButton
               className={styles.ctaButton}
               customStyles={{ padding: isMobile ? "7px 12px" : undefined }}

--- a/src/modules/commerce/utils/buildBonusFromPromotion.ts
+++ b/src/modules/commerce/utils/buildBonusFromPromotion.ts
@@ -1,0 +1,37 @@
+import { IBonus, IOtherBonificatedProduct, IPromotion } from "@/types/commerce/ICommerce";
+
+/**
+ * Reconstruye el estado `IBonus` desde el `promotion` guardado en un borrador.
+ * Contraparte de `handleConfirm` (modal-bonus): mapea
+ * `active_range.gift_options[].items` (grupos fixed/pool) a `bonusOptions[].cards`,
+ * tomando la cantidad elegida del propio `qty` de cada item del borrador
+ * (única fuente de las selecciones en la respuesta del draft). Descarta items
+ * con qty 0.
+ */
+export const buildBonusFromPromotion = (
+  promotion?: IPromotion,
+  otherBonificatedProducts?: IOtherBonificatedProduct[]
+): IBonus | undefined => {
+  if (!promotion) return undefined;
+
+  const cards = (promotion.active_range?.gift_options ?? []).flatMap((option) =>
+    option.items
+      .map((group) => ({
+        fixed: group.fixed,
+        items: group.items
+          .map(({ image: _img, ...rest }) => rest)
+          .filter((item) => item.qty > 0)
+      }))
+      .filter((card) => card.items.length > 0)
+  );
+
+  const otherBonificated = (otherBonificatedProducts ?? [])
+    .map(({ image: _img, max_selection_qty: _max, ...rest }) => rest)
+    .filter((item) => item.qty > 0);
+
+  return {
+    id: promotion.promotion_id,
+    bonusOptions: cards.length > 0 ? [{ cards }] : [],
+    otherBonificated
+  };
+};

--- a/src/types/chat/IChat.ts
+++ b/src/types/chat/IChat.ts
@@ -62,6 +62,7 @@ export interface IMessage {
       email: string;
     };
   };
+  authorType: "BOT" | "HUMAN_AGENT" | "CUSTOMER" | null;
 }
 
 interface IPagination {
@@ -124,11 +125,24 @@ export interface IMessageSocket {
   updatedAt: string;
   customer: ICustomerSocket;
   ticket: ITicketSocket;
+  authorType: "BOT" | "HUMAN_AGENT" | "CUSTOMER" | null;
+}
+
+export interface ITicketEvent {
+  id: string;
+  ticketId: string;
+  type: string;
+  actor: string;
+  reason: string;
+  summary: string;
+  metadata: any;
+  createdAt: string;
 }
 
 export interface IChatData {
   messages: IMessage[];
   pagination: IPagination;
+  events?: ITicketEvent[];
 }
 
 export interface IWhatsAppTemplate {

--- a/src/types/commerce/ICommerce.ts
+++ b/src/types/commerce/ICommerce.ts
@@ -1,3 +1,5 @@
+import { IOrderViewContext } from "@/app/comercio/cetaphil/page";
+
 export interface IEcommerceClient {
   client_id: string;
   client_name: string;
@@ -247,6 +249,8 @@ export interface IOrderConfirmedResponse {
   insufficientStockProducts: string[];
   promotion?: IPromotion;
   other_bonificated_products?: IOtherBonificatedProduct[];
+  client: IOrderViewContext["client"];
+  bussines_untit: string;
 }
 
 export interface IOrderSummaryPayload extends Omit<IOrderConfirmedResponse, "discount_package"> {
@@ -306,6 +310,7 @@ export interface ICreateOrderData {
    * pertenecen a un rango de la promoción.
    */
   range_promotion_id?: number;
+  draft_id: number | undefined;
 }
 
 export interface ISucessCreateOrder {


### PR DESCRIPTION
This pull request introduces several improvements and bug fixes across the chat and commerce modules. The most significant changes include enhancements to the order draft and checkout flow, improved handling of addresses in order drafts, and UI/UX improvements in the chat message bubble component. Additionally, several types and utility functions have been updated or added to better support these features.

**Commerce Module Improvements**

* Enhanced order draft and checkout flow:
  - The order creation payload now includes `client` and `bussines_untit` fields, and optionally includes `draft_id` for draft-based orders. The logic for creating orders from drafts has been streamlined by removing the separate `createOrderFromDraft` call, and the payload is now more consistent. [[1]](diffhunk://#diff-946724022fb5b4dbf7742f549668679cba81a28440e35673a4b2b0ff7b8eb7bbL197-R194) [[2]](diffhunk://#diff-946724022fb5b4dbf7742f549668679cba81a28440e35673a4b2b0ff7b8eb7bbR214) [[3]](diffhunk://#diff-946724022fb5b4dbf7742f549668679cba81a28440e35673a4b2b0ff7b8eb7bbL234-L251)
  - When loading a draft, the client, business unit, and related fields are now set from the draft's `order_summary`, improving consistency and reducing errors. [[1]](diffhunk://#diff-68e2136af859399549bd1836fa204041ca4ace9fa42a8726f239748624768f4bL144-R149) [[2]](diffhunk://#diff-68e2136af859399549bd1836fa204041ca4ace9fa42a8726f239748624768f4bL179-R198)
  - A new utility, `buildBonusFromPromotion`, reconstructs the bonus state from a saved promotion in a draft, ensuring accurate bonus data restoration. [[1]](diffhunk://#diff-d8f67a7b81b26b0452277ac0e64db96308cb6a68f3b76dbbb3977d4f537af266R1-R37) [[2]](diffhunk://#diff-68e2136af859399549bd1836fa204041ca4ace9fa42a8726f239748624768f4bL179-R198)
  - The draft info is now cleared when starting a new order to prevent unwanted draft restoration. [[1]](diffhunk://#diff-435ddfd432b62bc77122902fb223be70cb6fa5862bc24a77aa2e25c1a4b518e3R50) [[2]](diffhunk://#diff-435ddfd432b62bc77122902fb223be70cb6fa5862bc24a77aa2e25c1a4b518e3L148-R155)
  - Types have been updated to reflect the new fields in order responses and payloads, including `client`, `bussines_untit`, and `draft_id`. [[1]](diffhunk://#diff-9f81dfc02cbe3385da8783726a173ee0bc277725cacbbc0a1b64cd54323a7e05R252-R253) [[2]](diffhunk://#diff-9f81dfc02cbe3385da8783726a173ee0bc277725cacbbc0a1b64cd54323a7e05R313)

* Improved handling of addresses in order drafts:
  - When a draft references an address ID not present in the current address list, that address is now injected into the options, ensuring it is selectable and not lost in the order payload.

* UI/UX and minor fixes:
  - The "Guardar borrador" (Save draft) button is now re-enabled and visible in the order shipment confirmation UI.
  - The "verBodega" button in the orders view table is no longer disabled for orders in process, ensuring consistent access.
  - The client group search query parameter has been renamed from `searchQuery` to `name` for clarity and backend compatibility.
  - Unused imports have been removed from the order checkout component.

**Chat Module Enhancements**

* Improved message bubble UI:
  - Added author icons (bot/user) to chat message bubbles, displaying the author type for outbound messages. [[1]](diffhunk://#diff-7b2346a87129be3dc5d72019ef885309e9995afa4ce76902f501540e06f5434dR7-R8) [[2]](diffhunk://#diff-7b2346a87129be3dc5d72019ef885309e9995afa4ce76902f501540e06f5434dL78-R99) [[3]](diffhunk://#diff-7b2346a87129be3dc5d72019ef885309e9995afa4ce76902f501540e06f5434dL125-R146)
  - The `IMessage` and `IMessageSocket` types now include an `authorType` field to support this feature. [[1]](diffhunk://#diff-8760d261c17d3fd4e99aa3d6da11b092ea512bb9241571bd95c717d97542d1e7R65) [[2]](diffhunk://#diff-8760d261c17d3fd4e99aa3d6da11b092ea512bb9241571bd95c717d97542d1e7R128-R145)
  - The chat footer and thread components have been updated to correctly propagate and handle the `authorType` field. [[1]](diffhunk://#diff-523ec0ba64cde7f3fa62db4b79cc59b75b49ea394230730a162dcdc1ded01a4cL110-R111) [[2]](diffhunk://#diff-bccbb7fd917767b9b9e81f2c695d389b488155b4f34a1212bd95b207e200c1c5L131-R132)
  - The `IChatData` type now optionally includes ticket events for future extensibility.

**Code Quality and Maintenance**

* Added missing imports and improved utility code organization, such as importing and using `buildBonusFromPromotion` in the order creation flow.

---

**Commerce: Order Drafts & Checkout**
- Enhanced order creation payload to include `client`, `bussines_untit`, and `draft_id`, and streamlined draft-based order creation logic. [[1]](diffhunk://#diff-946724022fb5b4dbf7742f549668679cba81a28440e35673a4b2b0ff7b8eb7bbL197-R194) [[2]](diffhunk://#diff-946724022fb5b4dbf7742f549668679cba81a28440e35673a4b2b0ff7b8eb7bbR214) [[3]](diffhunk://#diff-946724022fb5b4dbf7742f549668679cba81a28440e35673a4b2b0ff7b8eb7bbL234-L251) [[4]](diffhunk://#diff-9f81dfc02cbe3385da8783726a173ee0bc277725cacbbc0a1b64cd54323a7e05R252-R253) [[5]](diffhunk://#diff-9f81dfc02cbe3385da8783726a173ee0bc277725cacbbc0a1b64cd54323a7e05R313)
- Improved draft loading logic to set client and business unit from `order_summary`, and clear draft info when starting a new order. [[1]](diffhunk://#diff-68e2136af859399549bd1836fa204041ca4ace9fa42a8726f239748624768f4bL144-R149) [[2]](diffhunk://#diff-68e2136af859399549bd1836fa204041ca4ace9fa42a8726f239748624768f4bL179-R198) [[3]](diffhunk://#diff-435ddfd432b62bc77122902fb223be70cb6fa5862bc24a77aa2e25c1a4b518e3R50) [[4]](diffhunk://#diff-435ddfd432b62bc77122902fb223be70cb6fa5862bc24a77aa2e25c1a4b518e3L148-R155)
- Added `buildBonusFromPromotion` utility to reconstruct bonus state from a promotion in a draft. [[1]](diffhunk://#diff-d8f67a7b81b26b0452277ac0e64db96308cb6a68f3b76dbbb3977d4f537af266R1-R37) [[2]](diffhunk://#diff-68e2136af859399549bd1836fa204041ca4ace9fa42a8726f239748624768f4bL179-R198)

**Commerce: Addresses & UI**
- Injected addresses from drafts into the address list if not present, preventing loss of address data.
- Re-enabled "Guardar borrador" button in order shipment confirmation UI.
- Fixed client group search parameter and removed unused imports. [[1]](diffhunk://#diff-7c2d282bb8716479656f2dbc7950156f1c834fb1e305483ec32dcc0fb9b4bd30L36-R36) [[2]](diffhunk://#diff-946724022fb5b4dbf7742f549668679cba81a28440e35673a4b2b0ff7b8eb7bbL8-R8)
- Ensured "verBodega" button is always enabled in orders view.

**Chat: Author Type & UI**
- Added author icons to chat message bubbles and updated types and components to support `authorType`. [[1]](diffhunk://#diff-7b2346a87129be3dc5d72019ef885309e9995afa4ce76902f501540e06f5434dR7-R8) [[2]](diffhunk://#diff-7b2346a87129be3dc5d72019ef885309e9995afa4ce76902f501540e06f5434dL78-R99) [[3]](diffhunk://#diff-7b2346a87129be3dc5d72019ef885309e9995afa4ce76902f501540e06f5434dL125-R146) [[4]](diffhunk://#diff-523ec0ba64cde7f3fa62db4b79cc59b75b49ea394230730a162dcdc1ded01a4cL110-R111) [[5]](diffhunk://#diff-bccbb7fd917767b9b9e81f2c695d389b488155b4f34a1212bd95b207e200c1c5L131-R132) [[6]](diffhunk://#diff-8760d261c17d3fd4e99aa3d6da11b092ea512bb9241571bd95c717d97542d1e7R65) [[7]](diffhunk://#diff-8760d261c17d3fd4e99aa3d6da11b092ea512bb9241571bd95c717d97542d1e7R128-R145)
- Extended `IChatData` with optional ticket events for future features.

**Code Quality**
- Added missing imports and improved utility code organization.