### PR TITLE
Fix business_unit field name and types

### DIFF
--- a/src/modules/commerce/components/create-order-checkout/create-order-checkout.tsx
+++ b/src/modules/commerce/components/create-order-checkout/create-order-checkout.tsx
@@ -99,6 +99,7 @@ export default function CheckoutPage() {
         discount_package: selectedDiscount,
         order_summary: products,
         executive_discounts: executiveDiscounts,
+        business_unit: businessUnit,
         deactivate_cross_selling: !deactivateCrossSelling,
         ...(bonus?.id !== undefined && { promotion_id: bonus.id }),
         promotion_applyed: promotionApplyed
@@ -200,7 +201,7 @@ export default function CheckoutPage() {
       executive_discounts: executiveDiscounts,
       deactivate_cross_selling: !deactivateCrossSelling,
       client: client,
-      bussines_untit: businessUnit
+      business_unit: businessUnit
     };
 
     // El range_promotion_id es el id del rango activo

--- a/src/modules/commerce/containers/create-order/create-order.tsx
+++ b/src/modules/commerce/containers/create-order/create-order.tsx
@@ -145,7 +145,7 @@ export const CreateOrderView: FC = () => {
       const productsResponse = await getProductsByClient(
         projectId,
         draftResponse.order_summary?.client?.id,
-        draftResponse.order_summary.bussines_untit
+        draftResponse.order_summary.business_unit
       );
       if (productsResponse.data) {
         const categoriesList: IFetchedCategories[] = productsResponse.data.map((category) => ({
@@ -186,8 +186,8 @@ export const CreateOrderView: FC = () => {
     if (order_summary.client) setClient({ ...order_summary.client });
     setShippingInfo(shipping_info);
     setChannelCode(order_summary.client?.nit_id || draftDetail.nit_id || "");
-    setChannelName(order_summary.bussines_untit ?? "");
-    setBusinessUnit(order_summary.bussines_untit ?? "");
+    setChannelName(order_summary.business_unit ?? "");
+    setBusinessUnit(order_summary.business_unit ?? "");
     setSelectedDiscount(order_summary.discount_package);
     setConfirmOrderData(order_summary);
     setExecutiveDiscounts(executive_discounts ?? []);

--- a/src/types/commerce/ICommerce.ts
+++ b/src/types/commerce/ICommerce.ts
@@ -79,6 +79,7 @@ export interface IConfirmOrderData {
     product_sku: string;
     quantity: number;
   }[];
+  business_unit: string;
   executive_discounts: IExecutiveDiscount[];
   deactivate_cross_selling: boolean;
   promotion_id?: number;
@@ -250,7 +251,7 @@ export interface IOrderConfirmedResponse {
   promotion?: IPromotion;
   other_bonificated_products?: IOtherBonificatedProduct[];
   client: IOrderViewContext["client"];
-  bussines_untit: string;
+  business_unit: string;
 }
 
 export interface IOrderSummaryPayload extends Omit<IOrderConfirmedResponse, "discount_package"> {


### PR DESCRIPTION
Corrected misspelled bussines_untit -> business_unit across commerce modules. Added business_unit to IConfirmOrderData, included it in checkout payload, and updated usages in create-order container (product fetch, channelName/businessUnit setters). These changes ensure consistent field naming and prevent runtime bugs when building order payloads and fetching products.

Files changed: src/modules/commerce/components/create-order-checkout/create-order-checkout.tsx, src/modules/commerce/containers/create-order/create-order.tsx, src/types/commerce/ICommerce.ts