### PR TITLE
Hot fix/UI revenue tracking cards and filter names

### DIFF
--- a/src/modules/commerce/components/revenue-tracking/filters-bar/filters-bar.tsx
+++ b/src/modules/commerce/components/revenue-tracking/filters-bar/filters-bar.tsx
@@ -32,8 +32,8 @@ const ENTITY_CATEGORIES: { key: string; label: string; entity: string }[] = [
   { key: "sellerIds", label: "Vendedor", entity: "vendedor" },
   { key: "clientIds", label: "Cliente", entity: "cliente" },
   { key: "cityIds", label: "Ciudad", entity: "ciudad" },
-  { key: "lineIds", label: "Línea de negocio", entity: "linea" },
-  { key: "channelIds", label: "Canal de venta", entity: "canal" }
+  { key: "lineIds", label: "Categoría", entity: "categoria" },
+  { key: "channelIds", label: "Unidad de negocio", entity: "unidad_de_negocio" }
 ];
 
 const ENTITY_BY_KEY: Record<string, string> = Object.fromEntries(

--- a/src/modules/commerce/components/revenue-tracking/filters-bar/filters-bar.tsx
+++ b/src/modules/commerce/components/revenue-tracking/filters-bar/filters-bar.tsx
@@ -32,8 +32,8 @@ const ENTITY_CATEGORIES: { key: string; label: string; entity: string }[] = [
   { key: "sellerIds", label: "Vendedor", entity: "vendedor" },
   { key: "clientIds", label: "Cliente", entity: "cliente" },
   { key: "cityIds", label: "Ciudad", entity: "ciudad" },
-  { key: "lineIds", label: "Categoría", entity: "categoria" },
-  { key: "channelIds", label: "Unidad de negocio", entity: "unidad_de_negocio" }
+  { key: "lineIds", label: "Categoría", entity: "linea" },
+  { key: "channelIds", label: "Unidad de negocio", entity: "canal" }
 ];
 
 const ENTITY_BY_KEY: Record<string, string> = Object.fromEntries(

--- a/src/modules/commerce/components/revenue-tracking/stat-cards/stat-cards.tsx
+++ b/src/modules/commerce/components/revenue-tracking/stat-cards/stat-cards.tsx
@@ -30,18 +30,25 @@ export default function StatCards() {
     badge?: string;
   }> = [
     {
-      title: "Total Revenue",
+      title: "Total invoiced",
       value: data ? formatCurrencyMoney(data.total_revenue.value) : PLACEHOLDER,
       subtitle: "vs Goal to date",
       icon: DollarSign,
       ...metricTrend(data?.total_revenue)
     },
     {
-      title: "Avg Ticket",
-      value: data ? formatCurrencyMoney(data.avg_ticket.value) : PLACEHOLDER,
-      subtitle: "vs Goal to date",
-      icon: Tag,
-      ...metricTrend(data?.avg_ticket)
+      title: "Orders in process",
+      value: data ? formatCurrencyMoney(data.orders_in_process.value) : PLACEHOLDER,
+      subtitle: "En proceso de fact.",
+      badge: data ? `${data.orders_in_process.count} orders` : undefined
+    },
+    {
+      title: "Total expected",
+      value: data
+        ? formatCurrencyMoney(data.orders_in_process.value + data.total_revenue.value)
+        : PLACEHOLDER,
+      subtitle: "",
+      icon: DollarSign
     },
     {
       title: "Total Sales",
@@ -51,17 +58,11 @@ export default function StatCards() {
       ...metricTrend(data?.total_orders)
     },
     {
-      title: "Unique Customers",
-      value: data ? formatNumber(data.unique_customers.value) : PLACEHOLDER,
+      title: "Avg Ticket",
+      value: data ? formatCurrencyMoney(data.avg_ticket.value) : PLACEHOLDER,
       subtitle: "vs Goal to date",
-      icon: Package,
-      ...metricTrend(data?.unique_customers)
-    },
-    {
-      title: "Orders in process",
-      value: data ? formatCurrencyMoney(data.orders_in_process.value) : PLACEHOLDER,
-      subtitle: "En proceso de fact.",
-      badge: data ? `${data.orders_in_process.count} Unid` : undefined
+      icon: Tag,
+      ...metricTrend(data?.avg_ticket)
     }
   ];
 
@@ -98,8 +99,8 @@ export default function StatCards() {
                     stat.isAlert
                       ? "bg-[#FF6B00]/20 text-[#FF6B00] dark:text-[#FF6B00]"
                       : stat.isPositive
-                      ? "bg-emerald-500/10 text-emerald-600 dark:text-emerald-400"
-                      : "bg-rose-500/10 text-rose-600 dark:text-rose-400"
+                        ? "bg-emerald-500/10 text-emerald-600 dark:text-emerald-400"
+                        : "bg-rose-500/10 text-rose-600 dark:text-rose-400"
                   }`}
                 >
                   {stat.isAlert ? null : stat.isPositive ? (
@@ -110,7 +111,7 @@ export default function StatCards() {
                   {stat.trend}
                 </div>
               )}
-              <span className="text-sm text-muted-foreground font-medium opacity-80 whitespace-nowrap">
+              <span className="text-sm text-muted-foreground font-medium opacity-80 whitespace-nowrap h-5">
                 {stat.subtitle}
               </span>
             </div>

--- a/src/modules/commerce/components/revenue-tracking/theme-toggle/theme-toggle.tsx
+++ b/src/modules/commerce/components/revenue-tracking/theme-toggle/theme-toggle.tsx
@@ -13,7 +13,7 @@ const THEME_OPTIONS: { key: "light" | "dark" | "system"; label: string; Icon: ty
 ];
 
 export default function ThemeToggle() {
-  const { theme, setTheme } = useTheme();
+  const { theme, setTheme, resolvedTheme } = useTheme();
 
   const TriggerIcon = THEME_OPTIONS.find((o) => o.key === theme)?.Icon ?? Sun;
 
@@ -21,7 +21,15 @@ export default function ThemeToggle() {
     key,
     icon: <Icon className="w-4 h-4" />,
     label: (
-      <span className={theme === key ? "text-primary font-semibold" : "text-foreground"}>
+      <span
+        className={
+          theme === key
+            ? "text-primary font-semibold"
+            : resolvedTheme === "dark"
+              ? "text-white"
+              : "text-foreground"
+        }
+      >
         {label}
       </span>
     ),


### PR DESCRIPTION
This pull request updates the revenue tracking UI to improve clarity and theming, focusing on stat card metrics and filter/category labels. The most important changes are grouped below:

**Revenue Stat Cards Updates:**

* Renamed and reorganized stat cards in `stat-cards.tsx`: "Total Revenue" is now "Total invoiced", "Avg Ticket" is moved, "Orders in process" and "Total expected" are added, and "Unique Customers" is removed. Card subtitles and badges are also updated for clarity. [[1]](diffhunk://#diff-3d2e9068bb85bcb70a036829161d8f81a0cda420ae8a62f5a0786e2d10038e35L33-R51) [[2]](diffhunk://#diff-3d2e9068bb85bcb70a036829161d8f81a0cda420ae8a62f5a0786e2d10038e35L54-R65)
* Adjusted subtitle styling in stat cards to ensure consistent height and alignment, improving UI appearance.

**Filter and Category Label Updates:**

* Updated labels in `filters-bar.tsx`: "Línea de negocio" is now "Categoría" and "Canal de venta" is now "Unidad de negocio" for improved terminology.

**Theme Toggle Improvements:**

* Enhanced theme toggle in `theme-toggle.tsx` to use `resolvedTheme` for better color contrast and correct highlighting of the selected theme option, especially in dark mode.