### PR TITLE
Fallback to original_price; add interface field

### DIFF
--- a/src/modules/commerce/containers/confirmed-order/confirmed-order.tsx
+++ b/src/modules/commerce/containers/confirmed-order/confirmed-order.tsx
@@ -75,7 +75,7 @@ export const ConfirmedOrderView: FC = () => {
           key: `${product.id}-${product.product_sku}`,
           description: product.product_name,
           sku: product.product_sku,
-          originalPrice: product.price,
+          originalPrice: product.original_price ?? product.price,
           finalPrice: primary?.new_price ?? product.price,
           quantity: product.quantity,
           discountPct: primary?.discount_applied?.discount ?? 0

--- a/src/types/commerce/ICommerce.ts
+++ b/src/types/commerce/ICommerce.ts
@@ -107,6 +107,7 @@ export interface IProductInDetail {
   discount: number;
   discount_percentage: number;
   shipment_unit: number;
+  original_price: number;
 }
 export interface DiscountApplied {
   id: number;


### PR DESCRIPTION
Use product.original_price (falling back to product.price) for originalPrice in ConfirmedOrderView to correctly reflect the product's original price. Add original_price to IProductInDetail so the type matches the API payload and prevents type errors. Affects: src/modules/commerce/containers/confirmed-order/confirmed-order.tsx and src/types/commerce/ICommerce.ts.