### PR TITLE
Fix/prefill comments when channel institucional

### DIFF
--- a/src/modules/commerce/components/create-order-checkout/order-shipment-confirm/order-shipment-confirm.tsx
+++ b/src/modules/commerce/components/create-order-checkout/order-shipment-confirm/order-shipment-confirm.tsx
@@ -19,6 +19,7 @@ import { formatNumber } from "@/utils/utils";
 import ModalShippingInfo from "../modal-shipping-info";
 import {
   NEW_ADDRESS_OPTION,
+  getDefaultCommentForBusinessUnit,
   isValidEmail,
   isValidPhone,
   phoneErrorMessage,
@@ -78,7 +79,8 @@ export default function OrderShipmentConfirm({
     shippingInfo,
     selectedDiscount,
     bonus,
-    channelCode
+    channelCode,
+    businessUnit
   } = useContext(OrderViewContext);
   const { callingCodeOptions, isLoading: isLoadingOptions } = useContactModalOptions();
   const draftInfo = useAppStore((state) => state.draftInfo);
@@ -201,11 +203,11 @@ export default function OrderShipmentConfirm({
       email: shippingInfo.email ?? "",
       indicativo,
       telefono,
-      observaciones: shippingInfo.comments ?? ""
+      observaciones: shippingInfo.comments || getDefaultCommentForBusinessUnit(businessUnit)
     });
 
     didHydrateFromDraftRef.current = true;
-  }, [shippingInfo, addresses, addressesFetched]);
+  }, [shippingInfo, addresses, addressesFetched, businessUnit]);
 
   // Auto-fill city/dispatch_address from selected address (single mode)
   useEffect(() => {
@@ -247,7 +249,7 @@ export default function OrderShipmentConfirm({
     email: client?.email ?? "",
     indicativo: "+57",
     telefono: "",
-    observaciones: "",
+    observaciones: getDefaultCommentForBusinessUnit(businessUnit),
     cantidades: Object.fromEntries(discountItems.map((i) => [i.item_uuid || i.product_sku, 0])),
     bonusCantidades: Object.fromEntries(bonusItems.map((i) => [i.product_sku, 0])),
     otherBonusCantidades: Object.fromEntries(otherBonusItems.map((i) => [i.product_sku, 0]))

--- a/src/modules/commerce/components/create-order-product/create-order-product.tsx
+++ b/src/modules/commerce/components/create-order-product/create-order-product.tsx
@@ -49,7 +49,7 @@ const CreateOrderProduct: FC<CreateOrderProductProps> = ({ product, categoryName
       <hr className={styles.separator} />
       <h4 className={styles.name}>
         {product.name}
-        {product.EAN?.trim() && <span className={styles.sku}>SKU: {product.EAN}</span>}
+        {product.EAN?.trim() && <span className={styles.sku}>EAN: {product.EAN}</span>}
         {!product.stock && (
           <SimpleTag
             text="Stock insuficiente"

--- a/src/modules/commerce/utils/constants/checkout.ts
+++ b/src/modules/commerce/utils/constants/checkout.ts
@@ -23,6 +23,13 @@ export const sanitizeComment = (value: string) =>
     .replace(/[\r\n]+/g, " ") // enters -> espacio
     .replace(/[\u{10000}-\u{10FFFF}]/gu, ""); // emojis / 4-byte chars -> fuera
 
+export const INSTITUCIONAL_DEFAULT_COMMENT = "PEDIDO INSTITUCIONAL";
+
+// Comentario de envío por defecto según la unidad de negocio (bu_name del canal).
+// Para el canal "Institucional" se prellena con "PEDIDO INSTITUCIONAL".
+export const getDefaultCommentForBusinessUnit = (businessUnit?: string): string =>
+  businessUnit?.trim().toLowerCase() === "institucional" ? INSTITUCIONAL_DEFAULT_COMMENT : "";
+
 export const phoneErrorMessage = (indicativo: string) =>
   indicativo === "+57"
     ? "Teléfono debe tener 10 dígitos"


### PR DESCRIPTION
This pull request updates the order shipment confirmation flow to automatically prefill the shipping comments field with a default value based on the selected business unit, specifically handling the "Institucional" channel. It also makes a minor label correction in the product display. The most important changes are:

**Order shipment comment autofill improvements:**

* Added a utility function `getDefaultCommentForBusinessUnit` in `checkout.ts` to return a default comment ("PEDIDO INSTITUCIONAL") when the business unit is "Institucional", and used it to prefill the `observaciones` field in the order shipment confirmation form. [[1]](diffhunk://#diff-6362d0289ff5e84cfe2211afc61e5c412feeb4b76c39910b45fd18af78a1092cR26-R32) [[2]](diffhunk://#diff-b4b4f1944cce9e8aa8c492a8f2f229c936efa65b0f39a3a91defef11e8fe7911R23)
* Updated the order shipment confirmation logic in `order-shipment-confirm.tsx` to use the default comment when no other comment is provided, both when hydrating from draft and when initializing a new order. [[1]](diffhunk://#diff-b4b4f1944cce9e8aa8c492a8f2f229c936efa65b0f39a3a91defef11e8fe7911L236-R242) [[2]](diffhunk://#diff-b4b4f1944cce9e8aa8c492a8f2f229c936efa65b0f39a3a91defef11e8fe7911L286-R288)
* Passed the `businessUnit` from context to the order shipment confirmation component to enable the above logic.

**UI/Label corrections:**

* Changed the label from "SKU" to "EAN" when displaying the product EAN in `create-order-product.tsx` for clarity and correctness.