### PR TITLE
refactor(revenue-tracking): reorder default tab and filters, simplify…

### DIFF
--- a/src/modules/commerce/components/revenue-tracking/dashboard-bottom-section/dashboard-bottom-section.tsx
+++ b/src/modules/commerce/components/revenue-tracking/dashboard-bottom-section/dashboard-bottom-section.tsx
@@ -10,14 +10,13 @@ import DashboardClientsDetailsTable from "@/modules/commerce/components/revenue-
 type TabType = "gross-to-net" | "regional-vendedor" | "detalles-cliente";
 
 const tabs = [
-  { id: "gross-to-net", label: "Bruto a neto" },
-  { id: "regional-vendedor", label: "Regional/Vendedor" },
-  { id: "detalles-cliente", label: "Detalles cliente" }
+  { id: "detalles-cliente", label: "Detalles cliente" },
+  { id: "regional-vendedor", label: "Regional/Vendedor" }
 ];
 
 export function DashboardBottomSection() {
   const isMobile = useIsMobile();
-  const [activeTab, setActiveTab] = useState<TabType>("regional-vendedor");
+  const [activeTab, setActiveTab] = useState<TabType>("detalles-cliente");
   const [isMenuMobileOpen, setIsMenuMobileOpen] = useState(false);
 
   const activeTabLabel = tabs.find((t) => t.id === activeTab)?.label;

--- a/src/modules/commerce/components/revenue-tracking/filters-bar/filters-bar.tsx
+++ b/src/modules/commerce/components/revenue-tracking/filters-bar/filters-bar.tsx
@@ -28,12 +28,12 @@ const FRECUENCIA_OPTIONS: FilterOptionItem[] = [
 ];
 
 const ENTITY_CATEGORIES: { key: string; label: string; entity: string }[] = [
+  { key: "channelIds", label: "Unidad de negocio", entity: "canal" },
   { key: "productIds", label: "Producto", entity: "producto" },
   { key: "sellerIds", label: "Vendedor", entity: "vendedor" },
   { key: "clientIds", label: "Cliente", entity: "cliente" },
   { key: "cityIds", label: "Ciudad", entity: "ciudad" },
-  { key: "lineIds", label: "Categoría", entity: "linea" },
-  { key: "channelIds", label: "Unidad de negocio", entity: "canal" }
+  { key: "lineIds", label: "Categoría", entity: "linea" }
 ];
 
 const ENTITY_BY_KEY: Record<string, string> = Object.fromEntries(
@@ -67,6 +67,13 @@ export default function FiltersBar() {
       .catch(() => setStatusByEntity((prev) => ({ ...prev, [entity]: "error" })));
   };
 
+  const toEntityCategory = ({ key, label, entity }: (typeof ENTITY_CATEGORIES)[number]) => ({
+    key,
+    label,
+    options: optionsByEntity[entity] ?? [],
+    status: statusByEntity[entity]
+  });
+
   const categories: FilterCategoryConfig[] = [
     {
       key: "fecha",
@@ -90,13 +97,9 @@ export default function FiltersBar() {
           </div>
         ) : null
     },
+    toEntityCategory(ENTITY_CATEGORIES[0]),
     { key: "frecuencia", label: "Frecuencia", selectMode: "single", options: FRECUENCIA_OPTIONS },
-    ...ENTITY_CATEGORIES.map(({ key, label, entity }) => ({
-      key,
-      label,
-      options: optionsByEntity[entity] ?? [],
-      status: statusByEntity[entity]
-    }))
+    ...ENTITY_CATEGORIES.slice(1).map(toEntityCategory)
   ];
 
   return (

--- a/src/modules/commerce/components/revenue-tracking/stat-cards/stat-cards.tsx
+++ b/src/modules/commerce/components/revenue-tracking/stat-cards/stat-cards.tsx
@@ -22,7 +22,7 @@ export default function StatCards() {
   const stats: Array<{
     title: string;
     value: string;
-    subtitle: string;
+    subtitle?: string;
     trend?: string;
     isPositive?: boolean;
     isAlert?: boolean;
@@ -32,35 +32,30 @@ export default function StatCards() {
     {
       title: "Total invoiced",
       value: data ? formatCurrencyMoney(data.total_revenue.value) : PLACEHOLDER,
-      subtitle: "vs Goal to date",
       icon: DollarSign,
       ...metricTrend(data?.total_revenue)
     },
     {
       title: "Orders in process",
       value: data ? formatCurrencyMoney(data.orders_in_process.value) : PLACEHOLDER,
-      subtitle: "En proceso de fact.",
       badge: data ? `${data.orders_in_process.count} orders` : undefined
     },
     {
-      title: "Total expected",
+      title: "Revenue expected",
       value: data
         ? formatCurrencyMoney(data.orders_in_process.value + data.total_revenue.value)
         : PLACEHOLDER,
-      subtitle: "",
       icon: DollarSign
     },
     {
-      title: "Total Sales",
+      title: "Total Orders",
       value: data ? formatNumber(data.total_orders.value) : PLACEHOLDER,
-      subtitle: "vs Goal to date",
       icon: Package,
       ...metricTrend(data?.total_orders)
     },
     {
-      title: "Avg Ticket",
+      title: "Avg. Order Value",
       value: data ? formatCurrencyMoney(data.avg_ticket.value) : PLACEHOLDER,
-      subtitle: "vs Goal to date",
       icon: Tag,
       ...metricTrend(data?.avg_ticket)
     }
@@ -111,9 +106,6 @@ export default function StatCards() {
                   {stat.trend}
                 </div>
               )}
-              <span className="text-sm text-muted-foreground font-medium opacity-80 whitespace-nowrap h-5">
-                {stat.subtitle}
-              </span>
             </div>
           </div>
         </div>


### PR DESCRIPTION
… stat cards

- Change default active tab to "detalles-cliente" from "regional-vendedor"
- Reorder ENTITY_CATEGORIES with channelIds first
- Refactor filter category mapping with toEntityCategory helper
- Make subtitle optional in stat cards and remove unnecessary subtitles
- Rename stat titles: "Total expected" to "Revenue expected", "Total Sales" to "Total Orders"

This pull request makes several improvements to the revenue tracking dashboard in the commerce module. The main changes include updating the tab and filter order for better usability, improving the stat cards’ titles and subtitles for clarity, and refactoring filter logic for maintainability.

**UI/UX Improvements:**

* The default active tab in `DashboardBottomSection` is now "Detalles cliente", and the order of tabs has been updated to show "Detalles cliente" first.
* The filter categories in `FiltersBar` now display "Unidad de negocio" (channel) first, followed by other categories, improving filter relevance and order. [[1]](diffhunk://#diff-bd7ef7b46f71f8084a33422a30f2ccf319f65f48723a67ee24c963f9e9b63076R31-R36) [[2]](diffhunk://#diff-bd7ef7b46f71f8084a33422a30f2ccf319f65f48723a67ee24c963f9e9b63076R100-R102)

**Stat Cards Enhancements:**

* Stat card titles have been clarified (e.g., "Total Sales" → "Total Orders", "Avg Ticket" → "Avg. Order Value", "Total expected" → "Revenue expected"), and unnecessary subtitles have been removed to reduce clutter. The `subtitle` field is now optional. [[1]](diffhunk://#diff-3d2e9068bb85bcb70a036829161d8f81a0cda420ae8a62f5a0786e2d10038e35L25-R25) [[2]](diffhunk://#diff-3d2e9068bb85bcb70a036829161d8f81a0cda420ae8a62f5a0786e2d10038e35L35-L63) [[3]](diffhunk://#diff-3d2e9068bb85bcb70a036829161d8f81a0cda420ae8a62f5a0786e2d10038e35L114-L116)

**Code Quality and Maintainability:**

* Introduced a `toEntityCategory` helper function to clean up filter category mapping logic in `FiltersBar`.