### PR TITLE
Support multi-order partial CSV download

### DIFF
--- a/src/modules/commerce/components/orders-generate-action-modal/orders-generate-action-modal.scss
+++ b/src/modules/commerce/components/orders-generate-action-modal/orders-generate-action-modal.scss
@@ -22,6 +22,19 @@
         margin-bottom: 0.25rem;
     }
 
+    &__selectedOrders {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 0.25rem;
+        padding: 0.75rem 1rem;
+        margin-bottom: 0.5rem;
+        background-color: rgba(0, 0, 0, 0.03);
+        border: 1px solid rgba(0, 0, 0, 0.08);
+        border-radius: 0.5rem;
+        font-size: 0.875rem;
+        word-break: break-word;
+    }
+
     .ant-modal-body {
         display: flex;
         flex-direction: column;

--- a/src/modules/commerce/components/orders-generate-action-modal/orders-generate-action-modal.tsx
+++ b/src/modules/commerce/components/orders-generate-action-modal/orders-generate-action-modal.tsx
@@ -35,7 +35,7 @@ const { Title, Text } = Typography;
 interface Props {
   isOpen: boolean;
   onClose: () => void;
-  ordersId: number[];
+  selectedOrders: IOrder[];
   setFetchMutate: () => void;
   setSelectedRows: Dispatch<SetStateAction<IOrder[] | undefined>>;
   setSelectedRowKeys: Dispatch<SetStateAction<Key[]>>;
@@ -46,13 +46,18 @@ interface Props {
 export const OrdersGenerateActionModal = ({
   isOpen,
   onClose,
-  ordersId,
+  selectedOrders,
   setFetchMutate,
   setSelectedRows,
   setSelectedRowKeys,
   handleDeleteRows,
   handleSendInvite
 }: Props) => {
+  const ordersId = selectedOrders.map((order) => order.id);
+  const selectedCount = selectedOrders.length;
+  const operationNumbersText = selectedOrders
+    .map((order) => order.operation_number)
+    .join(", ");
   const { ID: projectId } = useAppStore((state) => state.selectedProject);
   const { showMessage } = useMessageApi();
 
@@ -190,15 +195,27 @@ export const OrdersGenerateActionModal = ({
   const handleDownloadCsvPartial = async (createBackorder: boolean) => {
     if (!validateOrdersSelected()) return;
     try {
-      const res = await downloadPartialOrderCSV(ordersId[0], createBackorder);
-      createAndDownloadTxt(res.txtContent);
-      if (res.createdBackorderId) {
+      const res = await downloadPartialOrderCSV(ordersId, createBackorder);
+      if (!res?.data) {
+        return showMessage("error", res?.message || "Error al descargar el CSV parcial");
+      }
+      const { txtContent, createdBackorderIds, failedOrders } = res.data;
+      if (txtContent) {
+        createAndDownloadTxt(txtContent);
+      }
+      if (createdBackorderIds?.length) {
         showMessage(
           "success",
-          `Se ha creado una orden de backorder con ID: ${res.createdBackorderId}`
+          `Se ${createdBackorderIds.length === 1 ? "ha" : "han"} creado ${
+            createdBackorderIds.length
+          } orden${createdBackorderIds.length === 1 ? "" : "es"} de backorder: ${createdBackorderIds.join(", ")}`
         );
       } else {
-        showMessage("success", "Descarga exitosa");
+        showMessage("success", res.message || "Descarga exitosa");
+      }
+      if (failedOrders?.length) {
+        setErrorMessage(`Órdenes con error: ${failedOrders.join(", ")}`);
+        setIsErrorModalOpen(true);
       }
       setFetchMutate();
       setSelectedRows([]);
@@ -327,6 +344,12 @@ export const OrdersGenerateActionModal = ({
         <p className="ordersGenerateActionModal__description">
           Selecciona la acción que vas a realizar
         </p>
+        <div className="ordersGenerateActionModal__selectedOrders">
+          <Text strong>
+            {selectedCount} {selectedCount === 1 ? "seleccionada" : "seleccionadas"}:{" "}
+          </Text>
+          <Text>{operationNumbersText}</Text>
+        </div>
         <Flex vertical gap="0.75rem">
           <ButtonGenerateAction
             onClick={handleChangeOrderState}
@@ -360,7 +383,6 @@ export const OrdersGenerateActionModal = ({
             onClick={handleDownloadPartialCsvShowQuestion}
             icon={<DownloadSimple size={16} />}
             title="Descarga parcial CSV"
-            disabled={ordersId.length !== 1}
           />
           <ButtonGenerateAction
             onClick={handleDeleteRows}

--- a/src/modules/commerce/containers/orders-view/orders-view.tsx
+++ b/src/modules/commerce/containers/orders-view/orders-view.tsx
@@ -206,7 +206,7 @@ export const OrdersView: FC = () => {
       <OrdersGenerateActionModal
         isOpen={isGenerateActionModalOpen}
         onClose={() => setIsGenerateActionModalOpen((prev) => !prev)}
-        ordersId={selectedRows?.map((order) => order.id) || []}
+        selectedOrders={selectedRows || []}
         setFetchMutate={mutate}
         setSelectedRows={setSelectedRows}
         setSelectedRowKeys={setSelectedRowKeys}

--- a/src/services/commerce/commerce.ts
+++ b/src/services/commerce/commerce.ts
@@ -289,16 +289,20 @@ export const dowloadOrderCSV = async (
   }
 };
 
-export const downloadPartialOrderCSV = async (orderId: number, sendToBackorder: boolean) => {
+export const downloadPartialOrderCSV = async (
+  orderIds: number[],
+  sendToBackorder: boolean
+) => {
   try {
-    const payload = { sendToBackorder };
+    const payload = { order_ids: orderIds, sendToBackorder };
     const formData = new FormData();
     formData.append("request", JSON.stringify(payload));
     const response: GenericResponse<{
       txtContent: string;
-      createdBackorderId: number | undefined;
-    }> = await API.post(`/marketplace/orders/${orderId}/download-csv`, formData);
-    return response.data;
+      createdBackorderIds: number[];
+      failedOrders: number[];
+    }> = await API.post(`/marketplace/orders/download-csv`, formData);
+    return response;
   } catch (error) {
     if (error instanceof ApiError) {
       throw new Error(error.message || "Error al descargar el CSV parcial");


### PR DESCRIPTION
Allow generating partial CSVs for multiple selected orders and surface selection info in the modal.

Changes:
- orders-generate-action-modal: renamed prop ordersId -> selectedOrders (IOrder[]), compute order IDs internally, show selected count and operation numbers, update handlers to support multiple orders and display success/error messages for created backorders and failed orders.
- orders-view: pass selectedOrders instead of ordersId.
- commerce service: downloadPartialOrderCSV now accepts orderIds[] and posts to /marketplace/orders/download-csv with order_ids payload; response shape updated (createdBackorderIds, failedOrders).
- SCSS: added styles for selected orders display.

Motivation: enable batch partial CSV downloads, improved UX and error reporting.